### PR TITLE
Add workflow to run GoatRodeo on its own JAR files

### DIFF
--- a/.github/workflows/adg_action_ci.yml
+++ b/.github/workflows/adg_action_ci.yml
@@ -3,13 +3,14 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Run Goat Rodeo
+name: Build ADG from Goat Rodeo JAR
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:  # Allows manual triggering
+  workflow_run:
+    workflows: ["Scala Build & Test"]
+    types: 
+      - completed  # Triggers only when "Scala Build & Test" completes
 
 permissions:
   contents: read

--- a/.github/workflows/adg_action_ci.yml
+++ b/.github/workflows/adg_action_ci.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Run Goat Rodeo
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Build Goat Rodeo Package
+      run: sbt package
+
+    - name: Set up directories for running Goat Rodeo against the Goat Rodeo package
+      run: |
+        mkdir -p target/input
+        mkdir -p target/output
+        cp target/scala-*/goatrodeo*.jar target/input
+
+    - name: Run Goat Rodeo against the Goat Rodeo package
+      run: |
+        docker run --platform linux/amd64 --quiet --rm --network none \
+           --user $(id -u):$(id -g) \
+           -v $(pwd)/target/input:/input:ro \
+           -v $(pwd)/target/output:/output \
+           spicelabs/goatrodeo:0.6.3 \
+           -b /input \
+           -o /output


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
  *  Added workflow to build agd's from Goat Godeo's own JAR files

### 🧠 Rationale Behind Change(s)
Use Goat Rodeo to check Goat Rodeo

### 📝 Test Plan
  *  Push to branch adg-action-test
  *  Run workflows
  *  If no errors submit pull request

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
