### PR TITLE
build: set version from git tags + following commits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import scala.sys.process._
 
 val projectName = "goatrodeo"
-val projectVersion = "0.6.1-SNAPSHOT"
 val scala3Version = "3.3.3"
 val luceneVersion = "4.3.0"
 
@@ -15,7 +14,6 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := projectName,
-    version := projectVersion,
     scalaVersion := scala3Version,
     libraryDependencies += "org.scala-lang" %% "toolkit" % "0.4.0",
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.3.0",
@@ -115,13 +113,12 @@ Test / testOptions += Tests.Setup(() => {
   }
 })
 
-
 enablePlugins(JavaAppPackaging)
+enablePlugins(GitVersioningPlugin)
 enablePlugins(DockerPlugin)
 
 Universal / mappings += file("data/grim.json") -> "data/grim.json"
 Docker / packageName := projectName
-Docker / version := projectVersion
 Docker / maintainer := "ext-engineering@spicelabs.io"
 
 dockerBaseImage := "eclipse-temurin:21-jre-ubi9-minimal" 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
+resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.6.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
+addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.6.0")


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)

Using `sbt-git-versioning`, we get the version of the code set from the git repository, rather than from the code itself.

### 🧠 Rationale Behind Change(s)
Being compiled tagged with the most recent git tag, and if there are commits since or the repository is modified, a flag to that effect, giving every different compile a theoretically unique version, and lets us control our versioning from a single place, the git tag, which can be signed.

### 📝 Test Plan
Proof will be in the test runs from the release and tag trigger.