### PR TITLE
Issue #81  Use the latest verion of sbt-assembly

### DIFF
--- a/.github/workflows/scala_container_publishing.yml
+++ b/.github/workflows/scala_container_publishing.yml
@@ -45,8 +45,13 @@ jobs:
           echo "short_git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
           echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_ENV"
       
-      - name: Package Scala Application
-        run: sbt package
+      # Previously used package. See Issue #81 jtp
+      # Converting to sbt assembly
+      #- name: Package Scala Application
+      #  run: sbt package
+
+       -- name: Package Scala Assembly
+          run: sbt assembly
         
       - name: Save JAR Artifact
         uses: actions/upload-artifact@v4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.6.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.2")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")


### PR DESCRIPTION
ssue #81  Modify plugins.sbt to use the latest verion of sbt-assembly which is 2.3.1.  Then modified publish workflow to call assembly instead of package.  Reading it appears all should work without other changes

### 💻 Description of Change(s) (w/ context)
Changed two files.  plugins.sbt to use latest version of [sbt assembly](https://github.com/sbt/sbt-assembly)

### 🧠 Rationale Behind Change(s)
Troubleshooting weird (technical team) classpath errors building grinder.  DPP discovered we should be using sbt-assembly to create the uber assembly

### 📝 Test Plan
Careful reading but unfortuantely need to land in main.  I did comment all changes in the workflow yaml so we can quickly revert if problem arises to make sure main can build.

### 📜 Documentation
None so far

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
