### PR TITLE
Gracefully handle certain file types that look like archives, but are not archives

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val projectName = "goatrodeo"
-val projectVersion = "0.4.4-SNAPSHOT"
+val projectVersion = "0.4.5-SNAPSHOT"
 val scala3Version = "3.3.3"
 val luceneVersion = "4.3.0"
 

--- a/src/main/scala/goatrodeo/Main.scala
+++ b/src/main/scala/goatrodeo/Main.scala
@@ -68,7 +68,7 @@ object Howdy {
     import builder._
     OParser.sequence(
       programName("goatrodeo"),
-      head("goatrodeo", "0.4.4"),
+      head("goatrodeo", "0.4.5"),
       opt[File]('a', "analyze")
         .action((x, c) =>
           c.copy(analyze = Some(x).filter(f => f.exists() && f.isFile()))


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
caught an exception thrown if something looks like a `cpio` archive, but is not.

Also, cleaned up the JSON for Unmasking output

### 🧠 Rationale Behind Change(s)
The process doesn't exit in the "bad CPIO" situation

### 📝 Test Plan
Ran against bad input

### 📜 Documentation
ScalaDocs

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [no ] Mention an issue number in the PR title?
- [ x] Update the version # in the build file?
- [ x] Create new and/or update relevant existing tests?
- [ x] Create or update relevant documentation and/or diagrams?
- [ x] Comment your code?
- [ x] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
