### PR TITLE
Added a history.jsonl file to each generated cluster. Issue #95

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import scala.sys.process._
 
 val projectName = "goatrodeo"
-val projectVersion = "0.7.0-SNAPSHOT"
+val projectVersion = "0.7.1-SNAPSHOT"
 val scala3Version = "3.6.3"
 
 // If "TEST_THREAD_CNT" is set that means we're

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,15 @@ lazy val root = project
     assembly / mainClass := Some("goatrodeo.Howdy"),
     compileOrder := CompileOrder.JavaThenScala,
     scalacOptions += "-no-indent",
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoKeys := Seq[BuildInfoKey](
+      name,
+      version,
+      scalaVersion,
+      sbtVersion,
+      BuildInfoKey.action("commit") {
+        scala.sys.process.Process("git rev-parse HEAD").!!.trim
+      }
+    ),
     buildInfoPackage := "hellogoat"
   )
 

--- a/src/main/scala/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/goatrodeo/omnibor/GraphManager.scala
@@ -262,7 +262,7 @@ object GraphManager {
 
     Files.writeString(
       File(targetDirectory, "history.jsonl").toPath(),
-      compact(render(jsonLine))
+      f"${compact(render(jsonLine))}\n"
     )
     (fileSet, targetFile)
   }


### PR DESCRIPTION
Adds a `history.jsonl` file to each cluster.

`{"date":"2025-04-16T20:12:19.530588476Z[UTC]","goat_rodeo_version":"0.6.4-7-e17ae45-dirty-SNAPSHOT","operation":"build_adg","goat_rodeo_commit":"e17ae45cad01b53f2d26289612b6f73520980575","cluster_name":"2025_04_16_20_12_19_5007688dc4d1abf4.grc"}`
