### PR TITLE
Fixed an issue with package URLs not being emitted correctly if found  in metadata

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
@@ -1,5 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor
 
+import com.github.packageurl.PackageURL
 import io.spicelabs.goatrodeo.util.Helpers
 
 import scala.collection.immutable.TreeMap
@@ -8,7 +9,7 @@ import scala.collection.immutable.TreeSet
 /** Data that augments an Item
   */
 sealed trait Augmentation {
-  def augment(item: Item): Item
+  def augment(item: Item, store: Storage): Item
   def hashValue: String
 }
 
@@ -24,7 +25,7 @@ final case class TopLevelExtraAugmentation(
     name: String,
     data: StringOrPair
 ) extends Augmentation {
-  def augment(item: Item): Item = {
+  def augment(item: Item, store: Storage): Item = {
     item.bodyMimeType match {
       case None | Some(ItemMetaData.mimeType) =>
         item.copy(
@@ -65,9 +66,11 @@ final case class TopLevelExtraAugmentation(
   */
 final case class ConnectionAugmentation(
     hashValue: String,
-    connection: (String, String)
+    connection: (String, String),
+    pURL: PackageURL
 ) extends Augmentation {
-  def augment(item: Item): Item = {
+  def augment(item: Item, store: Storage): Item = {
+    store.addPurl(pURL)
     item.copy(connections = item.connections + connection)
   }
 }
@@ -86,7 +89,7 @@ final case class ExtraAugmentation(
     name: String,
     data: StringOrPair
 ) extends Augmentation {
-  def augment(item: Item): Item = {
+  def augment(item: Item, store: Storage): Item = {
     item.bodyMimeType match {
       case None | Some(ItemMetaData.mimeType) =>
         item.copy(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -189,11 +189,13 @@ abstract class ParentScope(
     val mine = if (this.augmentationByHash.isEmpty) { Vector() }
     else {
 
-      for {
+      val mine2 = for {
         hash <- hashes
         augs <- this.augmentationByHash.get(hash).toVector
         aug <- augs
       } yield aug
+
+      mine2
     }
 
     mine ++ (for {
@@ -312,8 +314,9 @@ trait ToProcess {
                 .map(_._2)
               val augmentations = parentScope.itemAugmentationByHashes(aliases)
               val item = augmentations.foldLeft(itemRaw) { case (item, aug) =>
-                aug.augment(item)
+                aug.augment(item, store)
               }
+
               val state = orgState.beginProcessing(artifact, item, marker)
               val itemScope1 =
                 parentScope.beginProcessing(store, artifact, item)
@@ -375,8 +378,10 @@ trait ToProcess {
               // this is *only* for the the pre-merged `Item`
               // why? The post merge `Item` has a lot of back-references
               // we do not need to update these as it'll only cause thrash
-              itemScope4
+              val backref = itemScope4
                 .buildListOfReferencesForAliasFromBuiltFromContainedBy()
+
+              backref
                 .foreach { case (aliasType, itemNeedingAlias) =>
                   store.write(
                     itemNeedingAlias,


### PR DESCRIPTION
When Package URLs are found in metadata, they are associated with `Item`s but not correctly output when the cluster is saved. This is fixed.