### PR TITLE
Added the ability to block (not index) certain gitoids

### DIFF
--- a/src/main/scala/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/goatrodeo/omnibor/Builder.scala
@@ -77,8 +77,8 @@ object Builder {
         Try{
           import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-          val lines = Files.readAllLines(file.toPath()).asScala.toVector
-          Set(lines*)
+          val lines = Files.readAllLines(file.toPath()).asScala.toSet
+          lines
         }.toOption match {
           case None => Set()
           case Some(s) => s

--- a/src/main/scala/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/goatrodeo/omnibor/Builder.scala
@@ -38,6 +38,7 @@ import scala.annotation.tailrec
 import java.io.FileWriter
 import scala.collection.immutable.TreeSet
 import goatrodeo.util.FileWrapper
+import java.nio.file.Files
 
 /** Build the GitOIDs the container and all the sub-elements found in the
   * container
@@ -59,7 +60,8 @@ object Builder {
   def buildDB(
       source: File,
       storage: Storage,
-      threadCnt: Int
+      threadCnt: Int,
+      blockList: Option[File]
   ): Option[File] = {
     val totalStart = Instant.now()
     val runningCnt = AtomicInteger(0)
@@ -67,6 +69,22 @@ object Builder {
 
     // The count of all the files found
     val cnt = new AtomicInteger(0)
+
+    // Get the gitoids to block
+    val blockGitoids: Set[String] = blockList match {
+      case None => Set()
+      case Some(file) => 
+        Try{
+          import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+          val lines = Files.readAllLines(file.toPath()).asScala.toVector
+          Set(lines*)
+        }.toOption match {
+          case None => Set()
+          case Some(s) => s
+        }
+      
+    }
 
     val destDir = storage
       .destDirectory()
@@ -123,7 +141,8 @@ object Builder {
               BuildGraph.graphForToProcess(
                 toProcess,
                 storage,
-                purlOut
+                purlOut,
+                blockGitoids
               )
               val updatedCnt = cnt.addAndGet(1)
               val theDuration = Duration

--- a/src/main/scala/goatrodeo/toplevel/HiddenReaper.scala
+++ b/src/main/scala/goatrodeo/toplevel/HiddenReaper.scala
@@ -178,7 +178,8 @@ object HiddenReaper {
           new BufferedWriter(
             new OutputStreamWriter(new ByteArrayOutputStream())
           ),
-          false
+          false,
+          Set()
         )
       } catch {
         case e: Exception =>

--- a/src/test/scala/GemFileSuite.scala
+++ b/src/test/scala/GemFileSuite.scala
@@ -90,7 +90,7 @@ class GemFileSuite extends munit.FunSuite {
         file.mkdirs()
         BufferedWriter(FileWriter(File(file, "purls.txt")))
       },
-      false
+      false, Set()
     )
 
 //    assert(built.nameToGitOID.size > 1200, f"Expection more than 1,200 items, got ${built.nameToGitOID.size}")

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -268,8 +268,46 @@ class MySuite extends munit.FunSuite {
         file.mkdirs()
         BufferedWriter(FileWriter(File(file, "purls.txt")))
       },
-      false
+      false,
+      Set()
     )
+
+    val built2 = BuildGraph.buildItemsFor(
+      nested,
+      nested.getName(),
+      MemStorage.getStorage(None),
+      Vector(),
+      None,
+      Map(), {
+        val file = File.createTempFile("goat_rodeo_purls", "_out")
+        file.delete()
+        file.mkdirs()
+        BufferedWriter(FileWriter(File(file, "purls.txt")))
+      },
+      false,
+      Set(
+        "gitoid:blob:sha256:e3f8d493cb200fd95c4881e248148836628e0f06ddb3c28cb3f95cf784e2f8e4"
+      )
+    )
+
+    val built3 = BuildGraph.buildItemsFor(
+      nested,
+      nested.getName(),
+      MemStorage.getStorage(None),
+      Vector(),
+      None,
+      Map(), {
+        val file = File.createTempFile("goat_rodeo_purls", "_out")
+        file.delete()
+        file.mkdirs()
+        BufferedWriter(FileWriter(File(file, "purls.txt")))
+      },
+      false,
+      Set()
+    )
+
+    assertEquals(built3.nameToGitOID, built.nameToGitOID, "Builds are reproducable")
+    assertNotEquals(built2.nameToGitOID, built.nameToGitOID, "Block list should work")
 
     assert(
       built.nameToGitOID.size > 1200,
@@ -321,7 +359,7 @@ class MySuite extends munit.FunSuite {
     import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
     for { toProcess <- files } {
-      BuildGraph.graphForToProcess(toProcess, store, purlOut = purlOut)
+      BuildGraph.graphForToProcess(toProcess, store, purlOut = purlOut, Set())
     }
 
     val keys = store.keys()
@@ -386,7 +424,7 @@ class MySuite extends munit.FunSuite {
             file.mkdirs()
             BufferedWriter(FileWriter(File(file, "purls.txt")))
           },
-          false
+          false, Set()
         )
         // No pURL
         // val pkgIndex = store.read("pkg:maven").get
@@ -418,7 +456,7 @@ class MySuite extends munit.FunSuite {
       import scala.collection.JavaConverters.collectionAsScalaIterableConverter
       import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
-      Builder.buildDB(source, store, 32)
+      Builder.buildDB(source, store, 32, None)
 
       // no pURL
       // val pkgIndex = store.read("pkg:maven").get


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Added a command-line option to block indexing certain gitoids

### 🧠 Rationale Behind Change(s)
Some gitoids are so common (e.g., the Apache license file) that it appears in hundreds of thousands or
even millions of artifacts. There's no reason to index these items, so there's a `--block` CLI option
that points to a text file that contains 1 gitoid per line to not index

### 📝 Test Plan
Added a test to ensure that when a gitoid is specified, it is not indexed

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
