### PR TITLE
added artifact filtering by MIME type.

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -24,6 +24,8 @@ import java.util.regex.Pattern
 import scala.annotation.static
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
+import io.spicelabs.goatrodeo.util.IncludeExclude
+import io.spicelabs.goatrodeo.util.Config.VectorOfStrings
 
 class GoatRodeoBuilder {
   private val log = Logger(classOf[GoatRodeoBuilder])
@@ -100,6 +102,16 @@ class GoatRodeoBuilder {
     this
   }
 
+  def withMimeFilter(filter: String): GoatRodeoBuilder = {
+    config = config.copy(mimeFilter = config.mimeFilter :+ filter)
+    this
+  }
+
+  def withMimeFilterFile(f: String): GoatRodeoBuilder = {
+    config = config.copy(mimeFilter = config.mimeFilter ++ VectorOfStrings(f))
+    this
+  }
+
   def withExtraArgs(args: java.util.Map[String, String]): GoatRodeoBuilder = {
     withExtraArgs(args.asScala.toMap)
   }
@@ -123,6 +135,8 @@ class GoatRodeoBuilder {
       case "tempDir"        => withTempDir(value)
       case "tag-json"       => withTagJson(value)
       case "tag"            => withTag(value)
+      case "mimeFilter"     => withMimeFilter(value)
+      case "mimeFilterFile" => withMimeFilterFile(value)
       case unknown =>
         log.warn(s"Ignored unknown GoatRodeoBuilder arg: $unknown=$value")
         this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -307,7 +307,7 @@ object Builder {
 
               val byHash: Map[String, Vector[Augmentation]] =
                 if (args.useStaticMetadata) {
-                  toProcess.runStaticMetadataGather()
+                  toProcess.runStaticMetadataGather(args.mimeFilter)
                 } else {
                   Map()
                 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/IncludeExclude.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/IncludeExclude.scala
@@ -19,11 +19,29 @@ class IncludeExclude (include: RegexPredicate, exclude: RegexPredicate) {
     def this(incExact: Set[String], incRegex: Vector[Regex], excExact: Set[String], excRegex: Vector[Regex]) = {
         this(RegexPredicate(incExact, incRegex), RegexPredicate(excExact, excRegex))
     }
+
+    def this() = {
+        this(RegexPredicate(Set(), Vector()), RegexPredicate(Set(), Vector()))
+    }
     
     def shouldInclude(candidate: String) = {
         // if the candidate is not in the exclude, it should be included.
         // if the candidate *is* is the exclude, then check to see if it's included
         !exclude.matches(candidate) || include.matches(candidate)
+    }
+
+    def :+ (predicate: String): IncludeExclude = {
+        val (inE, inR, exE, exR) = IncludeExclude.aggregatePredicate(predicate,
+            (include.exact, include.regexes, exclude.exact, exclude.regexes))
+        IncludeExclude(RegexPredicate(inE, inR), RegexPredicate(exE, exR))
+    }
+
+    def ++ (predicates: Iterable[String]): IncludeExclude = {
+        var inex = this
+        for (predicate <- predicates) {
+            inex = inex :+ predicate
+        }
+        inex
     }
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
@@ -46,8 +46,8 @@ object StaticMetadata {
     * @return
     *   if it should not be processed by Syft
     */
-  def isBlocked(artifact: ArtifactWrapper): Boolean = {
-    false
+  def isBlocked(artifact: ArtifactWrapper, mimeFilter: IncludeExclude): Boolean = {
+    !mimeFilter.shouldInclude(artifact.mimeType)
   }
 
   lazy val hasSyft: Boolean = {
@@ -61,12 +61,13 @@ object StaticMetadata {
   }
 
   def runStaticMetadataGather(
-      artfiact: ArtifactWrapper,
-      tempDir: Path
+      artifact: ArtifactWrapper,
+      tempDir: Path,
+      mimeFilter: IncludeExclude
   ): Option[StaticMetadataResult] = {
-    if (hasSyft && !isBlocked(artfiact)) {
+    if (hasSyft && !isBlocked(artifact, mimeFilter)) {
       Try {
-        val targetFile = artfiact.forceFile(tempDir)
+        val targetFile = artifact.forceFile(tempDir)
         val pb = ProcessBuilder(
           List(
             "syft",

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -16,6 +16,7 @@ import io.spicelabs.goatrodeo.util.StaticMetadata
 import org.json4s.*
 
 import java.io.File
+import io.spicelabs.goatrodeo.util.IncludeExclude
 class MetadataSuite extends munit.FunSuite {
   test("Metadata collections works") {
     if (StaticMetadata.hasSyft) {
@@ -23,7 +24,7 @@ class MetadataSuite extends munit.FunSuite {
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
       val runner =
-        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath())
+        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath(), IncludeExclude())
       val (str, json) = runner.get.runForMillis(100000).get
 
       assert(str.length() > 400, s"Metadata answer too small ${str}")
@@ -38,7 +39,7 @@ class MetadataSuite extends munit.FunSuite {
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
       val runner =
-        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath())
+        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath(), IncludeExclude())
       val (str, json) = runner.get.runForMillis(100000).get
 
       // val artifacts =


### PR DESCRIPTION
This addresses issue [#169](https://github.com/spice-labs-inc/goatrodeo/issues/169).

If you want to filter out text files but allow dsrc, you need these rules:
```
/text\/.*
+text/x-dsrc
```

@dpp - do you want me to add those in as defaults?