### PR TITLE
Jt/publish binaries

### DIFF
--- a/.github/workflows/scala_container_publishing.yml
+++ b/.github/workflows/scala_container_publishing.yml
@@ -53,6 +53,13 @@ jobs:
         with:
           name: goatrodeo-${{ github.run_id }}
           path: target/scala-*/goatrodeo*.jar
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+             target/scala-*/goatrodeo*.jar
+          make_latest: true  
       
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/scala_container_publishing.yml
+++ b/.github/workflows/scala_container_publishing.yml
@@ -1,6 +1,7 @@
 name: Publish Scala Container Images
 
 on:
+  workflow_dispatch:
   push:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Adjusted the scala_container_publishing.yml to add `workflow_dispatch:` and the following action.  
`      - name: Release
        uses: softprops/action-gh-release@v2
        with:
          files: |
             target/scala-*/goatrodeo*.jar
          make_latest: true  `

This publishes the jar binary to the release in addition to the docker image

### 🧠 Rationale Behind Change(s)
Release jar is needed for inclusion into grinder

### 📝 Test Plan
This is an unusual change in that I have to get into main in order to test on branches going forward.  Plan is to land, test, and then pull the workflow dispatch with another PR

### 📜 Documentation
spice-labs-inc/grinder#1 is the associated release.

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
