### PR TITLE
Implemented the mime-type structure for Goat Rodeo clusters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import scala.sys.process._
 
 val projectName = "goatrodeo"
-val projectVersion = "0.6.1-SNAPSHOT"
-val scala3Version = "3.3.3"
-val luceneVersion = "4.3.0"
+val projectVersion = "0.6.2-SNAPSHOT"
+val scala3Version = "3.6.3"
+// val luceneVersion = "4.3.0"
 
 fork := true
 

--- a/src/main/scala/goatrodeo/envelopes/Envelope.scala
+++ b/src/main/scala/goatrodeo/envelopes/Envelope.scala
@@ -165,7 +165,7 @@ case class IndexFileEnvelope(
 object IndexFileEnvelope {
 
   def build(
-      version: Int = 1,
+      version: Int = 2,
       magic: Int = GraphManager.Consts.IndexFileMagicNumber,
       size: Int,
       dataFiles: Vector[Long],
@@ -197,7 +197,7 @@ case class ClusterFileEnvelope(
 
 object ClusterFileEnvelope {
   def build(
-      version: Int = 1,
+      version: Int = 2,
       magic: Int = GraphManager.Consts.ClusterFileMagicNumber,
       dataFiles: Vector[Long],
       indexFiles: Vector[Long],

--- a/src/main/scala/goatrodeo/omnibor/BuildGraph.scala
+++ b/src/main/scala/goatrodeo/omnibor/BuildGraph.scala
@@ -166,27 +166,27 @@ object BuildGraph {
           (fileType.sourceGitOid() match {
             case None => TreeSet[Edge]()
             case Some(source) =>
-              TreeSet[Edge]((EdgeType.BuiltFrom, source))
+              TreeSet[Edge]((EdgeType.builtFrom, source))
           })
           ++
           // include parent back-reference
           (parent match {
             case Some(parentId) =>
-              Vector[Edge]((EdgeType.ContainedBy, parentId))
+              Vector[Edge]((EdgeType.containedBy, parentId))
             case None => topConnections
           })
           ++
           // include aliases only if we aren't merging this item (if we're)
           // merging, then the aliases already exist and no point in regenerating them
-          (aliases.map(alias => (EdgeType.AliasFrom, alias))).toSet
+          (aliases.map(alias => (EdgeType.aliasFrom, alias))).toSet
 
 
         val item = Item(
           identifier = mainFileGitOID,
           reference = Item.noopLocationReference,
           connections = computedConnections,
-          
-          metadata = Some(
+          bodyMimeType = Some("application/goatrodeo"),
+          body = Some(
             ItemMetaData.from(
               name,
               fileType,
@@ -194,7 +194,6 @@ object BuildGraph {
               fileSize = file.size(),
             )
           ),
-          mergedFrom = TreeSet(),
         ).fixReferences(store)
         nameToGitOID = nameToGitOID + (name -> mainFileGitOID)
         parentStackToGitOID = parentStackToGitOID + (parentStack -> mainFileGitOID)

--- a/src/main/scala/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/goatrodeo/omnibor/Builder.scala
@@ -182,7 +182,7 @@ object Builder {
     purlOut.close()
 
     val ret = storage match {
-      case lf: (ListFileNames with Storage) if !dead_? =>
+      case lf: (ListFileNames & Storage) if !dead_? =>
         writeGoatRodeoFiles(lf)
       case _ => println("Didn't write"); None
     }
@@ -192,7 +192,7 @@ object Builder {
     ret
   }
 
-  def writeGoatRodeoFiles(store: ListFileNames with Storage): Option[File] = {
+  def writeGoatRodeoFiles(store: ListFileNames & Storage): Option[File] = {
     store.target() match {
       case Some(target) => {
         println(f"In store with target ${target}")
@@ -321,7 +321,7 @@ object ToProcess {
       var fileSet = TreeSet(
         Helpers
           .findFiles(root, _ => true)
-          .map(_.getAbsoluteFile()): _*
+          .map(_.getAbsoluteFile())*
       )
 
       val pomLike = buildQueueForPOMS(

--- a/src/main/scala/goatrodeo/omnibor/Cluster.scala
+++ b/src/main/scala/goatrodeo/omnibor/Cluster.scala
@@ -163,15 +163,15 @@ object GoatRodeoCluster {
       val indexFiles = Map((for { indexFile <- env.indexFiles } yield {
 
         (indexFile -> IndexFile.open(theDir, indexFile))
-      }): _*)
+      })*)
 
       val dataFileHashes = TreeSet((for {
         idx <- indexFiles.values; dataFile <- idx.envelope.dataFiles
-      } yield dataFile).toSeq: _*)
+      } yield dataFile).toSeq*)
 
       val dataFiles = Map((for {
         dataFileHash <- dataFileHashes.toSeq
-      } yield (dataFileHash -> DataFile.open(theDir, dataFileHash))): _*)
+      } yield (dataFileHash -> DataFile.open(theDir, dataFileHash)))*)
 
       GoatRodeoCluster(
         envelope = env,

--- a/src/main/scala/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/goatrodeo/omnibor/GraphManager.scala
@@ -189,7 +189,7 @@ object GraphManager {
 
     def updateBiggest(item: Item): Unit = {
       val containedBy =
-        item.connections.filter(_._1 == EdgeType.ContainedBy).size
+        item.connections.filter(_._1 == EdgeType.containedBy).size
       if (biggest.length <= 50) {
         biggest = (biggest :+ (item -> containedBy)).sortBy(_._2).reverse
       } else if (biggest.last._2 < containedBy) {
@@ -252,7 +252,7 @@ object GraphManager {
     if (false) {
       for { i <- biggest } {
         println(
-          f"Item ${i._1.identifier} ${i._1.metadata.map(_.fileNames).getOrElse(Vector())} has ${i._2} connections"
+          f"Item ${i._1.identifier} ${i._1.body.map(_.fileNames).getOrElse(Vector())} has ${i._2} connections"
         )
       }
     }

--- a/src/main/scala/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/goatrodeo/omnibor/Storage.scala
@@ -286,7 +286,7 @@ object MemStorage {
     * @return
     *   the storage directory
     */
-  def getStorage(targetDir: Option[File]): Storage with ListFileNames = {
+  def getStorage(targetDir: Option[File]): Storage & ListFileNames = {
 
     MemStorage(targetDir)
   }

--- a/src/main/scala/goatrodeo/toplevel/HiddenReaper.scala
+++ b/src/main/scala/goatrodeo/toplevel/HiddenReaper.scala
@@ -93,8 +93,7 @@ object HiddenReaper {
       println(f"Joined ${name}")
     }
 
-    val bad =
-      Map(res: _*)
+    val bad = Map(res*)
 
     if (!bad.isEmpty) {
       import org.json4s.JsonDSL._
@@ -241,7 +240,7 @@ object HiddenReaper {
           artifactIdToFoundItem(
             subArtifact
           )
-        )): _*
+        ))*
       )
       // maybe some phantom markers were found... but eliminated,
       // so check again
@@ -268,7 +267,7 @@ object HiddenReaper {
     val artToContainer = Map((for {
       (k, vs) <- containerToArtifactList.toVector
       v <- vs
-    } yield v -> k): _*)
+    } yield v -> k)*)
 
     (artToContainer, containerToArtifactList, artToContainer.keySet)
   }

--- a/src/main/scala/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/goatrodeo/util/Helpers.scala
@@ -339,7 +339,6 @@ object Helpers {
     }
   }
 
-
   @inline def hexChar(b: Byte): Char = {
     b match {
       case 0  => '0'
@@ -889,7 +888,7 @@ object PackageIdentifier {
           case a :: b :: _ => Vector((a.trim().toLowerCase(), b.trim()))
           case _           => Vector()
         }
-      }): _*)
+      })*)
 
       val pkg = attrs.get("package")
       val version = attrs.get("version")
@@ -957,7 +956,7 @@ case class PackageIdentifier(
     ) ++ arch.toVector.map(a => "arch" -> TreeSet(a)) ++ distro.toVector.map(
       d => "distro" -> TreeSet(d)
     )
-    Map(info: _*) ++ this.extra
+    Map(info*) ++ this.extra
   }
 
   def purl(): Vector[String] = {
@@ -1085,7 +1084,7 @@ enum FileType {
           subtype.map(st => "subtype" -> TreeSet(st))
         ).flatten
       case Other => Vector("type" -> TreeSet("other"))
-    }: _*)
+    }*)
   }
 
 }
@@ -1132,7 +1131,10 @@ object FileType {
 
         ObjectFile(Some("classfile"), sourceGitOID)
       }
-      case s if s.equals("metadata") => MetaData(Some("metadata")) // ruby gem metadata file at toplevel (in metadata.gz)
+      case s if s.equals("metadata") =>
+        MetaData(
+          Some("metadata")
+        ) // ruby gem metadata file at toplevel (in metadata.gz)
       case s if s.endsWith(".o")     => ObjectFile(Some("o"), None)
       case s if s.endsWith(".dll")   => ObjectFile(Some("dll"), None)
       case s if s.endsWith(".java")  => SourceFile(Some("java"))

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -345,7 +345,7 @@ class MySuite extends munit.FunSuite {
     assert(gitoid.startsWith("gitoid:"))
     val top = store.read(gitoid).get
     store.read("gitoid:blob:sha1:2e79b179ad18431600e9a074735f40cd54dde7f6").get
-    for { edge <- top.connections if edge._1 == EdgeType.Contains } {
+    for { edge <- top.connections if edge._1 == EdgeType.contains } {
       val contained = store.read(edge._2).get
     }
 
@@ -355,7 +355,7 @@ class MySuite extends munit.FunSuite {
       )
       .get
     assert(
-      log4j.connections.filter(_._1 == EdgeType.Contains).size > 1200
+      log4j.connections.filter(_._1 == EdgeType.contains).size > 1200
     )
   }
 
@@ -384,10 +384,10 @@ class MySuite extends munit.FunSuite {
     assert(items.length > 1100)
 
     val sourceRef = items.filter(i =>
-      i.connections.filter(e => e._1 == EdgeType.BuiltFrom).size > 0
+      i.connections.filter(e => e._1 == EdgeType.builtFrom).size > 0
     )
     val fromSource = for {
-      i <- items; c <- i.connections if c._1 == EdgeType.BuildsTo
+      i <- items; c <- i.connections if c._1 == EdgeType.buildsTo
     } yield c
     assert(sourceRef.length > 100)
 


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Goat Rodeo changes that correspond to Big Tent's changes under this PR: https://github.com/spice-labs-inc/bigtent/pull/25

moved Big Tent to serve the Body (formerly ItemMetaData) with a mime type rather than being generic. This means that BigTent can serve any Body that can be CBOR encoded. Also moved from explicit Enum for Connections to text plus a directional suffix. This expands connections beyond Aliases, Contained, and Compiled

### 🧠 Rationale Behind Change(s)
Rather than having different versions of Big Tent for each type of "ItemMetaData", just treat the contents of the record as
a "body" that has a mime type and is a CBOR (on disk) or JSON (in HTTP responses).

Thus a single Big Tent instance can serve many different data types.

Also change Connection from an enumeration to String with some "direction of connection" suffixes to denote Left/Right relationships (e.g., Aliases) as well as Up/Down relationships (Contains, ContainedBy)

### 📝 Test Plan
Passes all existing tests

### 📜 Documentation
Added some comments

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
