### PR TITLE
added infrastructure for include/exclude

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/util/IncludeExclude.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/IncludeExclude.scala
@@ -1,0 +1,51 @@
+/* Copyright 2024 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+package io.spicelabs.goatrodeo.util
+
+import scala.util.matching.Regex
+
+class IncludeExclude (include: RegexPredicate, exclude: RegexPredicate) {
+    def this(incExact: Set[String], incRegex: Vector[Regex], excExact: Set[String], excRegex: Vector[Regex]) = {
+        this(RegexPredicate(incExact, incRegex), RegexPredicate(excExact, excRegex))
+    }
+    
+    def shouldInclude(candidate: String) = {
+        // if the candidate is not in the exclude, it should be included.
+        // if the candidate *is* is the exclude, then check to see if it's included
+        !exclude.matches(candidate) || include.matches(candidate)
+    }
+}
+
+object IncludeExclude {
+    def aggregatePredicate(predicate: String,
+        inc_exc: (incExact: Set[String], incRegex: Vector[Regex], excExact: Set[String], excRegex: Vector[Regex])
+    ): (Set[String], Vector[Regex], Set[String], Vector[Regex]) = {
+        if (predicate.isEmpty()) {
+            return inc_exc
+        }
+        val command = predicate.charAt(0)
+        val pattern = predicate.substring(1)
+        if (pattern.isEmpty()) {
+            return inc_exc
+        }
+        command match {
+            case '#' => inc_exc
+            case '+' => (inc_exc.incExact + pattern, inc_exc.incRegex, inc_exc.excExact, inc_exc.excRegex)
+            case '*' => (inc_exc.incExact, inc_exc.incRegex :+ pattern.r, inc_exc.excExact, inc_exc.excRegex)
+            case '-' => (inc_exc.incExact, inc_exc.incRegex, inc_exc.excExact + pattern, inc_exc.excRegex)
+            case '/' => (inc_exc.incExact, inc_exc.incRegex, inc_exc.excExact, inc_exc.excRegex :+ pattern.r)
+            case _ => throw IllegalArgumentException(s"illegal command '${command}' expecting one of #, +, *, -, /")
+        }
+    }
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/util/RegexPredicate.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/RegexPredicate.scala
@@ -1,0 +1,22 @@
+/* Copyright 2024 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+package io.spicelabs.goatrodeo.util
+
+import scala.util.matching.Regex
+
+final case class RegexPredicate(exact: Set[String], regexes: Vector[Regex])
+{
+    def matches(str: String) =
+        exact.contains(str) || regexes.exists((regex) => regex.matches(str))
+}

--- a/src/test/scala/IncExcTesting.scala
+++ b/src/test/scala/IncExcTesting.scala
@@ -1,0 +1,108 @@
+import io.spicelabs.goatrodeo.util.IncludeExclude
+import io.spicelabs.goatrodeo.util.RegexPredicate
+import scala.util.matching.Regex
+
+
+class IncExcTesting extends munit.FunSuite {
+    test("none-accepted") {
+        val predicates = RegexPredicate(Set[String](), Vector[Regex]())
+        assert(!predicates.matches("anything"))
+    }
+    
+    test("exact-match") {
+        val key = "splunge"
+        val predicates = RegexPredicate(Set(key), Vector[Regex]())
+        assert(predicates.matches(key))
+    }
+
+    test("regex-match") {
+        val key = "splunge"
+        val predicates = RegexPredicate(Set[String](), Vector("spl\\w*".r))
+        assert(predicates.matches(key))
+    }
+
+    test("includes-all") {
+        val includer = IncludeExclude(Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+        assert(includer.shouldInclude("all"))
+    }
+
+    test("excludes-all-text-MIME") {
+        val includer = IncludeExclude(Set[String](), Vector[Regex](), Set[String](), Vector("text\\/.*".r))
+        assert(!includer.shouldInclude("text/html"))
+        assert(!includer.shouldInclude("text/plain"))
+        assert(!includer.shouldInclude("text/json"))
+    }
+
+    test("excludes-all-text-MIME-but-HTML") {
+        val includer = IncludeExclude(Set("text/html"), Vector[Regex](), Set[String](), Vector("text\\/.*".r))
+        assert(includer.shouldInclude("text/html"))
+        assert(!includer.shouldInclude("text/plain"))
+        assert(!includer.shouldInclude("text/json"))
+    }
+
+    test("excludes-all-text-MIME-but-hanything") {
+        val includer = IncludeExclude(Set("text/html"), Vector("text\\/h.*".r), Set[String](), Vector("text\\/.*".r))
+        assert(includer.shouldInclude("text/html"))
+        assert(includer.shouldInclude("text/howdy"))
+        assert(!includer.shouldInclude("text/plain"))
+        assert(!includer.shouldInclude("text/json"))
+    }
+
+    test("comment") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("# this is a comment", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 0)
+        assertEquals(incR.size, 0)
+        assertEquals(excE.size, 0)
+        assertEquals(excR.size, 0)
+    }
+
+    test("include-exact") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("+splunge", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 1)
+        assertEquals(incR.size, 0)
+        assertEquals(excE.size, 0)
+        assertEquals(excR.size, 0)
+    }
+
+    test("include-regx") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("*foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 0)
+        assertEquals(incR.size, 1)
+        assertEquals(excE.size, 0)
+        assertEquals(excR.size, 0)
+    }
+
+    test("exclude-exact") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("-foo", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 0)
+        assertEquals(incR.size, 0)
+        assertEquals(excE.size, 1)
+        assertEquals(excR.size, 0)
+    }
+
+    test("exclude-regex") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("/foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 0)
+        assertEquals(incR.size, 0)
+        assertEquals(excE.size, 0)
+        assertEquals(excR.size, 1)
+    }
+
+    test("bad-command") {
+        intercept[IllegalArgumentException] {
+            val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("&foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        }
+    }
+
+    test("empty-comment") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("#", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+    }
+
+    test("empty-command") {
+        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("+", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+        assertEquals(incE.size, 0)
+        assertEquals(incR.size, 0)
+        assertEquals(excE.size, 0)
+        assertEquals(excR.size, 0)
+    }
+}


### PR DESCRIPTION
This adds two classes:
`RegexPredicate` is a combination of an exact matcher via set and a regex matcher.

`IncludeExclude` is a container with an RegexPredicate for inclusion and one for exclusion.

Exclusion is done first.
Anything that is marked as excluded then gets tested for last-chance inclusion.

Added tests from here to eternity.