### PR TITLE
Removed predicate in findFiles - it's never used.

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -529,7 +529,7 @@ object ToProcess {
       onFound: ToProcess => Unit = _ => ()
   ): Vector[ToProcess] = {
     val wrappers = Helpers
-      .findFiles(directory, _ => true)
+      .findFiles(directory)
       .map(f => FileWrapper(f, f.getName(), tempDir))
 
     strategiesForArtifacts(wrappers, onFound = onFound, infoMsgs_?)

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -50,7 +50,7 @@ case class Config(
     filenameFilter: IncludeExclude = IncludeExclude()
 ) {
   def getFileListBuilders(): Vector[() => Seq[File]] = {
-    build.map(file => () => Helpers.findFiles(file, f => true)) ++ fileList
+    build.map(file => () => Helpers.findFiles(file)) ++ fileList
       .map(f => {
         val fileNames =
           Files

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -246,8 +246,7 @@ object Helpers {
     *   the found files
     */
   def findFiles(
-      root: File,
-      ok: File => Boolean
+      root: File
   ): Vector[File] = {
     val count: AtomicLong = AtomicLong()
     import scala.jdk.CollectionConverters.IteratorHasAsScala
@@ -258,7 +257,7 @@ object Helpers {
         1000,
         (path, info) => {
           val f = path.toFile()
-          if (info.isRegularFile() && ok(f) && !f.getName().startsWith(".")) {
+          if (info.isRegularFile() && !f.getName().startsWith(".")) {
             val curCount = count.addAndGet(1)
             if (curCount % 100000 == 0) {
               logger.info(s"Find Files count ${curCount}")

--- a/src/test/scala/ADGTests.scala
+++ b/src/test/scala/ADGTests.scala
@@ -63,7 +63,7 @@ class ADGTests extends munit.FunSuite {
           .getOrElse(25),
         maxRecords = 50000,
         tag = Some(TagInfo("foo", None)),
-        fileListers = Vector(() => Helpers.findFiles(source, f => true)),
+        fileListers = Vector(() => Helpers.findFiles(source)),
         ignorePathSet = Set(),
         excludeFileRegex = Vector(),
         blockList = None,


### PR DESCRIPTION
I did some benchmarks on this and found a modest improvement in performance by removing the predicate. It's never used, so no harm no foul.

If we need this functionality in the future, it's best to either add a different flavor of `findFiles` which includes a predicate and use that only where it's needed.