### PR TITLE
Goatrodeo: Workflow Update to Allow Spice Labs CLI Scaning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
-name: Publish package to Maven Central, Github Packages, and Container Image to Docker Hub
+name: Publish package to Maven Central, GitHub Packages, and Container Image to Docker Hub
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+      - mj/cli-scan
+    tags:
+      - "v*.*.*"
 
 env:
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,12 @@ env:
   DOCKERHUB_NAMESPACE: ${{ secrets.DOCKER_USERNAME }}
   PLATFORMS: linux/amd64,linux/arm64
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
 jobs:
   publish-jars:
     name: Publish JARs to GitHub (Maven Central temporarily disabled)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
+      is_tag: ${{ steps.guard.outputs.is_tag }}
+      is_tag_on_main: ${{ steps.guard.outputs.is_tag_on_main }}
       release_timestamp: ${{ steps.release-notification.outputs.timestamp }}
       release_channel_id: ${{ steps.release-notification.outputs.channel_id }}
 
@@ -37,17 +39,40 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           username-mapping: ${{ secrets.GH_SLACK_USERNAME_MAPPING }}
           github-token: ${{ github.token }}
+
       - name: Checkout with LFS
         uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
+
+      - name: Determine release conditions (tag on main)
+        id: guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          IS_TAG=false
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            IS_TAG=true
+          fi
+          IS_TAG_ON_MAIN=false
+          if [[ "$IS_TAG" == "true" ]]; then
+            git fetch -q origin main
+            TAG_SHA="$(git rev-parse HEAD)"
+            MAIN_SHA="$(git rev-parse origin/main)"
+            if git merge-base --is-ancestor "$TAG_SHA" "$MAIN_SHA"; then
+              IS_TAG_ON_MAIN=true
+            fi
+          fi
+          echo "is_tag=$IS_TAG" >> "$GITHUB_OUTPUT"
+          echo "is_tag_on_main=$IS_TAG_ON_MAIN" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'sbt'
+          java-version: "21"
+          distribution: "temurin"
+          cache: "sbt"
 
       - name: Set up SBT
         uses: sbt/setup-sbt@v1
@@ -57,14 +82,20 @@ jobs:
         shell: bash
         run: |
           raw_version="${GITHUB_REF#refs/tags/v}"
-          if [[ ! "$raw_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format: $raw_version. Must be v<major>.<minor>.<patch>." >&2
-            exit 1
+          if [[ "${{ steps.guard.outputs.is_tag }}" == "true" ]]; then
+            if [[ ! "$raw_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid tag format: $raw_version. Must be v<major>.<minor>.<patch>." >&2
+              exit 1
+            fi
+            echo "projectVersion=$raw_version" >> "$GITHUB_ENV"
+            echo "version=$raw_version" >> "$GITHUB_OUTPUT"
+          else
+            # Branch build: still build/scan but no publish-from-branch
+            echo "projectVersion=0.0.0-SNAPSHOT" >> "$GITHUB_ENV"
+            echo "version=0.0.0-SNAPSHOT" >> "$GITHUB_OUTPUT"
           fi
-          echo "projectVersion=$raw_version" >> "$GITHUB_ENV"
-          echo "version=$raw_version" >> "$GITHUB_OUTPUT"
 
-      - name: Publish standard and fat JARs to GitHub Packages
+      - name: Build and publish JARs to GitHub Packages
         run: |
           SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt \
             "set ThisBuild / version := \"${{ env.projectVersion }}\"" \
@@ -73,15 +104,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github
 
-      
+      - name: Scan built artifacts with Spice-Labs CLI
+        if: always()
+        env:
+          SPICE_PASS: ${{ secrets.SPICE_PASS }}
+        shell: bash
+        run: |
+          # Use channel-style scan tags per project defaults
+          TAG="${{ (startsWith(github.ref, 'refs/tags/v')) && format('{0}-release', github.event.repository.name) || format('{0}-staging', github.event.repository.name) }}"
+          # SBT places output jars under **/target/**
+          docker run --rm \
+            -v "$PWD:/work:ro" \
+            -e SPICE_PASS \
+            spicelabs/spice-labs-cli:0.2.27 \
+            --input /work/target \
+            --tag "$TAG"
 
   publish-to-central:
     name: Re-publish Goatrodeo to Maven Central
     runs-on: ubuntu-24.04
     needs: publish-jars
+    if: needs.publish-jars.outputs.is_tag_on_main == 'true'
     permissions:
       contents: read
       packages: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,9 +136,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
+          java-version: "21"
+          distribution: "temurin"
+          cache: "maven"
       
       - name: Write settings.xml for Central
         run: |
@@ -111,7 +158,6 @@ jobs:
       - name: Import GPG key
         run: |
           echo "${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}" | gpg --batch --import
-
 
       - name: Set project version from tag
         run: |
@@ -144,7 +190,6 @@ jobs:
       - name: Inject real dependencies block into fake pom.xml
         run: |
           set -e
-
           VERSION="${{ needs.publish-jars.outputs.version }}"
           REAL_POM="maven/target/external/goatrodeo_3-${VERSION}.pom"
           FAKE_POM="maven/pom.xml"
@@ -154,8 +199,7 @@ jobs:
             {print}
           ' "$FAKE_POM" > "${FAKE_POM}.tmp" && mv "${FAKE_POM}.tmp" "$FAKE_POM"
 
-
-      - name: Publish to Maven Central (staging only)
+      - name: Publish to Maven Central
         run: |
           cd maven
           mvn --batch-mode deploy
@@ -163,7 +207,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
 
   docker-image:
-    name: Build and Push Docker Image
+    name: Build (always) and Push (tags on main only) Docker Image
     runs-on: ubuntu-24.04
     needs: publish-jars
     permissions:
@@ -184,6 +228,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Fat JAR from GitHub Packages
+        if: needs.publish-jars.outputs.is_tag == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -192,40 +237,21 @@ jobs:
             -H "Accept: application/octet-stream" \
             "https://maven.pkg.github.com/spice-labs-inc/goatrodeo/io/spicelabs/goatrodeo_3/${{ needs.publish-jars.outputs.version }}/goatrodeo_3-${{ needs.publish-jars.outputs.version }}-fat.jar"
 
-      - name: Extract Metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: spicelabs/goatrodeo
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-          flavor: |
-            latest=auto
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and Push Docker Image
+      - name: Build and (conditionally) push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ env.PLATFORMS }}
-          push: true
+          push: ${{ needs.publish-jars.outputs.is_tag_on_main == 'true' }}
           provenance: mode=max
           sbom: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: spicelabs/goatrodeo:${{ needs.publish-jars.outputs.version }}
 
   notify:
     needs: [publish-jars, publish-to-central, docker-image]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -233,38 +259,18 @@ jobs:
         id: deployment-status
         shell: bash
         run: |
-          # Check job outcomes
           JARS_STATUS="${{ needs.publish-jars.result }}"
           CENTRAL_STATUS="${{ needs.publish-to-central.result }}"
           DOCKER_STATUS="${{ needs.docker-image.result }}"
-          
-          # Determine overall success
-          if [ "$JARS_STATUS" == "success" ] && [ "$CENTRAL_STATUS" == "success" ] && [ "$DOCKER_STATUS" == "success" ]; then
+          if [ "$JARS_STATUS" = "success" ] && [ "$CENTRAL_STATUS" = "success" ] && [ "$DOCKER_STATUS" = "success" ]; then
             echo "overall_status=success" >> $GITHUB_OUTPUT
-            echo "message=✅ All components published successfully!" >> $GITHUB_OUTPUT
+            echo "message=All components published successfully" >> $GITHUB_OUTPUT
           else
             echo "overall_status=failure" >> $GITHUB_OUTPUT
-            
-            # Build detailed failure message
-            MESSAGE="❌ Publishing failed:"
-            if [ "$JARS_STATUS" != "success" ]; then
-              MESSAGE="$MESSAGE ❌ SBT JAR publishing failed."
-            else
-              MESSAGE="$MESSAGE ✅ SBT JAR publishing succeeded."
-            fi
-            
-            if [ "$CENTRAL_STATUS" != "success" ]; then
-              MESSAGE="$MESSAGE ❌ Maven Central publishing failed."
-            else
-              MESSAGE="$MESSAGE ✅ Maven Central publishing succeeded."
-            fi
-            
-            if [ "$DOCKER_STATUS" != "success" ]; then
-              MESSAGE="$MESSAGE ❌ Docker build/push failed."
-            else
-              MESSAGE="$MESSAGE ✅ Docker build/push succeeded."
-            fi
-            
+            MESSAGE="Publishing summary:"
+            MESSAGE="$MESSAGE $([ "$JARS_STATUS" = success ] && echo 'JARs OK' || echo 'JARs FAILED');"
+            MESSAGE="$MESSAGE $([ "$CENTRAL_STATUS" = success ] && echo ' Central OK' || echo ' Central FAILED');"
+            MESSAGE="$MESSAGE $([ "$DOCKER_STATUS" = success ] && echo ' Docker OK' || echo ' Docker FAILED')"
             echo "message=$MESSAGE" >> $GITHUB_OUTPUT
           fi
 
@@ -274,7 +280,7 @@ jobs:
           type: ${{ steps.deployment-status.outputs.overall_status == 'success' && 'deployment-success' || 'deployment-failure' }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           username-mapping: ${{ secrets.GH_SLACK_USERNAME_MAPPING }}
-          workflow-name: ${{ steps.deployment-status.outputs.overall_status == 'success' && 'Release' || format('Release - {0}', steps.deployment-status.outputs.message) }}
+          workflow-name: Release
           environment: production
           thread-ts: ${{ needs.publish-jars.outputs.release_timestamp }}
           channel-id: ${{ needs.publish-jars.outputs.release_channel_id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,6 @@ jobs:
   publish-jars:
     name: Publish JARs to GitHub (Maven Central temporarily disabled)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       release_timestamp: ${{ steps.release-notification.outputs.timestamp }}


### PR DESCRIPTION
## Changes
- Updated triggers: now runs on `main`, `mj/cli-scan`, and semver tags (`v*.*.*`)
- Enforced tag-on-main gating for releases (Docker Hub & Maven Central only publish when tag commit is on `main`)
- Removed `:latest` tagging, Docker images are published only as `:<version>`
- Added Spice-Labs CLI scan for built artifacts with channel tags (`goatrodeo-staging` / `goatrodeo-release`)
- Standardised runners to `ubuntu-24.04`
- Ensured required workflow permissions (`contents`, `packages`, `id-token`, `attestations`)

## Testing
1. Builds and scans will run on `mj/cli-scan` for validation
2. No publishing from feature/test branches
3. Publishing to Docker Hub and Maven Central is gated to semver tags on `main`

When aLL tests have passed the temporary branch trigger will be removed before merging to `main`.
