### PR TITLE
Add the sbt/setup-sbt GitHub Action

### DIFF
--- a/.github/workflows/scala_ci.yml
+++ b/.github/workflows/scala_ci.yml
@@ -30,6 +30,8 @@ jobs:
         java-version: '21'
         distribution: 'adopt-hotspot'
         cache: 'sbt'
+    - name: Set up sbt
+      uses: sbt/setup-sbt@v1
     - name: Run tests
       run: sbt test
       # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository

--- a/.github/workflows/scala_container_publishing.yml
+++ b/.github/workflows/scala_container_publishing.yml
@@ -50,6 +50,8 @@ jobs:
             java-version: '21'
             distribution: 'adopt-hotspot'
             cache: 'sbt'
+        - name: Set up sbt
+          uses: sbt/setup-sbt@v1
         - name: Declare some variables
           shell: bash
           run: |


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
*What did you change, and what additional context do reviewers need?*

This adds the `sbt/setup-sbt` GitHub Action to both workflows.

### 🧠 Rationale Behind Change(s)
*Why were these changes made? What tradeoffs were considered?*

This unbreaks the GHA workflows, which stopped working upstream `ubuntu-latest` image migrated to 24.04, which leaves out sbt by default.

### 📝 Test Plan
*Beyond unit tests, how did you make sure this code is ready for production?*

The `Scala Build & Test` workflow now succeeds:

https://github.com/spice-labs-inc/goatrodeo/actions/runs/12775779111

### 📜 Documentation
*What documentation did you add or update?*
*Was the documentation appropriate for the scope of this change?*

### 💣 Quality Control
*(All items must be checked before a PR is merged)*
*Did you…*
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- *Make sure the Quality Control boxes are all ticked*
- *Make sure any open comments or conversations on the PR are resolved*
