### PR TITLE
Revised connection strings, improved performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,8 @@ lazy val root = project
     libraryDependencies += "com.github.luben" % "zstd-jni" % "1.5.6-4",
     libraryDependencies += "org.apache.commons" % "commons-compress" % "1.27.1",
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.5.15",
-    // libraryDependencies += "slf4j" % "simple" % "2.0.16",
+    libraryDependencies +=
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     libraryDependencies += "org.apache.tika" % "tika-core" % "3.0.0",
     libraryDependencies +=  "com.github.package-url" % "packageurl-java" % "1.5.0",

--- a/src/main/scala/goatrodeo/envelopes/Envelope.scala
+++ b/src/main/scala/goatrodeo/envelopes/Envelope.scala
@@ -188,8 +188,6 @@ case class ClusterFileEnvelope(
     magic: Int,
     @key("data_files") dataFiles: Vector[Long],
     @key("index_files") indexFiles: Vector[Long],
-    @key("built_on") builtOn: Option[String],
-    @key("builder") builder: Option[String],
     info: TreeMap[String, String]
 ) {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
@@ -209,8 +207,6 @@ object ClusterFileEnvelope {
     dataFiles = dataFiles,
     indexFiles = indexFiles,
     info = info,
-    builtOn = Some(Helpers.currentDate8601()),
-    builder = Some(f"Goat Rodeo version ${"FIXME"}")
   )
 
   given forOption[T: Encoder]: Encoder.DefaultValueAware[Option[T]] =

--- a/src/main/scala/goatrodeo/envelopes/Envelope.scala
+++ b/src/main/scala/goatrodeo/envelopes/Envelope.scala
@@ -114,7 +114,7 @@ object MD5 extends DecodeCBOR[MD5] {
 type Position = Long
 
 type MultifilePosition = (Long, Long)
- import io.bullet.borer.derivation.MapBasedCodecs.derived
+import io.bullet.borer.derivation.MapBasedCodecs.derived
 
 case class DataFileEnvelope(
     version: Int,
@@ -123,8 +123,7 @@ case class DataFileEnvelope(
     @key("depends_on") dependsOn: TreeSet[Long],
     @key("built_from_merge") builtFromMerge: Boolean,
     info: TreeMap[String, String]
-) derives Codec
- {
+) derives Codec {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
 }
 
@@ -189,6 +188,8 @@ case class ClusterFileEnvelope(
     magic: Int,
     @key("data_files") dataFiles: Vector[Long],
     @key("index_files") indexFiles: Vector[Long],
+    @key("built_on") builtOn: Option[String],
+    @key("builder") builder: Option[String],
     info: TreeMap[String, String]
 ) {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
@@ -207,10 +208,32 @@ object ClusterFileEnvelope {
     magic = magic,
     dataFiles = dataFiles,
     indexFiles = indexFiles,
-    info = info
+    info = info,
+    builtOn = Some(Helpers.currentDate8601()),
+    builder = Some(f"Goat Rodeo version ${"FIXME"}")
   )
 
-  
+  given forOption[T: Encoder]: Encoder.DefaultValueAware[Option[T]] =
+    new Encoder.DefaultValueAware[Option[T]] {
+
+      def write(w: Writer, value: Option[T]) =
+        value match {
+          case Some(x) => w.write(x)
+          case None    => w.writeNull()
+        }
+
+      def withDefaultValue(defaultValue: Option[T]): Encoder[Option[T]] =
+        if (defaultValue eq None)
+          new Encoder.PossiblyWithoutOutput[Option[T]] {
+            def producesOutputFor(value: Option[T]) = value ne None
+            def write(w: Writer, value: Option[T]) =
+              value match {
+                case Some(x) => w.write(x)
+                case None    => w
+              }
+          }
+        else this
+    }
 
   given Codec[ClusterFileEnvelope] = {
     import io.bullet.borer.derivation.MapBasedCodecs.*

--- a/src/main/scala/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/goatrodeo/omnibor/GraphManager.scala
@@ -29,7 +29,7 @@ object GraphManager {
     val DataFileMagicNumber: Int = 0x00be1100 // Bell
     val IndexFileMagicNumber: Int = 0x54154170 // Shishitō
     val ClusterFileMagicNumber: Int = 0xba4a4a // Banana
-    val TargetMaxFileSize: Long = 15L * 1024L * 1024L * 1024L // 7G
+    val TargetMaxFileSize: Long = 15L * 1024L * 1024L * 1024L // 15G
   }
 
   case class DataAndIndexFiles(dataFile: Long, indexFile: Long)
@@ -66,7 +66,8 @@ object GraphManager {
     while (items.hasNext && writer.position() < Consts.TargetMaxFileSize) {
       val orgEntry = items.next()
       val currentPosition = writer.position()
-      val entry = orgEntry.fixReferencePosition(0L, currentPosition)
+      // val entry = orgEntry.fixReferencePosition(0L, currentPosition)
+      val entry = orgEntry
 
       val md5 = entry.identifierMD5()
 
@@ -75,7 +76,7 @@ object GraphManager {
       pairs = pairs.appended((Helpers.toHex(md5), md5, currentPosition))
 
 
-      val toAlloc = 256 + /*(envelopeBytes.length) + */(entryBytes.length)
+      val toAlloc = 256 + (entryBytes.length)
       val bb = ByteBuffer.allocate(toAlloc)
 
       bb.putInt(entryBytes.length)
@@ -189,7 +190,6 @@ object GraphManager {
       val dataAndIndex = writeABlock(
         targetDirectory,
         entries,
-       //  compression,
         previous = previousInChain,
         updateBiggest
       )

--- a/src/main/scala/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/goatrodeo/omnibor/Item.scala
@@ -16,20 +16,20 @@ import goatrodeo.util.GitOID
 
 case class Item(
     identifier: String,
-    reference: LocationReference,
+    //reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
     body: Option[ItemMetaData]
 ) {
 
-  def encodeCBOR(): Array[Byte] = Cbor.encode(this).toByteArray
+  def encodeCBOR(): Array[Byte] = cachedCBOR
 
-  def fixReferencePosition(hash: Long, offset: Long): Item = {
-    val hasCur = reference != Item.noopLocationReference
-    this.copy(
-      reference = (hash, offset)
-    )
-  }
+  // def fixReferencePosition(hash: Long, offset: Long): Item = {
+  //   val hasCur = reference != Item.noopLocationReference
+  //   this.copy(
+  //     reference = (hash, offset)
+  //   )
+  // }
 
   /** add a connection
     *
@@ -44,6 +44,8 @@ case class Item(
     this.copy(connections = this.connections + (edgeType -> id))
 
   private lazy val md5 = Helpers.computeMD5(identifier)
+
+  lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
 
   def identifierMD5(): Array[Byte] = md5
 
@@ -131,7 +133,7 @@ case class Item(
 
     Item(
       identifier = this.identifier,
-      reference = this.reference,
+      // reference = this.reference,
       connections = this.connections ++ other.connections,
       bodyMimeType = mime,
       body = body
@@ -232,7 +234,7 @@ object Item {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
       id,
-      Item.noopLocationReference,
+      // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
       ) ++ container.toSeq.map(c => EdgeType.containedBy -> c),

--- a/src/main/scala/goatrodeo/omnibor/Struct.scala
+++ b/src/main/scala/goatrodeo/omnibor/Struct.scala
@@ -56,48 +56,8 @@ object EdgeType {
     s == aliasTo
   }
 
-  /** Is the type a peer "from left"
-    *
-    * @param s
-    *   the EdgeType to check
-    * @return
-    *   the EdgeType a peer "from left"
-    */
-  def isFromLeft(s: String): Boolean = {
-    s.endsWith(fromLeft)
-  }
-
-  /** Is the type a peer "to right"
-    *
-    * @param s
-    *   the EdgeType to check
-    * @return
-    *   the EdgeType is peer "to right"
-    */
-  def isToRight(s: String): Boolean = {
-    s.endsWith(toRight)
-  }
-
-  /** Is the type hierarchical "down" (e.g., ContainsDown)
-    *
-    * @param s
-    *   the EdgeType to check
-    * @return
-    *   the EdgeType is hierarchical "down"
-    */
   def isDown(s: String): Boolean = {
-    s.endsWith(containsDown)
-  }
-
-  /** Is the type hierarchical "up" (e.g., ContainedBy)
-    *
-    * @param s
-    *   the EdgeType to check
-    * @return
-    *   the EdgeType is hierarchical "up"
-    */
-  def isUp(s: String): Boolean = {
-    s.endsWith(containedByUp)
+    s.endsWith(down)
   }
 
   /** Is the type "BuiltFrom"
@@ -122,17 +82,17 @@ object EdgeType {
     s == buildsTo
   }
 
-  val toRight = ":->";
-  val fromLeft = ":<-";
-  val containsDown = ":||";
-  val containedByUp = ":^";
+  val to = ":to"
+  val from = ":from"
+  val down = ":down"
+  val up = ":up"
 
-  val containedBy = "ContainedBy:^";
-  val contains = "Contains:||";
-  val aliasTo = "AliasTo:->";
-  val aliasFrom = "AliasFrom:<-";
-  val buildsTo = "BuildsTo:^"
-  val builtFrom = "BuiltFrom:||"
+  val containedBy = "contained:up";
+  val contains = "contained:down";
+  val aliasTo = "alias:to";
+  val aliasFrom = "alias:from";
+  val buildsTo = "build:up"
+  val builtFrom = "build:down"
 
 }
 
@@ -196,7 +156,6 @@ object StringOrPair {
 
   }
 }
-
 case class ItemMetaData(
     @key("file_names") fileNames: TreeSet[String],
     @key("mime_type") mimeType: TreeSet[String],
@@ -206,12 +165,14 @@ case class ItemMetaData(
   def encodeCBOR(): Array[Byte] = Cbor.encode(this).toByteArray
 
   def merge(other: ItemMetaData): ItemMetaData = {
-    ItemMetaData(
+    val ret = ItemMetaData(
       fileNames = this.fileNames ++ other.fileNames,
       mimeType = this.mimeType ++ other.mimeType,
       fileSize = this.fileSize,
       extra = Helpers.mergeTreeMaps(this.extra, other.extra)
     )
+
+    ret
   }
 }
 

--- a/src/main/scala/goatrodeo/util/FileWalker.scala
+++ b/src/main/scala/goatrodeo/util/FileWalker.scala
@@ -57,12 +57,7 @@ object FileWalker {
       import scala.collection.JavaConverters.asScalaIteratorConverter
       val theFile = in match {
         case FileWrapper(f, _) => f
-        case _ => {
-          val tempFile =
-            Helpers.tempFileFromStream(in.asStream(), true, tempDir)
-
-          tempFile
-        }
+        case _ => Helpers.tempFileFromStream(in.asStream(), true, tempDir)
       }
 
       try {
@@ -115,8 +110,7 @@ object FileWalker {
         import scala.collection.JavaConverters.asScalaIteratorConverter
         val theFile = in match {
           case FileWrapper(f, _) => f
-          case _ =>
-            Helpers.tempFileFromStream(in.asStream(), true, tempPath)
+          case _ => Helpers.tempFileFromStream(in.asStream(), true, tempPath)
         }
 
         val isoFileReader: IsoFileReader = new IsoFileReader(theFile)
@@ -267,10 +261,10 @@ object FileWalker {
   )
 
   val notCompressedSet = Set[String](
-    "application/vnd.android.package-archive",
-    //"application/x-debian-package",
-    //"application/gzip",
-    //"application/x-gtar"
+    "application/vnd.android.package-archive"
+    // "application/x-debian-package",
+    // "application/gzip",
+    // "application/x-gtar"
   )
 
   def notArchive(in: ArtifactWrapper): Boolean =

--- a/src/main/scala/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/goatrodeo/util/Helpers.scala
@@ -60,6 +60,9 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.FileVisitResult
 import java.io.IOException
 import goatrodeo.omnibor.StringOrPair
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+import java.util.Date
 type GitOID = String
 
 /** A bunch of helpers/utilities
@@ -203,6 +206,16 @@ object Helpers {
       case _ => TreeSet()
     }
 
+  }
+
+  /**
+   * Get the current date in ISO 8601 format
+   */
+  def currentDate8601(): String = {
+    val timezone = TimeZone.getTimeZone("UTC")
+    val dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    dateFormat.setTimeZone(timezone);
+    dateFormat.format(new Date())
   }
 
   /** Given a file root and a filter function, return a channel that contains

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -411,11 +411,10 @@ class MySuite extends munit.FunSuite {
           resForBigTent.delete()
         }
       }
-      val store = MemStorage.getStorage(Some(resForBigTent))
       import scala.collection.JavaConverters.collectionAsScalaIterableConverter
       import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
-      Builder.buildDB(source, store, 32, None)
+      Builder.buildDB(source, resForBigTent, 32, None, 1000000)
 
       // no pURL
       // val pkgIndex = store.read("pkg:maven").get


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Revised the connection strings to `contained:up` etc. rather than using glyphs

Support for saving bundles every n items processed... default to 50,000

Parallelized some caching operations

### 🧠 Rationale Behind Change(s)
Why were these changes made? What tradeoffs were considered?

### 📝 Test Plan
Passes tests and Big Tent can read and process created Clusters
