### PR TITLE
Add instructions for installing git-lfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The Goat Rodeo code will generate GitOID Corpus segments from collections of JAR
 
 ## How?
 
+Install [large file support for Git](https://git-lfs.com/).
+
 Install [sbt](https://www.scala-sbt.org/) to build and run Goat Rodeo.
 
 To create an "assembly" (a stand-alone executable JAR file): `sbt assembly`


### PR DESCRIPTION
### 📜 Documentation

Without `git lfs`, *data/grim.json* appears to clone incorrectly, which breaks tests.  This updates the instructions to clarify the requirement.