### PR TITLE
Improve the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,22 @@
 ### 💻 Description of Change(s) (w/ context)
+
 What did you change, and what additional context do reviewers need?
 
 ### 🧠 Rationale Behind Change(s)
+
 Why were these changes made? What tradeoffs were considered?
 
 ### 📝 Test Plan
+
 Beyond unit tests, how did you make sure this code is ready for production?
 
 ### 📜 Documentation
-What documentation did you add or update? 
+
+What documentation did you add or update?
 Was the documentation appropriate for the scope of this change?
 
 ### 💣 Quality Control
+
 (All items must be checked before a PR is merged)
 Did you…
 
@@ -23,5 +28,6 @@ Did you…
 - [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?
 
 ### Before Merging…
+
 - Make sure the Quality Control boxes are all ticked
 - Make sure any open comments or conversations on the PR are resolved

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@ Was the documentation appropriate for the scope of this change?
 ### 💣 Quality Control
 (All items must be checked before a PR is merged)
 Did you…
-- [ ] Mention an issue number in the PR title?
+
+- [ ] Mention an issue number in the PR body?
 - [ ] Update the version # in the build file?
 - [ ] Create new and/or update relevant existing tests?
 - [ ] Create or update relevant documentation and/or diagrams?


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)

Suggest using the body not the title

### 🧠 Rationale Behind Change(s)

Github auto-links there and auto-closes, while the title is hard to read, limited space, and does not do that.