### PR TITLE
make the augmenter more idiomatic and remove a set constructor that c…

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/util/FileWalker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/FileWalker.scala
@@ -425,7 +425,7 @@ object FileWalker {
   def notArchive(path: String, mimeType: Set[String]): Boolean = {
     mimeType.exists(_.startsWith("text/")) ||
     mimeType.exists(_.startsWith("image/")) ||
-    definitelyNotArchive.intersect(mimeType).size == mimeType.size /*||
+    mimeType.forall(definitelyNotArchive.contains(_)) /*||
     (mimeType.contains("application/zip") && path.endsWith(".xpi"))*/
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/SaffronDetector.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/SaffronDetector.scala
@@ -2,32 +2,31 @@ package io.spicelabs.goatrodeo.util
 
 import io.spicelabs.saffron.DiskFormat
 import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
 import scala.jdk.OptionConverters.RichOptional
 
 object SaffronDetector {
   // detect if an artifact wrapper is a mime type known to saffron
-  private def readFormat(artifact: ArtifactWrapper): Option[String] = {
+  private def readFormat(artifact: ArtifactWrapper): Set[String] = {
     artifact.withFile(file => {
-      Try {
-        DiskFormat.detect(file.toPath())
-      } match {
-        case Failure(exception) => None
-        case Success(value) => value.toScala.map(format => format.mimeType())
-      }
+      Try(DiskFormat.detect(file.toPath()))
+        .toOption
+        .flatMap(_.toScala)
+        .map(d => Set(d.mimeType()))
+        .getOrElse(Set.empty[String])
     })
   }
   def mimeTypeAugmenter(
       artifact: ArtifactWrapper,
       currentMimes: Set[String]
   ): Set[String] = {
-    readFormat(artifact) match {
-      // Tika misidentifies vhd files as text/vhdl
-      // if there are future problems with this filter being too loose, it can be tightened to
-      // .filter(!_.startsWith("text/" && value == "application/vhd"))
-      case Some(value) => currentMimes.filterNot(_.startsWith("text/")) + value
-      case None        => currentMimes
-    }
+    val myMimes = readFormat(artifact)
+    // why the conditional?
+    // an empty set indicates that this augmentinator should absolutely do nothing to the
+    // current mimes, otherwise we remove any that start with "text/"
+    // This is still fairly heavy-handed, but if it turns out to do too much, the filter could
+    // be narrowed to one that specifically filters out "text/x-vhdl" when myMimes contains
+    // application/vhd". This happens in ONE specific case when tika misidentifies a .vhd file as
+    // "text/x-vhdl"
+    if myMimes.isEmpty then currentMimes else currentMimes.filterNot(_.startsWith("text/")) ++ myMimes
   }
 }


### PR DESCRIPTION
This PR integrates some suggestions for the code to make it more idiomatic/performant.

I'm of two minds about the changes to the augmenter. The original one returns `Option[String]` and that serves a purpose to describe whether or not `detect` found something. Changing the return to `Set[String]` changes the predicate for whether or not `currentMimes` needs to be filtered. The original suggestion would remove "text/x-vhdl" under all circumstances and that's not OK - we only want to remove that when the detector has detected something otherwise we could end up with a case when an actual .vhd file comes in, detector detects nothing (empty set) and we filter out .vhd anyway.

The resulting code in `mimeTypeAugmenter` is more terse and doesn't have as much chaff. That's good. The code in
readFormat is more complicated because the Try now returns `Option[Option[DiskFormat]]`. It just seems like more work
needs to happen as there are about 6 method calls now when before there were fewer.
 Suggestions welcome.