### PR TITLE
Better, faster, more debugging info

### DIFF
--- a/src/main/scala/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/goatrodeo/omnibor/Builder.scala
@@ -146,6 +146,7 @@ object Builder {
                 None,
                 store = storage,
                 purlOut = purlOut,
+                parentScope = ParentScope.forAndWith(toProcess.main, None),
                 blockList = blockGitoids,
                 keepRunning = () => !dead_?,
                 atEnd = (parent, _) => {
@@ -166,7 +167,9 @@ object Builder {
                           .toDouble
                         val itemsPerMinute = itemsPerSecond * 60.0d
                         val left = totalItems.toDouble - updatedCnt.toDouble
-                        val remainingDuration = Duration.ZERO.plusSeconds((left / itemsPerSecond).round)
+                        val remainingDuration = Duration.ZERO.plusSeconds(
+                          (left / itemsPerSecond).round
+                        )
                         f" Items/minute ${itemsPerMinute.round}, est remaining ${remainingDuration}"
                       } else ""
                       logger.info(
@@ -293,7 +296,8 @@ object Builder {
               )
             }
           updatedAlias
-        }
+        },
+        item => f"Inserting Merkle Tree of ${itemId}"
       )
       // and update the Item with the AliasFrom
       data.write(
@@ -307,7 +311,8 @@ object Builder {
             val toAdd = (EdgeType.aliasFrom, tree)
             if (item.connections.contains(toAdd)) item
             else item.copy(connections = item.connections + toAdd)
-        }
+        },
+        item => f"Updating Merkle Tree alias for ${itemId}"
       )
     }
 

--- a/src/test/scala/ISOFileSuite.scala
+++ b/src/test/scala/ISOFileSuite.scala
@@ -19,6 +19,7 @@ import java.io.File
 import goatrodeo.omnibor.strategies.GenericFile
 import goatrodeo.omnibor.MemStorage
 import com.github.packageurl.PackageURL
+import goatrodeo.omnibor.ParentScope
 
 // For more information on writing tests, see
 // https://scalameta.org/munit/docs/getting-started.html
@@ -58,7 +59,7 @@ class ISOFileSuite extends munit.FunSuite {
 
     val tp = GenericFile(nested)
     val store = MemStorage(None)
-    tp.process(None, store)
+    tp.process(None, store, ParentScope.forAndWith("Testing ISO", None))
     val cnt = store.keys().size
     assert(cnt > 1200, f"expected more than 1,200, got ${cnt}")
   }


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Added lock contention detection with additional context to figure out the context (depth of container descent)

Improved the way back-references (contained by, etc.) handled to make things much more efficient.

### 🧠 Rationale Behind Change(s)
There were a bunch of issues around handling large sets of JARs that contained a lot of the same class files.
The number of Items per minute would decline as there were more Items processed.

So, I added detection for row-level lock contention.

Turns out there was a lot of lock contention, although lock contention should have been rare.

But there was mistake in the way back-references were handled.

Back-references were done after an Item was merged with the Item in storage. This means that
if a `.class` file was contained in a lot of different JAR files, each time the `.class` file was processed,
it updated all the references to all the JAR files that it had previously been referenced.

This was causing lock contention and a lot of extra processing.

This change should speed Goat Rodeo by 2x or more.

### 📝 Test Plan
Existing tests pass

### 📜 Documentation
Scala docs

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
