### PR TITLE
moved .NET assembly detection into a Detector

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/util/DotnetDetector.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/DotnetDetector.scala
@@ -1,0 +1,68 @@
+/* Copyright 2024 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import org.apache.tika.detect.Detector
+import java.io.FileInputStream
+import java.io.File
+import java.io.InputStream
+import org.apache.tika.metadata.Metadata
+import org.apache.tika.mime.MediaType
+import org.apache.tika.metadata.TikaCoreProperties
+import io.spicelabs.cilantro.AssemblyDefinition
+import java.io.IOException
+
+class DotnetDetector extends  Detector {
+    override def detect(input: InputStream, metadata: Metadata): MediaType = {
+        var fs:FileInputStream = null
+        try {
+            fs = FileInputStreamEx.toFileInputStream(input, metadata)
+            val assembly = AssemblyDefinition.readAssembly(fs)
+            assembly != null && assembly.mainModule != null
+            return DotnetDetector.DOTNET_MIME
+        } catch {
+            case _ => return MediaType.OCTET_STREAM
+        } finally {
+            if (fs.isInstanceOf[FileInputStreamEx])
+                fs.close()
+        }
+    }
+}
+
+object DotnetDetector {
+    lazy val DOTNET_MIME = {
+        MediaType.parse("application/x-msdownload; format=pe32-dotnet")
+    }
+}
+
+class FileInputStreamEx(private val f: File) extends FileInputStream(f) {
+    def this(path: String) = {
+        this(File(path))
+    }
+}
+
+object FileInputStreamEx {
+    def toFileInputStream(is: InputStream, metadata: Metadata): FileInputStream = {
+        if (is.isInstanceOf[FileInputStream])
+            return is.asInstanceOf[FileInputStream]
+        val path = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY)
+        if (path == null)
+            throw new IllegalArgumentException("metadata data needs the RESOURCE_NAME_KEY set to the path name")
+        val f = File(path)
+        if (!f.exists())
+            throw new IllegalArgumentException(s"RESOURCE_NAME_KEY is set to ${path} but that path doesn't exist")
+        FileInputStreamEx(metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY))
+    }
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/util/TikaDetectorFactory.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/TikaDetectorFactory.scala
@@ -1,0 +1,113 @@
+/* Copyright 2024 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import org.apache.tika.config.TikaConfig
+import org.apache.tika.detect.Detector
+import java.{util => ju}
+import scala.collection.mutable.ArrayBuffer
+import ju.ArrayList
+import scala.jdk.CollectionConverters._
+import org.apache.tika.detect.CompositeDetector
+
+
+// notes:
+// if you want to hook into tika's detection process you either need to statically create
+// an xml configuration file and reference a jar with your detector(s) in it, or you
+// can grab the detectors from TikaConfig and embed it and your detectors into a single
+// CompositeDetector. This advice to do this came from here: https://user.tika.apache.narkive.com/iqudHf8O/add-custom-mime-type-programmatically
+// which was 11 years old when I found it, so clearly not a lot is going on to improve things.
+//
+// The CompositeDetector is constructed from a java.util.List of Detector objects.
+// The detection process works like this:
+// The output MediaType is assumed to be an octet stream
+// Each detector gets an oppotunity to run on the input stream and either returns a MediaType of the detected
+// stream, or it returns MediaType.OCTET_STREAM.
+// If the returned media type is a specialization of the current output MediatType, it will replace the
+// current. Therefore, when crafting our own set of detectors the order may very well matter.
+// Further, there may be an OverrideDetector in the mix that uses the metadata parameter to detect
+// to set how the output should be set.
+
+// TikaDetectorFactory is a simple class to aggregate a set of detectors that are broken into 3 categories:
+// firstResponders - a list of detectors to run before the Tika detector
+// tikaDetector - a detector grabbed from the TikaConfig object
+// finalResponders - a list of detectors to run after the Tika detector
+
+// Where to put a detector is going to depend upon how you're detecting. If for example, you are specifically doing a
+// specialization of something that was detected previously, it would make sense to put it in the finalResponders.
+// If you are doing a stand-alone detection with high confidence of true positive and true negative, it should go in
+// the firstResponders.
+
+// It wasn't clear to me in designing this how it will be configured and used, so I made it thread-safe and written
+// such that the toDetector method is cached and any subsequent invocations of toDetector() won't interfere with previous
+// invocations.
+
+
+class TikaDetectorFactory(tika: TikaConfig, detectors: Detector*) {
+    private val firstResponders = TikaDetectorFactory.toArrayBuffer(detectors)
+    private val tikaDetector = tika.getDetector()
+    private val finalResponders = ArrayBuffer[Detector]()
+    private var dirty = true
+    private var detector: Detector = null
+
+    def addFirst(detectors: Detector*) =
+        this.synchronized {
+            firstResponders.addAll(detectors)
+            dirty = true
+        }
+    def clearFirst() =
+        this.synchronized {
+            firstResponders.clear()
+            dirty = true
+        }
+    
+    def addFinal(detectors: Detector*) =
+        this.synchronized {
+            finalResponders.addAll(detectors)
+            dirty = true;
+        }
+    def clearFinal() =
+        this.synchronized {
+            finalResponders.clear()
+            dirty = true
+        }
+    
+    def clearAll() = 
+        this.synchronized {
+            clearFirst()
+            clearFinal()
+            dirty = true
+        }
+
+    def toDetector(): Detector =
+        this.synchronized {
+            if (dirty) {
+                val detectors: ju.List[Detector] = ArrayList[Detector]()
+                detectors.addAll(firstResponders.asJava)
+                detectors.add(tikaDetector)
+                detectors.addAll(finalResponders.asJava)
+                detector = CompositeDetector(detectors)
+                dirty = false
+            }
+            detector
+        }
+}
+
+object TikaDetectorFactory {
+    def toArrayBuffer(detectors: Seq[Detector]) = {
+        val ab = ArrayBuffer[Detector]()
+        ab.addAll(detectors)
+    }
+}


### PR DESCRIPTION
OK - this is a little weird, but bear with me.

I added the ability to run the Tika detectors in tandem with our own. TikaDetectorFactory documents it and the process.

This works and makes ArtifactWrapper cleaner as a result. We like.

Things we don't like:
- It looks like you need to do a `mark` and `reset` pair around the code that does detection (this is not documented in Tika)
- There is no specific detection response meaning "NOT MINE" instead you return OCTET_STREAM which works because it's the parent of every other mime type.
- There is no way to find out what other detectors (if any have done). This is inefficient - if I write something that detects a binary stream and a previous detector called it "text/whatever", I shouldn't do *any* work
- I wrote a JsonDetector which causes test failures that I was unable to diagnose, but likely has to do with several of the preceding issues.
- We need a stream with seeking for cilantro, which means we need to open the file, which means we need the file name, so we jam that into the metadata (which is probably wrong).

With regards to the JsonDetector, I wrote this as the detector:
```scala
class JsonDetector extends Detector {
    override def detect(input: InputStream, metadata: Metadata): MediaType = {
        try {
            val tikaInputStream = TikaInputStream.get(input)
            val position = tikaInputStream.getPosition()
            if (position > 0)
                tikaInputStream.skip(-position)
            val bytes = new String(Helpers.slurpInputNoClose(tikaInputStream), "UTF-8")
            val p = parseOpt(bytes)
            val sameStm = input == tikaInputStream
            tikaInputStream.close()
            p match {
                case Some(json) => MediaType.parse("application/json")
                case _ => MediaType.OCTET_STREAM
            }
        } catch {
            case _ => MediaType.OCTET_STREAM
        }
    }
}
```
Here is a test that I put in that passes identifying json:
```scala
class JsonDetectionTesting extends munit.FunSuite {
  test("get-me-a-mime") {
    val path = "test_data/sample.json"
    val metadata = new Metadata()
    metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, path)
    val input = TikaInputStream.get(File(path), metadata)
    val mime = ArtifactWrapper.mimeTypeFor(input, path)
    assertEquals("application/json", mime)
  }
}
```
I tried mark/reset, but that was causing an exception. I tried the above code that uses a tikaInputStream to wrap the input stream, but that causes problems in later tests and I was unable to diagnose the cause, but I'm spending too much time on this right now, so I opened an issue to revisit it in the future.
