### PR TITLE
Hardcoded the Syft file filters based on the globs and mime types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,6 @@ GoatRodeo.builder()
 | `--mime-filter-file <value>` | The value is a path to a text file containing mime filters. |
 |                            | Each line contains one mime filter and starts with a command. |
 |                            | Empty lines are ignored. |
-| `--syft-filter`            | Allows artifacts targeted for syft to be filtered by file name. |
-|                            | Uses the same syntax as `--mime-filter`                         |
-| `--syft-filter-file <value>` | The value is a path to a text file containing filters for |
-|                            | artifacts targeted for syft |
 | `-?`, `--help`             | Print help and exit. |
 
 ---

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -18,14 +18,14 @@ import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.util.Config.VectorOfStrings
+import io.spicelabs.goatrodeo.util.IncludeExclude
 
 import java.nio.file.Paths
 import java.util.regex.Pattern
 import scala.annotation.static
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
-import io.spicelabs.goatrodeo.util.IncludeExclude
-import io.spicelabs.goatrodeo.util.Config.VectorOfStrings
 
 class GoatRodeoBuilder {
   private val log = Logger(classOf[GoatRodeoBuilder])

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -9,6 +9,7 @@ import io.spicelabs.goatrodeo.util.FileWalker
 import io.spicelabs.goatrodeo.util.FileWrapper
 import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.StaticMetadata
 
 import java.io.File
@@ -17,7 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
-import io.spicelabs.goatrodeo.util.IncludeExclude
 
 /** When processing Artifacts, knowing the Artifact type for a sequence of
   * artifacts can be helpful. For example (Java POM File, Java Sources,
@@ -254,12 +254,16 @@ trait ToProcess {
     */
   def getElementsToProcess(): (Seq[(ArtifactWrapper, MarkerType)], StateType)
 
-  def runStaticMetadataGather(mimeFilter: IncludeExclude): Map[String, Vector[Augmentation]] = {
+  def runStaticMetadataGather(
+      mimeFilter: IncludeExclude
+  ): Map[String, Vector[Augmentation]] = {
     FileWalker.withinTempDir { tempDir =>
       {
         val augmentation: Seq[Map[String, Vector[Augmentation]]] = for {
           (wrapper, _) <- getElementsToProcess()._1
-          it <- StaticMetadata.runStaticMetadataGather(wrapper, tempDir, mimeFilter).toList
+          it <- StaticMetadata
+            .runStaticMetadataGather(wrapper, tempDir, mimeFilter)
+            .toList
           answer <- it.runForMillis(120L * 1000 * 60) // 120 minutes
 
         } yield it.buildAugmentation()

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -12,11 +12,10 @@ import java.io.File
 import java.io.FileFilter
 import java.nio.file.Files
 import java.util.regex.Pattern
+import scala.io.BufferedSource
+import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
-import os.ReadablePath
-import scala.io.Source
-import scala.io.BufferedSource
 
 /** Command Line Configuration
   *
@@ -163,17 +162,15 @@ object Config {
         )
         .action((t, c) => c.copy(threads = t)),
       opt[String]("mime-filter")
-        .text("add an include or exclude MIME type filter:\n +mime include mime\n -mime exclude mime\n *regex include mime that matches regex\n /regex exclude mime that matches regex")
+        .text(
+          "add an include or exclude MIME type filter:\n +mime include mime\n -mime exclude mime\n *regex include mime that matches regex\n /regex exclude mime that matches regex"
+        )
         .action((x, c) => c.copy(mimeFilter = c.mimeFilter :+ x)),
       opt[File]("mime-filter-file")
         .text("a file of lines, each of which will be treated as a MIME filter")
-        .action((f, c) => c.copy(mimeFilter = c.mimeFilter ++ VectorOfStrings(f))),
-      opt[String]("syft-filter")
-        .text("add a regular expression to include or exclude a syft file filter:\n  +file include file\n -file exclude file\n *regex include file that matches regex\n /regex exclude mime that matches regex")
-        .action((x, c) => c.copy(filenameFilter = c.filenameFilter :+ x)),
-      opt[File]("syft-filter-file")
-        .text("a file of lines, each of which will be treated as a syft file filter")
-        .action((f, c) => c.copy(filenameFilter = c.filenameFilter ++ VectorOfStrings(f))),
+        .action((f, c) =>
+          c.copy(mimeFilter = c.mimeFilter ++ VectorOfStrings(f))
+        ),
       opt[Unit]('V', "version")
         .text("print version and exit")
         .action((_, c) => {
@@ -196,7 +193,9 @@ object Config {
       var source: BufferedSource = null
       try {
         source = Source.fromFile(in.getAbsoluteFile())
-        source.getLines().toVector // getLines() does not include new lines (yay!)
+        source
+          .getLines()
+          .toVector // getLines() does not include new lines (yay!)
       } finally {
         source.close()
       }
@@ -206,7 +205,6 @@ object Config {
       apply(f)
     }
   }
-
 
   object ExpandFiles {
     def apply(in: File): Vector[File] = {

--- a/src/main/scala/io/spicelabs/goatrodeo/util/DotnetDetector.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/DotnetDetector.scala
@@ -14,55 +14,62 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.util
 
-import org.apache.tika.detect.Detector
-import java.io.FileInputStream
-import java.io.File
-import java.io.InputStream
-import org.apache.tika.metadata.Metadata
-import org.apache.tika.mime.MediaType
-import org.apache.tika.metadata.TikaCoreProperties
 import io.spicelabs.cilantro.AssemblyDefinition
-import java.io.IOException
+import org.apache.tika.detect.Detector
+import org.apache.tika.metadata.Metadata
+import org.apache.tika.metadata.TikaCoreProperties
+import org.apache.tika.mime.MediaType
 
-class DotnetDetector extends  Detector {
-    override def detect(input: InputStream, metadata: Metadata): MediaType = {
-        var fs:FileInputStream = null
-        try {
-            fs = FileInputStreamEx.toFileInputStream(input, metadata)
-            val assembly = AssemblyDefinition.readAssembly(fs)
-            assembly != null && assembly.mainModule != null
-            return DotnetDetector.DOTNET_MIME
-        } catch {
-            case _ => return MediaType.OCTET_STREAM
-        } finally {
-            if (fs.isInstanceOf[FileInputStreamEx])
-                fs.close()
-        }
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+
+class DotnetDetector extends Detector {
+  override def detect(input: InputStream, metadata: Metadata): MediaType = {
+    var fs: FileInputStream = null
+    try {
+      fs = FileInputStreamEx.toFileInputStream(input, metadata)
+      val assembly = AssemblyDefinition.readAssembly(fs)
+      assembly != null && assembly.mainModule != null
+      return DotnetDetector.DOTNET_MIME
+    } catch {
+      case _ => return MediaType.OCTET_STREAM
+    } finally {
+      if (fs.isInstanceOf[FileInputStreamEx])
+        fs.close()
     }
+  }
 }
 
 object DotnetDetector {
-    lazy val DOTNET_MIME = {
-        MediaType.parse("application/x-msdownload; format=pe32-dotnet")
-    }
+  lazy val DOTNET_MIME = {
+    MediaType.parse("application/x-msdownload; format=pe32-dotnet")
+  }
 }
 
 class FileInputStreamEx(private val f: File) extends FileInputStream(f) {
-    def this(path: String) = {
-        this(File(path))
-    }
+  def this(path: String) = {
+    this(File(path))
+  }
 }
 
 object FileInputStreamEx {
-    def toFileInputStream(is: InputStream, metadata: Metadata): FileInputStream = {
-        if (is.isInstanceOf[FileInputStream])
-            return is.asInstanceOf[FileInputStream]
-        val path = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY)
-        if (path == null)
-            throw new IllegalArgumentException("metadata data needs the RESOURCE_NAME_KEY set to the path name")
-        val f = File(path)
-        if (!f.exists())
-            throw new IllegalArgumentException(s"RESOURCE_NAME_KEY is set to ${path} but that path doesn't exist")
-        FileInputStreamEx(metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY))
-    }
+  def toFileInputStream(
+      is: InputStream,
+      metadata: Metadata
+  ): FileInputStream = {
+    if (is.isInstanceOf[FileInputStream])
+      return is.asInstanceOf[FileInputStream]
+    val path = metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY)
+    if (path == null)
+      throw new IllegalArgumentException(
+        "metadata data needs the RESOURCE_NAME_KEY set to the path name"
+      )
+    val f = File(path)
+    if (!f.exists())
+      throw new IllegalArgumentException(
+        s"RESOURCE_NAME_KEY is set to ${path} but that path doesn't exist"
+      )
+    FileInputStreamEx(metadata.get(TikaCoreProperties.RESOURCE_NAME_KEY))
+  }
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/RegexPredicate.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/RegexPredicate.scala
@@ -15,8 +15,7 @@ package io.spicelabs.goatrodeo.util
 
 import scala.util.matching.Regex
 
-final case class RegexPredicate(exact: Set[String], regexes: Vector[Regex])
-{
-    def matches(str: String) =
-        exact.contains(str) || regexes.exists((regex) => regex.matches(str))
+final case class RegexPredicate(exact: Set[String], regexes: Vector[Regex]) {
+  def matches(str: String) =
+    exact.contains(str) || regexes.exists((regex) => regex.matches(str))
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
@@ -10,7 +10,7 @@ import org.json4s.*
 import org.json4s.native.JsonMethods.*
 
 import java.io.ByteArrayOutputStream
-import java.nio.file.Path
+import java.nio.file.*
 import scala.util.Try
 
 /** The bridge to Syft https://github.com/anchore/syft
@@ -18,6 +18,54 @@ import scala.util.Try
 object StaticMetadata {
   private val logger = Logger(getClass())
   private lazy val staticMetadataMimeTypes = Set(
+    "application/x-archive",
+    "application/x-cpio",
+    "application/x-shar",
+    "application/x-iso9660-image",
+    "application/x-sbx",
+    "application/x-tar",
+    // compression only
+    "application/x-bzip2",
+    "application/gzip",
+    "application/x-lzip",
+    "application/x-lzma",
+    "application/x-lzop",
+    "application/x-snappy-framed",
+    "application/x-xz",
+    "application/x-compress",
+    "application/zstd",
+    // archiving and compression
+    "application/x-7z-compressed",
+    "application/x-ace-compressed",
+    "application/x-astrotite-afa",
+    "application/x-alz-compressed",
+    "application/vnd.android.package-archive",
+    "application/x-freearc",
+    "application/x-arj",
+    "application/x-b1",
+    "application/vnd.ms-cab-compressed",
+    "application/x-cfs-compressed",
+    "application/x-dar",
+    "application/x-dgc-compressed",
+    "application/x-apple-diskimage",
+    "application/x-gca-compressed",
+    "application/java-archive",
+    "application/x-lzh",
+    "application/x-lzx",
+    "application/x-rar-compressed",
+    "application/x-stuffit",
+    "application/x-stuffitx",
+    "application/x-gtar",
+    "application/x-ms-wim",
+    "application/x-xar",
+    "application/zip",
+    "application/x-zoo",
+    "application/x-executable",
+    "application/x-mach-binary",
+    "application/x-elf",
+    "application/x-sharedlib",
+    "application/vnd.microsoft.portable-executable",
+    "application/x-executable",
     "application/zip",
     "application/java-archive",
     "application/vnd.android.package-archive",
@@ -29,6 +77,137 @@ object StaticMetadata {
     "application/gzip",
     "application/zstd"
   )
+
+  private lazy val globSet = Set(
+    "**/*.app",
+    "**/*.bom",
+    "**/*.bom.*",
+    "**/bom",
+    "**/cabal.project.freeze",
+    "**/Cargo.lock",
+    "**/*.cdx",
+    "**/*.cdx.*",
+    "**/Cellar/*/*/.brew/*.rb",
+    "**/composer.lock",
+    "**/conanfile.txt",
+    "**/conaninfo.txt",
+    "**/conan.lock",
+    "**/conda-meta/*.json",
+    "**/*.deb",
+    "**/DESCRIPTION",
+    "**/*dist-info/METADATA",
+    "**/*DIST-INFO/METADATA",
+    "**/*.dll",
+    "**/doc/linux-modules-*/changelog.Debian.gz",
+    "**/*.ear",
+    "**/*.egg-info",
+    "**/*egg-info/PKG-INFO",
+    "**/*EGG-INFO/PKG-INFO",
+    "**/*.exe",
+    "**/Gemfile.lock",
+    "**/*.gemspec",
+    "**/.github/actions/*/action.yaml",
+    "**/.github/actions/*/action.yml",
+    "**/.github/workflows/*.yaml",
+    "**/.github/workflows/*.yml",
+    "**/go.mod",
+    "**/gradle.lockfile*",
+    "**/*.hpi",
+    "**/installed.json",
+    "**/*.jar",
+    "**/*.jpi",
+    "**/*.kar",
+    "**/kernel",
+    "**/kernel-*",
+    "**/lib/apk/db/installed",
+    "**/lib/dpkg/status",
+    "**/lib/dpkg/status.d/*",
+    "**/lib/modules/**/*.ko",
+    "**/lib/opkg/info/*.control",
+    "**/lib/opkg/status",
+    "**/Library/Taps/*/*/Formula/*.rb",
+    "**/*.lpkg",
+    "**/meta/snap.yaml",
+    "**/mix.lock",
+    "**/*.nar",
+    "**/*opam",
+    "/opt/bitnami/**/.spdx-*.spdx",
+    "**/package.json",
+    "**/package-lock.json",
+    "**/.package.resolved",
+    "**/Package.resolved",
+    "**/packages.lock.json",
+    "**/pack.pl",
+    "**/*.par",
+    "**/php/.registry/.channel.*/*.reg",
+    "**/php/.registry/**/*.reg",
+    "**/Pipfile.lock",
+    "**/pnpm-lock.yaml",
+    "**/Podfile.lock",
+    "**/poetry.lock",
+    "**/pubspec.lock",
+    "**/pubspec.yaml",
+    "**/pubspec.yml",
+    "**/rebar.lock",
+    "**/release",
+    "**/*requirements*.txt",
+    "**/*.rockspec",
+    "**/*.sar",
+    "**/*.sbom",
+    "**/*.sbom.*",
+    "**/sbom",
+    "**/setup.py",
+    "**/snap/manifest.yaml",
+    "**/snap/snapcraft.yaml",
+    "**/*.spdx",
+    "**/*.spdx.*",
+    "**/specifications/**/*.gemspec",
+    "**/stack.yaml",
+    "**/stack.yaml.lock",
+    "**/*.syft.json",
+    "**/*.tar",
+    "**/*.tar.br",
+    "**/*.tar.bz",
+    "**/*.tar.bz2",
+    "**/*.tar.gz",
+    "**/*.tar.lz4",
+    "**/*.tar.sz",
+    "**/*.tar.xz",
+    "**/*.tar.zst",
+    "**/*.tar.zstd",
+    "**/*.tbr",
+    "**/*.tbz",
+    "**/*.tbz2",
+    "**/.terraform.lock.hcl",
+    "**/*.tgz",
+    "**/*.tlz4",
+    "**/*.tsz",
+    "**/*.txz",
+    "**/*.tzst",
+    "**/*.tzstd",
+    "**/usr/share/snappy/dpkg.yaml",
+    "**/uv.lock",
+    "**/var/db/pkg/*/*/CONTENTS",
+    "**/var/lib/pacman/local/**/desc",
+    "**/var/lib/rpmmanifest/container-manifest-2",
+    "**/{var/lib,usr/share,usr/lib/sysimage}/rpm/{Packages,Packages.db,rpmdb.sqlite}",
+    "**/vmlinux",
+    "**/vmlinux-*",
+    "**/vmlinuz",
+    "**/vmlinuz-*",
+    "**/*.war",
+    "**/wp-content/plugins/*/*.php",
+    "**/yarn.lock",
+    "**/*.zip"
+  )
+
+  private lazy val pathMatchers = {
+    val fs = FileSystems.getDefault()
+    for {
+      glob <- globSet.toVector
+      pm <- Try { fs.getPathMatcher(f"glob:${glob}") }.toOption.toVector
+    } yield pm
+  }
 
   /** Is the artifact a container that this module how to process?
     *
@@ -46,8 +225,23 @@ object StaticMetadata {
     * @return
     *   if it should not be processed by Syft
     */
-  def isBlocked(artifact: ArtifactWrapper, mimeFilter: IncludeExclude): Boolean = {
+  def isBlocked(
+      artifact: ArtifactWrapper,
+      mimeFilter: IncludeExclude
+  ): Boolean = {
     !mimeFilter.shouldInclude(artifact.mimeType)
+  }
+
+  def isAllowed(artifact: ArtifactWrapper): Boolean = {
+    staticMetadataMimeTypes.contains(artifact.mimeType) || {
+      artifact match {
+        case fw: FileWrapper => {
+          val path = fw.wrappedFile.toPath
+          pathMatchers.find(pm => pm.matches(path)).isDefined
+        }
+        case _ => false
+      }
+    }
   }
 
   lazy val hasSyft: Boolean = {
@@ -65,26 +259,31 @@ object StaticMetadata {
       tempDir: Path,
       mimeFilter: IncludeExclude
   ): Option[StaticMetadataResult] = {
-    if (hasSyft && !isBlocked(artifact, mimeFilter)) {
-      Try {
-        val targetFile = artifact.forceFile(tempDir)
-        val pb = ProcessBuilder(
-          List(
-            "syft",
-            "scan",
-            f"file:${targetFile.getName()}",
-            "--enrich",
-            "all",
-            "--scope",
-            "all-layers",
-            "--output",
-            "syft-json"
-          )*
-        ).directory(targetFile.getCanonicalFile().getParentFile())
-        val ret = StaticMetadataResult(pb, targetFile.getCanonicalPath())
-        ret.go()
-        ret
-      }.toOption
+    if (hasSyft && isAllowed(artifact) && !isBlocked(artifact, mimeFilter)) {
+      artifact match {
+        case fw: FileWrapper =>
+          Try {
+            val thePath = fw.wrappedFile.getCanonicalPath()
+            // println(s"Syfting ${thePath}")
+            val pb = ProcessBuilder(
+              List(
+                "syft",
+                "scan",
+                f"file:${thePath}",
+                "--enrich",
+                "all",
+                "--scope",
+                "all-layers",
+                "--output",
+                "syft-json"
+              )*
+            )
+            val ret = StaticMetadataResult(pb, thePath)
+            ret.go()
+            ret
+          }.toOption
+        case _ => None
+      }
     } else None
 
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/TikaDetectorFactory.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/TikaDetectorFactory.scala
@@ -15,13 +15,14 @@ limitations under the License. */
 package io.spicelabs.goatrodeo.util
 
 import org.apache.tika.config.TikaConfig
-import org.apache.tika.detect.Detector
-import java.{util => ju}
-import scala.collection.mutable.ArrayBuffer
-import ju.ArrayList
-import scala.jdk.CollectionConverters._
 import org.apache.tika.detect.CompositeDetector
+import org.apache.tika.detect.Detector
 
+import java.util as ju
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters.*
+
+import ju.ArrayList
 
 // notes:
 // if you want to hook into tika's detection process you either need to statically create
@@ -54,60 +55,59 @@ import org.apache.tika.detect.CompositeDetector
 // such that the toDetector method is cached and any subsequent invocations of toDetector() won't interfere with previous
 // invocations.
 
-
 class TikaDetectorFactory(tika: TikaConfig, detectors: Detector*) {
-    private val firstResponders = TikaDetectorFactory.toArrayBuffer(detectors)
-    private val tikaDetector = tika.getDetector()
-    private val finalResponders = ArrayBuffer[Detector]()
-    private var dirty = true
-    private var detector: Detector = null
+  private val firstResponders = TikaDetectorFactory.toArrayBuffer(detectors)
+  private val tikaDetector = tika.getDetector()
+  private val finalResponders = ArrayBuffer[Detector]()
+  private var dirty = true
+  private var detector: Detector = null
 
-    def addFirst(detectors: Detector*) =
-        this.synchronized {
-            firstResponders.addAll(detectors)
-            dirty = true
-        }
-    def clearFirst() =
-        this.synchronized {
-            firstResponders.clear()
-            dirty = true
-        }
-    
-    def addFinal(detectors: Detector*) =
-        this.synchronized {
-            finalResponders.addAll(detectors)
-            dirty = true;
-        }
-    def clearFinal() =
-        this.synchronized {
-            finalResponders.clear()
-            dirty = true
-        }
-    
-    def clearAll() = 
-        this.synchronized {
-            clearFirst()
-            clearFinal()
-            dirty = true
-        }
+  def addFirst(detectors: Detector*) =
+    this.synchronized {
+      firstResponders.addAll(detectors)
+      dirty = true
+    }
+  def clearFirst() =
+    this.synchronized {
+      firstResponders.clear()
+      dirty = true
+    }
 
-    def toDetector(): Detector =
-        this.synchronized {
-            if (dirty) {
-                val detectors: ju.List[Detector] = ArrayList[Detector]()
-                detectors.addAll(firstResponders.asJava)
-                detectors.add(tikaDetector)
-                detectors.addAll(finalResponders.asJava)
-                detector = CompositeDetector(detectors)
-                dirty = false
-            }
-            detector
-        }
+  def addFinal(detectors: Detector*) =
+    this.synchronized {
+      finalResponders.addAll(detectors)
+      dirty = true;
+    }
+  def clearFinal() =
+    this.synchronized {
+      finalResponders.clear()
+      dirty = true
+    }
+
+  def clearAll() =
+    this.synchronized {
+      clearFirst()
+      clearFinal()
+      dirty = true
+    }
+
+  def toDetector(): Detector =
+    this.synchronized {
+      if (dirty) {
+        val detectors: ju.List[Detector] = ArrayList[Detector]()
+        detectors.addAll(firstResponders.asJava)
+        detectors.add(tikaDetector)
+        detectors.addAll(finalResponders.asJava)
+        detector = CompositeDetector(detectors)
+        dirty = false
+      }
+      detector
+    }
 }
 
 object TikaDetectorFactory {
-    def toArrayBuffer(detectors: Seq[Detector]) = {
-        val ab = ArrayBuffer[Detector]()
-        ab.addAll(detectors)
-    }
+  def toArrayBuffer(detectors: Seq[Detector]) = {
+    val ab = ArrayBuffer[Detector]()
+    ab.addAll(detectors)
+  }
 }

--- a/src/test/scala/IncExcTesting.scala
+++ b/src/test/scala/IncExcTesting.scala
@@ -1,108 +1,152 @@
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.RegexPredicate
+
 import scala.util.matching.Regex
 
-
 class IncExcTesting extends munit.FunSuite {
-    test("none-accepted") {
-        val predicates = RegexPredicate(Set[String](), Vector[Regex]())
-        assert(!predicates.matches("anything"))
-    }
-    
-    test("exact-match") {
-        val key = "splunge"
-        val predicates = RegexPredicate(Set(key), Vector[Regex]())
-        assert(predicates.matches(key))
-    }
+  test("none-accepted") {
+    val predicates = RegexPredicate(Set[String](), Vector[Regex]())
+    assert(!predicates.matches("anything"))
+  }
 
-    test("regex-match") {
-        val key = "splunge"
-        val predicates = RegexPredicate(Set[String](), Vector("spl\\w*".r))
-        assert(predicates.matches(key))
-    }
+  test("exact-match") {
+    val key = "splunge"
+    val predicates = RegexPredicate(Set(key), Vector[Regex]())
+    assert(predicates.matches(key))
+  }
 
-    test("includes-all") {
-        val includer = IncludeExclude(Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
-        assert(includer.shouldInclude("all"))
-    }
+  test("regex-match") {
+    val key = "splunge"
+    val predicates = RegexPredicate(Set[String](), Vector("spl\\w*".r))
+    assert(predicates.matches(key))
+  }
 
-    test("excludes-all-text-MIME") {
-        val includer = IncludeExclude(Set[String](), Vector[Regex](), Set[String](), Vector("text\\/.*".r))
-        assert(!includer.shouldInclude("text/html"))
-        assert(!includer.shouldInclude("text/plain"))
-        assert(!includer.shouldInclude("text/json"))
-    }
+  test("includes-all") {
+    val includer = IncludeExclude(
+      Set[String](),
+      Vector[Regex](),
+      Set[String](),
+      Vector[Regex]()
+    )
+    assert(includer.shouldInclude("all"))
+  }
 
-    test("excludes-all-text-MIME-but-HTML") {
-        val includer = IncludeExclude(Set("text/html"), Vector[Regex](), Set[String](), Vector("text\\/.*".r))
-        assert(includer.shouldInclude("text/html"))
-        assert(!includer.shouldInclude("text/plain"))
-        assert(!includer.shouldInclude("text/json"))
-    }
+  test("excludes-all-text-MIME") {
+    val includer = IncludeExclude(
+      Set[String](),
+      Vector[Regex](),
+      Set[String](),
+      Vector("text\\/.*".r)
+    )
+    assert(!includer.shouldInclude("text/html"))
+    assert(!includer.shouldInclude("text/plain"))
+    assert(!includer.shouldInclude("text/json"))
+  }
 
-    test("excludes-all-text-MIME-but-hanything") {
-        val includer = IncludeExclude(Set("text/html"), Vector("text\\/h.*".r), Set[String](), Vector("text\\/.*".r))
-        assert(includer.shouldInclude("text/html"))
-        assert(includer.shouldInclude("text/howdy"))
-        assert(!includer.shouldInclude("text/plain"))
-        assert(!includer.shouldInclude("text/json"))
-    }
+  test("excludes-all-text-MIME-but-HTML") {
+    val includer = IncludeExclude(
+      Set("text/html"),
+      Vector[Regex](),
+      Set[String](),
+      Vector("text\\/.*".r)
+    )
+    assert(includer.shouldInclude("text/html"))
+    assert(!includer.shouldInclude("text/plain"))
+    assert(!includer.shouldInclude("text/json"))
+  }
 
-    test("comment") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("# this is a comment", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 0)
-        assertEquals(incR.size, 0)
-        assertEquals(excE.size, 0)
-        assertEquals(excR.size, 0)
-    }
+  test("excludes-all-text-MIME-but-hanything") {
+    val includer = IncludeExclude(
+      Set("text/html"),
+      Vector("text\\/h.*".r),
+      Set[String](),
+      Vector("text\\/.*".r)
+    )
+    assert(includer.shouldInclude("text/html"))
+    assert(includer.shouldInclude("text/howdy"))
+    assert(!includer.shouldInclude("text/plain"))
+    assert(!includer.shouldInclude("text/json"))
+  }
 
-    test("include-exact") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("+splunge", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 1)
-        assertEquals(incR.size, 0)
-        assertEquals(excE.size, 0)
-        assertEquals(excR.size, 0)
-    }
+  test("comment") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "# this is a comment",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 0)
+    assertEquals(incR.size, 0)
+    assertEquals(excE.size, 0)
+    assertEquals(excR.size, 0)
+  }
 
-    test("include-regx") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("*foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 0)
-        assertEquals(incR.size, 1)
-        assertEquals(excE.size, 0)
-        assertEquals(excR.size, 0)
-    }
+  test("include-exact") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "+splunge",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 1)
+    assertEquals(incR.size, 0)
+    assertEquals(excE.size, 0)
+    assertEquals(excR.size, 0)
+  }
 
-    test("exclude-exact") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("-foo", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 0)
-        assertEquals(incR.size, 0)
-        assertEquals(excE.size, 1)
-        assertEquals(excR.size, 0)
-    }
+  test("include-regx") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "*foo.*",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 0)
+    assertEquals(incR.size, 1)
+    assertEquals(excE.size, 0)
+    assertEquals(excR.size, 0)
+  }
 
-    test("exclude-regex") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("/foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 0)
-        assertEquals(incR.size, 0)
-        assertEquals(excE.size, 0)
-        assertEquals(excR.size, 1)
-    }
+  test("exclude-exact") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "-foo",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 0)
+    assertEquals(incR.size, 0)
+    assertEquals(excE.size, 1)
+    assertEquals(excR.size, 0)
+  }
 
-    test("bad-command") {
-        intercept[IllegalArgumentException] {
-            val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("&foo.*", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        }
-    }
+  test("exclude-regex") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "/foo.*",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 0)
+    assertEquals(incR.size, 0)
+    assertEquals(excE.size, 0)
+    assertEquals(excR.size, 1)
+  }
 
-    test("empty-comment") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("#", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
+  test("bad-command") {
+    intercept[IllegalArgumentException] {
+      val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+        "&foo.*",
+        (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+      )
     }
+  }
 
-    test("empty-command") {
-        val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate("+", (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]()))
-        assertEquals(incE.size, 0)
-        assertEquals(incR.size, 0)
-        assertEquals(excE.size, 0)
-        assertEquals(excR.size, 0)
-    }
+  test("empty-comment") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "#",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+  }
+
+  test("empty-command") {
+    val (incE, incR, excE, excR) = IncludeExclude.aggregatePredicate(
+      "+",
+      (Set[String](), Vector[Regex](), Set[String](), Vector[Regex]())
+    )
+    assertEquals(incE.size, 0)
+    assertEquals(incR.size, 0)
+    assertEquals(excE.size, 0)
+    assertEquals(excR.size, 0)
+  }
 }

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -12,11 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.StaticMetadata
 import org.json4s.*
 
 import java.io.File
-import io.spicelabs.goatrodeo.util.IncludeExclude
 class MetadataSuite extends munit.FunSuite {
   test("Metadata collections works") {
     if (StaticMetadata.hasSyft) {
@@ -24,7 +24,11 @@ class MetadataSuite extends munit.FunSuite {
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
       val runner =
-        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath(), IncludeExclude())
+        StaticMetadata.runStaticMetadataGather(
+          fileWrapper,
+          file.toPath(),
+          IncludeExclude()
+        )
       val (str, json) = runner.get.runForMillis(100000).get
 
       assert(str.length() > 400, s"Metadata answer too small ${str}")
@@ -39,7 +43,11 @@ class MetadataSuite extends munit.FunSuite {
       val fileWrapper =
         FileWrapper(file, "slf4j-simple-1.6.1.jar", None, f => ())
       val runner =
-        StaticMetadata.runStaticMetadataGather(fileWrapper, file.toPath(), IncludeExclude())
+        StaticMetadata.runStaticMetadataGather(
+          fileWrapper,
+          file.toPath(),
+          IncludeExclude()
+        )
       val (str, json) = runner.get.runForMillis(100000).get
 
       // val artifacts =


### PR DESCRIPTION
### Summary

When Goat Rodeo is run on a lot of files on the filesystem (rather than on a TAR, Zip, iso, cpio, etc.) and the `--static-metadata true` option is selected, Syft (the OSS used to extract static metadata from artifacts) was invoked as a separate process on every file, rather than the files that Syft can derive metadata from.

The result was a > 10x slowdown for building ADGs from many, many files on the filesystem.

This change was based on getting all the globs and mime types that Syft uses (see #176) and using that as an allow list for files that Syft will be run against.

### Tests
Ran Goat Rodeo against 690,000 files on the filesystem. Goat Rodeo took 7 hours to complete the ADG build at an average of 3,500 files/minute. This is a 35x performance improvement over the 100 files/minute when Syft was run against every file.

### Ticket

https://github.com/spice-labs-inc/goatrodeo/issues/176
