### PR TITLE
Remove unused version label

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import scala.sys.process._
 
 val projectName = "goatrodeo"
-val projectVersion = "0.7.1-SNAPSHOT"
 val scala3Version = "3.6.3"
 
 // If "TEST_THREAD_CNT" is set that means we're


### PR DESCRIPTION
The version is calculated at build time in sbt from the git tags present, leaving `projectVersion` unused. We can remove it to avoid confusion and having mismatched version identifiers.