### PR TITLE
fixed typo in API name

### DIFF
--- a/info/goat_rodeo_api.md
+++ b/info/goat_rodeo_api.md
@@ -25,7 +25,7 @@ There is a one to one correspondence between the `with` methods and command-line
 - `withBlockList(String b)`
 - `withTempDir(String d)`
 - `withTag(String t)`
-- `withStatisMetadata(Boolean b)`
+- `withStaticMetadata(Boolean b)`
 - `withTagJson(String t)`
 - `withExtraArgs(java.util.Map<String, String> args)`
 - `withExtraArg(String arg, String value)` - possibly an accumulator

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -88,7 +88,7 @@ class GoatRodeoBuilder {
     this
   }
 
-  def withStatisMetadata(b: Boolean): GoatRodeoBuilder = {
+  def withStaticMetadata(b: Boolean): GoatRodeoBuilder = {
     config = config.copy(useStaticMetadata = b)
     this
   }


### PR DESCRIPTION
this addresses issue [#159](https://github.com/spice-labs-inc/goatrodeo/issues/159)
`withStatisMetadata` -> `withStaticMetadata`