### PR TITLE
Support for dumping roots and dumping the whole ADG as JSON

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -15,15 +15,15 @@ limitations under the License. */
 package io.spicelabs.goatrodeo
 
 import com.typesafe.scalalogging.Logger
-
-import java.nio.file.Paths
-import scala.annotation.static
-import scala.jdk.CollectionConverters.*
-import io.spicelabs.goatrodeo.util.Config
-import scala.util.Try
-import java.util.regex.Pattern
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
+import io.spicelabs.goatrodeo.util.Config
+
+import java.nio.file.Paths
+import java.util.regex.Pattern
+import scala.annotation.static
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
 
 class GoatRodeoBuilder {
   private val log = Logger(classOf[GoatRodeoBuilder])

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
@@ -1,8 +1,9 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import scala.collection.immutable.TreeSet
-import scala.collection.immutable.TreeMap
 import io.spicelabs.goatrodeo.util.Helpers
+
+import scala.collection.immutable.TreeMap
+import scala.collection.immutable.TreeSet
 
 /** Data that augments an Item
   */

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -55,6 +55,27 @@ case class Item(
     myHash < thatHash
   }
 
+  /** Is the item a root item
+    *
+    * @return
+    */
+  def isRoot(): Boolean = {
+    if (this.bodyMimeType != Some(ItemMetaData.mimeType)) {
+      false
+    } else if (this.identifier == "tags") {
+      false
+    } else if (
+      this.connections
+        .find(e => EdgeType.isAliasTo(e._1) || EdgeType.isContainedByUp(e._1))
+        .isDefined
+    ) { false }
+    else {
+
+      true
+    }
+
+  }
+
   /** Builds a list of items that are referenced from this item. The references
     * are of types `AliasFrom`, `BuiltFrom`, and `ContainedBy`
     *
@@ -236,7 +257,7 @@ case class Item(
         val augmentedFileNames = filenames.flatMap(name =>
           maybeParent match {
             case Some(parent)
-                if baseFileNames.size > 1 || !baseFileNames.contains(name) =>
+                if baseFileNames.size > 1 || (baseFileNames.size == 1 && !baseFileNames.contains(name)) =>
               Vector(name, f"${parent}/${name}")
             case _ => Vector(name)
           }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -16,10 +16,12 @@ package io.spicelabs.goatrodeo.omnibor
 
 import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
+import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.File
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import scala.collection.immutable.TreeSet
@@ -107,6 +109,30 @@ trait Storage {
     *   the purls
     */
   def purls(): TreeSet[String]
+
+  def emitRootsToDir(dir: File): Unit = {
+    dir.mkdirs()
+    val fileName = f"roots_${System.currentTimeMillis()}.json"
+    val file = new File(dir, fileName)
+    val rootItems = for {
+      key <- keys().toVector
+      item <- read(key) if item.isRoot()
+    } yield item.identifier
+
+    Files.writeString(file.toPath(), Json.encode(rootItems).toUtf8String)
+  }
+
+  def emitAllItemsToDir(dir: File): Unit = {
+    dir.mkdirs()
+    val fileName = f"items_${System.currentTimeMillis()}.json"
+    val file = new File(dir, fileName)
+    val rootItems = for {
+      key <- keys().toVector
+      item <- read(key)
+    } yield item
+
+    Files.writeString(file.toPath(), Json.encode(rootItems).toUtf8String)
+  }
 }
 
 /** Can the filenames be listed?

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala
@@ -40,6 +40,8 @@ object EdgeType {
 
   def isContains(s: String): Boolean = s == contains
 
+  def isContainedByUp(s: String): Boolean = s == containedBy
+
   /** Is the type `AliasTo`
     *
     * @param s

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -2,6 +2,7 @@ package io.spicelabs.goatrodeo.omnibor.strategies
 
 import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
+import io.spicelabs.goatrodeo.omnibor.Augmentation
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ParentScope
@@ -18,7 +19,7 @@ import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.PURLHelpers.Ecosystems
-import io.spicelabs.goatrodeo.omnibor.Augmentation
+
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
 import scala.util.Try

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -1,18 +1,18 @@
 package io.spicelabs.goatrodeo.util
 
+import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
+import io.bullet.borer.Json
+import org.apache.commons.io.filefilter.WildcardFileFilter
+import scopt.OParser
+import scopt.OParserBuilder
 
 import java.io.File
+import java.io.FileFilter
 import java.nio.file.Files
 import java.util.regex.Pattern
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
-import scopt.OParser
-import scopt.OParserBuilder
-import com.typesafe.scalalogging.Logger
-import io.bullet.borer.Json
-import org.apache.commons.io.filefilter.WildcardFileFilter
-import java.io.FileFilter
 
 /** Command Line Configuration
   *
@@ -39,7 +39,9 @@ case class Config(
     blockList: Option[File] = None,
     maxRecords: Int = 50000,
     tempDir: Option[File] = None,
-    useSyft: Boolean = false
+    useSyft: Boolean = false,
+    dumpRootDir: Option[File] = None,
+    emitJsonDir: Option[File] = None
 ) {
   def getFileListBuilders(): Vector[() => Seq[File]] = {
     build.map(file => () => Helpers.findFiles(file, f => true)) ++ fileList
@@ -57,7 +59,7 @@ case class Config(
 }
 
 object Config {
-    private val logger = Logger(getClass())
+  private val logger = Logger(getClass())
   lazy val builder: OParserBuilder[Config] = OParser.builder[Config]
   lazy val parser1: OParser[Unit, Config] = {
     import builder._
@@ -132,6 +134,14 @@ object Config {
       opt[File]('o', "out")
         .text("output directory for the file-system based gitoid storage")
         .action((x, c) => c.copy(out = Some(x))),
+      opt[File]("dump-roots")
+        .text(
+          "Make a directory and dump the roots in JSON files in the directory"
+        )
+        .action((x, c) => c.copy(dumpRootDir = Some(x))),
+      opt[File]("dump-json")
+        .text("Make a directory and dump the ADG as JSON in to directory")
+        .action((x, c) => c.copy(emitJsonDir = Some(x))),
       opt[File]("tempdir")
         .text("Where to temporarily store files... should be a RAM disk")
         .action((x, c) => c.copy(tempDir = Some(x))),

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Syft.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Syft.scala
@@ -1,16 +1,16 @@
 package io.spicelabs.goatrodeo.util
 
 import com.typesafe.scalalogging.Logger
+import io.spicelabs.goatrodeo.omnibor.*
+import io.spicelabs.goatrodeo.omnibor.ConnectionAugmentation
+import io.spicelabs.goatrodeo.omnibor.EdgeType
+import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
 
 import java.io.ByteArrayOutputStream
 import java.nio.file.Path
 import scala.util.Try
-import io.spicelabs.goatrodeo.omnibor.StringOrPair
-import io.spicelabs.goatrodeo.omnibor.ConnectionAugmentation
-import io.spicelabs.goatrodeo.omnibor.EdgeType
-import io.spicelabs.goatrodeo.omnibor.*
 
 /** The bridge to Syft https://github.com/anchore/syft
   */

--- a/src/test/scala/ADGTests.scala
+++ b/src/test/scala/ADGTests.scala
@@ -71,7 +71,7 @@ class ADGTests extends munit.FunSuite {
           sync.synchronized { captured = captured :+ f }; ()
         },
         done = b => { finished = b },
-        preWriteDB = store => {
+        preWriteDB = Vector(store => {
           store.keys().toVector.zipWithIndex.foreach {
             case (key, idx) => {
               val item = store.read(key).get
@@ -106,7 +106,7 @@ class ADGTests extends munit.FunSuite {
             }
             case None => assert(false, "Failed to read tags"); true
           }
-        }
+        })
       )
 
       assert(tagCount > 8000, s"Expecting lots of tags, got ${tagCount}")


### PR DESCRIPTION
Issue #124 

The `--dump-json <directory>` flag will dump the ADG as JSON

The `--dump-roots <directory>` flag will dump the root items of the ADG

 