### PR TITLE
Publish Images to GHCR and Docker Hub on Tag Release

### DIFF
--- a/.github/workflows/scala_container_publishing.yml
+++ b/.github/workflows/scala_container_publishing.yml
@@ -2,18 +2,8 @@ name: Publish Scala Container Images
 
 on:
   push:
-    branches:
-      - "publish-images"
-      - "main"
-    tags:
-      - "v*.*.*"
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Scala Build & Test"]
-    types: [completed]
-    branches:
-      - "publish-images"
-      - "main"
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
 
 env:
   GHCR_REGISTRY: ghcr.io
@@ -61,8 +51,8 @@ jobs:
       - name: Save JAR artifact
         uses: actions/upload-artifact@v4
         with:
-          name: my-scala-app-${{ github.run_id }}
-          path: target/scala-*/goatrodeo*.jar
+          name: goatrodeo-${{ github.run_id }}
+          path: target/release/goatrodeo
       
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)

  *  Release on Semver tagging only
  *  Completed #63 

### 🧠 Rationale Behind Change(s)
Stop images unnecessarily being created

### 📝 Test Plan

Published v0.6.1 - image successfully uploaded to GHCR.io and Docker Hub 

https://github.com/spice-labs-inc/goatrodeo/actions/runs/13932832536

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
