### PR TITLE
Changed from Syft to static metadata to allow for other static metadata gathering

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -88,8 +88,8 @@ class GoatRodeoBuilder {
     this
   }
 
-  def withSyft(b: Boolean): GoatRodeoBuilder = {
-    config = config.copy(useSyft = b)
+  def withStatisMetadata(b: Boolean): GoatRodeoBuilder = {
+    config = config.copy(useStaticMetadata = b)
     this
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
@@ -15,7 +15,7 @@ sealed trait Augmentation {
 /** Something that augments the `ItemMetaData` `extra` field
   *
   * @param name
-  *   the name (e.g., "syft-all")
+  *   the name (e.g., "static-metadata-all")
   * @param data
   *   the information to store in the extra field
   */

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -306,8 +306,8 @@ object Builder {
               // build the package
 
               val byHash: Map[String, Vector[Augmentation]] =
-                if (args.useSyft) {
-                  toProcess.runSyft()
+                if (args.useStaticMetadata) {
+                  toProcess.runStaticMetadataGather()
                 } else {
                   Map()
                 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -9,7 +9,7 @@ import io.spicelabs.goatrodeo.util.FileWalker
 import io.spicelabs.goatrodeo.util.FileWrapper
 import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers
-import io.spicelabs.goatrodeo.util.Syft
+import io.spicelabs.goatrodeo.util.StaticMetadata
 
 import java.io.File
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -251,12 +251,12 @@ trait ToProcess {
     */
   def getElementsToProcess(): (Seq[(ArtifactWrapper, MarkerType)], StateType)
 
-  def runSyft(): Map[String, Vector[Augmentation]] = {
+  def runStaticMetadataGather(): Map[String, Vector[Augmentation]] = {
     FileWalker.withinTempDir { tempDir =>
       {
         val augmentation: Seq[Map[String, Vector[Augmentation]]] = for {
           (wrapper, _) <- getElementsToProcess()._1
-          it <- Syft.runSyftFor(wrapper, tempDir).toList
+          it <- StaticMetadata.runStaticMetadataGather(wrapper, tempDir).toList
           answer <- it.runForMillis(120L * 1000 * 60) // 120 minutes
 
         } yield it.buildAugmentation()
@@ -684,8 +684,8 @@ object ToProcess {
   ): Storage = {
 
     for { individual <- toProcess } {
-      val augmentation = if (args.useSyft) {
-        individual.runSyft()
+      val augmentation = if (args.useStaticMetadata) {
+        individual.runStaticMetadataGather()
       } else Map()
 
       individual.process(

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -39,7 +39,7 @@ case class Config(
     blockList: Option[File] = None,
     maxRecords: Int = 50000,
     tempDir: Option[File] = None,
-    useSyft: Boolean = false,
+    useStaticMetadata: Boolean = false,
     dumpRootDir: Option[File] = None,
     emitJsonDir: Option[File] = None
 ) {
@@ -79,11 +79,11 @@ object Config {
               .filter(f => f.exists())
           )
         ),
-      opt[Boolean]("syft")
+      opt[Boolean]("static-metadata")
         .text(
           "Enhance metadata with Syft (must install https://github.com/anchore/syft)"
         )
-        .action((x, c) => c.copy(useSyft = x)),
+        .action((x, c) => c.copy(useStaticMetadata = x)),
       opt[String]("tag")
         .text(
           "Tag all top level artifacts (files) with the current date and the text of the tag"

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -12,31 +12,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 import io.spicelabs.goatrodeo.util.FileWrapper
-import io.spicelabs.goatrodeo.util.Syft
+import io.spicelabs.goatrodeo.util.StaticMetadata
 import org.json4s.*
 
 import java.io.File
-class SyftSuite extends munit.FunSuite {
-  test("Syft works") {
-    if (Syft.hasSyft) {
+class MetadataSuite extends munit.FunSuite {
+  test("Metadata collections works") {
+    if (StaticMetadata.hasSyft) {
       val file = File("test_data/jar_test/slf4j-simple-1.6.1.jar")
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
-      val runner = Syft.runSyftFor(fileWrapper, file.toPath())
+      val runner =
+        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath())
       val (str, json) = runner.get.runForMillis(100000).get
 
-      assert(str.length() > 400, s"Syft answer too small ${str}")
+      assert(str.length() > 400, s"Metadata answer too small ${str}")
     } else {
       assert(true)
     }
   }
 
-  test("Syft works on nested stuff") {
-    if (Syft.hasSyft) {
+  test("Metadata collections works on nested stuff") {
+    if (StaticMetadata.hasSyft) {
       val file = File("test_data/nested.tar")
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
-      val runner = Syft.runSyftFor(fileWrapper, file.toPath())
+      val runner =
+        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath())
       val (str, json) = runner.get.runForMillis(100000).get
 
       // val artifacts =

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -169,7 +169,7 @@ class MySuite extends munit.FunSuite {
 
     val store = ToProcess.buildGraphFromArtifactWrapper(
       nested,
-      args = Config(useSyft = true)
+      args = Config(useStaticMetadata = true)
     )
 
     val gitoids = store.gitoidKeys()
@@ -177,7 +177,7 @@ class MySuite extends munit.FunSuite {
 
     assert(cnt > 1200, f"expected more than 1,200, got ${cnt}")
 
-    if (Syft.hasSyft) { // only run the Syft tests if Syft is installed
+    if (StaticMetadata.hasSyft) { // only run the Static Metadata tests if Syft is installed
       {
         // 46dccecac556623d8e2ce8648496824a82951d139062a4e61148aff1a25ed18d  log4j-core-2.22.1.jar
         val item = store
@@ -198,7 +198,10 @@ class MySuite extends munit.FunSuite {
         assert(purls.length == 1, s"should be a purl ${purls} on log4j")
 
         assert(
-          item.bodyAsItemMetaData.get.extra.get("syft-artifact").get.size == 1,
+          item.bodyAsItemMetaData.get.extra
+            .get("static-metadata-artifact")
+            .get
+            .size == 1,
           "Should have one augmentation on log4j"
         )
       }
@@ -227,7 +230,10 @@ class MySuite extends munit.FunSuite {
         )
 
         assert(
-          item.bodyAsItemMetaData.get.extra.get("syft-artifact").get.size == 1,
+          item.bodyAsItemMetaData.get.extra
+            .get("static-metadata-artifact")
+            .get
+            .size == 1,
           "Should have one augmentation on tk"
         )
       }


### PR DESCRIPTION
Mostly a naming change.

Changed from being Syft-specific in static metadata gathering to simply calling things static metadata gathering. Allows for other static metadata gathering tools in the future.

This will require updates to the CLI