### PR TITLE
add ADG scan via reusable action to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github
 
-      
+      - name: Index and upload ADG
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          token: ${{ secrets.SPICE_PASS }}
+          input: target
+          tag: ${{ github.event.repository.name }}
 
   publish-to-central:
     name: Re-publish Goatrodeo to Maven Central

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,9 +70,9 @@ jobs:
       - name: Index and upload ADG
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
-          token: ${{ secrets.SPICE_PASS }}
-          input: target
-          tag: ${{ github.event.repository.name }}
+          spice_pass: "${{ secrets.SPICE_PASS }}"
+          file_path: "./target"
+          tag: "${{ github.event.repository.name }}"
 
   publish-to-central:
     name: Re-publish Goatrodeo to Maven Central


### PR DESCRIPTION
Adds a single step to index and upload ADGs using spice-labs-inc/action-spice-labs-cli-scan@v3.

**Testing**

1. Create a release (e.g., tag vX.Y.Z).
2. Confirm GitHub Packages/Docker Hub and Maven Central publishing proceed as before.
3. Verify the new “Index and upload ADG” step runs and uploads ADGs to Spice Labs.
  - Link to successful run: https://github.com/spice-labs-inc/goatrodeo/actions/runs/17848354560
  - Screenshots of upload & dashboard
<img width="991" height="103" alt="image" src="https://github.com/user-attachments/assets/c04de460-94aa-421e-8ec1-758ed8642e07" />
<img width="574" height="86" alt="image" src="https://github.com/user-attachments/assets/2f32250c-f748-415e-be2a-5e19a690e74e" />

