### PR TITLE
fix for -b bug

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -61,6 +61,14 @@ object Howdy {
 
     val fileListers = params.getFileListBuilders()
 
+    if (!params.nonexistantDirectories.isEmpty) {
+      logger.error("One or more directories in a -b or --build option was not found: ")
+      params.nonexistantDirectories.foreach(f => logger.error(f.getAbsolutePath()))
+      logger.info(OParser.usage(Config.parser1))
+      Helpers.bailFail()
+      return
+    }
+
     if (fileListers.isEmpty) {
       logger.error("At least one `-b` or `--file-list` must be provided")
       logger.info(OParser.usage(Config.parser1))


### PR DESCRIPTION
This is a fix for issue [155](https://github.com/spice-labs-inc/goatrodeo/issues/155).

What caused the issue: any directories supplied with `-b` or `--build` are eagerly traversed for files and the directories are themselves ignored from there on out. This means that when the check happens for "did we get any files?" the actual cause is lost.

What I did to fix this:
- Added a vector to the parameters for directories that don't exist
- Accumulate non-existent directories into the vector during argument processing
- Early in `run()` check for non-existent directories and if so, spew error information