### PR TITLE
Per-Package Tagging and Top-Level Tag Version/Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ test_data/iso_tests/*
 test_data/gem_tests/*
 test_data/download/*
 
+/housekeeping/
+

--- a/info/README.md
+++ b/info/README.md
@@ -23,6 +23,7 @@ This directory contains detailed documentation for Goat Rodeo. Use this index to
 
 ### [Goat Rodeo Operation](goat_rodeo_operation.md)
 Complete guide to how Goat Rodeo processes artifacts:
+- [Survey tags vs. sub-tags](goat_rodeo_operation.md#tags) — when to use `--tag` vs. `--package-tags`
 - CLI parameters and their effects
 - File discovery phase
 - Strategy determination (Maven, Docker, Debian, Generic)

--- a/info/goat_rodeo_operation.md
+++ b/info/goat_rodeo_operation.md
@@ -8,6 +8,32 @@ has certain operational characteristics.
 
 This document describes how Goat Rodeo works and how to tune parameters.
 
+## Tags
+
+Goat Rodeo supports two kinds of tags, which serve different purposes:
+
+### Survey Tags (top-level)
+
+Tags as they were initially conceived represented an **entire survey** — a single Goat Rodeo run. A survey tag provides an anchor, a connection point for the whole run.
+
+Survey tags are created with `--tag` and can optionally include `--tag-version` and `--tag-date`.
+
+### Sub-Tags (per-package)
+
+As we start working on surveying in bulk (downloading hundreds of artifacts from Docker Hub, etc.), we need a more granular meaning of "tag" — in this case the individual artifact that's being tagged rather than the whole survey. A **sub-tag** is a tag associated with a single artifact (a Docker image, a JAR file, etc.) so that for bulk operations, there might be many sub-tags.
+
+Sub-tags are created automatically with `--package-tags` when Goat Rodeo detects a package (Maven JAR, Docker image, Linux package, .NET assembly). Each sub-tag captures the package name, version, and build date from the artifact's own metadata.
+
+### Relationship
+
+| | Survey Tag | Sub-Tag |
+|---|---|---|
+| Scope | Entire run | Single package |
+| Source | CLI (`--tag`) | Artifact metadata (`--package-tags`) |
+| Index item | `tags` | `tags` (same root) |
+| Edge type | `tag:from` → `tags` | `tag:from` → `tags` |
+| JSON marker | — | `"package_tag": true` |
+
 ## CLI parameters:
 
      

--- a/info/goat_rodeo_operation.md
+++ b/info/goat_rodeo_operation.md
@@ -24,6 +24,9 @@ This document describes how Goat Rodeo works and how to tune parameters.
   use the RAM disk as the `tempdir`
 * `--tag` : create a `tags` Item and link to `{iso 8601 date}/{text after tag param}` Item and link each Item representing a found file
   to that Item. This allows for the identification of all the top level files in a Goat Rodeo run on a particular day.
+* `--tag-version <version>` : Set a version field in the top-level tag JSON (requires `--tag`). The version string is included as-is in the tag output.
+* `--tag-date <date>` : Set a date field in the top-level tag JSON (requires `--tag`). The date is parsed flexibly and always output in ISO 8601 format.
+  Supported formats include: `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SSZ`, `MM/DD/YYYY`, `DD/MM/YYYY`, `MMM D YYYY`, and relative terms like `today`, `yesterday`, `now`.
 * `--package-tags` : Create per-package tags for identified packages (Maven, Docker, Baharat, Annatto, Dotnet). Each package gets a tag Item
   with fields: `tag` (package name), `version` (package version), and `date` (build/publish date in ISO 8601 format). The `version` field
   is omitted if not available. Tag items are linked from a `packages` index Item and linked to the main package artifact.

--- a/info/goat_rodeo_operation.md
+++ b/info/goat_rodeo_operation.md
@@ -24,6 +24,11 @@ This document describes how Goat Rodeo works and how to tune parameters.
   use the RAM disk as the `tempdir`
 * `--tag` : create a `tags` Item and link to `{iso 8601 date}/{text after tag param}` Item and link each Item representing a found file
   to that Item. This allows for the identification of all the top level files in a Goat Rodeo run on a particular day.
+* `--package-tags` : Create per-package tags for identified packages (Maven, Docker, Baharat, Annatto, Dotnet). Each package gets a tag Item
+  with fields: `tag` (package name), `version` (package version), and `date` (build/publish date in ISO 8601 format). The `version` field
+  is omitted if not available. Tag items are linked from a `packages` index Item and linked to the main package artifact.
+* `--package-tags-short-name` : Use short package names (e.g., `artifactId` for Maven) instead of fully qualified names
+  (e.g., `groupId:artifactId`). Applies when `--package-tags` is enabled.
 * `--ingested` : Append all the ingested files to this file on successful completion
 * `--ignore` : A file containing paths to ignore, likely because they have been processed in the past. This can be used in conjunction
   with `--ingested` (they can point to the same file) to record the files that were processed by Goat Rodeo such that those files

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -230,7 +230,8 @@ class GoatRodeoBuilder {
     this
   }
 
-  /** Use short package names (e.g., artifactId) instead of full qualified names.
+  /** Use short package names (e.g., artifactId) instead of full qualified
+    * names.
     *
     * @return
     *   this builder
@@ -238,6 +239,37 @@ class GoatRodeoBuilder {
   def withPackageTagsShortName(): GoatRodeoBuilder = {
     config = config.copy(packageTagsShortName = true)
     this
+  }
+
+  /** Set the version for the top-level tag (requires tag to be set).
+    *
+    * @param v
+    *   the version string
+    * @return
+    *   this builder
+    */
+  def withTagVersion(v: String): GoatRodeoBuilder = {
+    config = config.copy(tagVersion = Some(v))
+    this
+  }
+
+  /** Set the date for the top-level tag (requires tag to be set).
+    *
+    * @param d
+    *   the date string (parsed flexibly, e.g., "2024-01-15", "today", "now")
+    * @return
+    *   this builder
+    * @throws IllegalArgumentException
+    *   if the date cannot be parsed
+    */
+  def withTagDate(d: String): GoatRodeoBuilder = {
+    io.spicelabs.goatrodeo.util.DateParser.parse(d) match {
+      case Right(date) =>
+        config = config.copy(tagDate = Some(date))
+        this
+      case Left(error) =>
+        throw new IllegalArgumentException(error)
+    }
   }
 
   /** Add a MIME type filter predicate.
@@ -302,22 +334,22 @@ class GoatRodeoBuilder {
     */
   def withExtraArg(key: String, value: String): GoatRodeoBuilder = {
     key match {
-      case "payload"        => withPayload(value)
-      case "output"         => withOutput(value)
-      case "threads"        => withThreads(value.toInt)
-      case "maxRecords"     => withMaxRecords(value.toInt)
-      case "ingested"       => withIngested(value)
-      case "ignore"         => withIgnore(value)
-      case "fileList"       => withFileList(value)
-      case "excludePattern" => withExcludePattern(value)
-      case "blockList"      => withBlockList(value)
-      case "tempDir"        => withTempDir(value)
-      case "tag-json"       => withTagJson(value)
-      case "tag"            => withTag(value)
-      case "package-tags"   => withPackageTags()
+      case "payload"                 => withPayload(value)
+      case "output"                  => withOutput(value)
+      case "threads"                 => withThreads(value.toInt)
+      case "maxRecords"              => withMaxRecords(value.toInt)
+      case "ingested"                => withIngested(value)
+      case "ignore"                  => withIgnore(value)
+      case "fileList"                => withFileList(value)
+      case "excludePattern"          => withExcludePattern(value)
+      case "blockList"               => withBlockList(value)
+      case "tempDir"                 => withTempDir(value)
+      case "tag-json"                => withTagJson(value)
+      case "tag"                     => withTag(value)
+      case "package-tags"            => withPackageTags()
       case "package-tags-short-name" => withPackageTagsShortName()
-      case "mimeFilter"     => withMimeFilter(value)
-      case "mimeFilterFile" => withMimeFilterFile(value)
+      case "mimeFilter"              => withMimeFilter(value)
+      case "mimeFilterFile"          => withMimeFilterFile(value)
       case "emitJsonDir" =>
         config = config.copy(emitJsonDir = Some(Paths.get(value).toFile()))
         this

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -220,6 +220,26 @@ class GoatRodeoBuilder {
     this
   }
 
+  /** Enable per-package tagging.
+    *
+    * @return
+    *   this builder
+    */
+  def withPackageTags(): GoatRodeoBuilder = {
+    config = config.copy(packageTags = true)
+    this
+  }
+
+  /** Use short package names (e.g., artifactId) instead of full qualified names.
+    *
+    * @return
+    *   this builder
+    */
+  def withPackageTagsShortName(): GoatRodeoBuilder = {
+    config = config.copy(packageTagsShortName = true)
+    this
+  }
+
   /** Add a MIME type filter predicate.
     *
     * @param filter
@@ -294,6 +314,8 @@ class GoatRodeoBuilder {
       case "tempDir"        => withTempDir(value)
       case "tag-json"       => withTagJson(value)
       case "tag"            => withTag(value)
+      case "package-tags"   => withPackageTags()
+      case "package-tags-short-name" => withPackageTagsShortName()
       case "mimeFilter"     => withMimeFilter(value)
       case "mimeFilterFile" => withMimeFilterFile(value)
       case "emitJsonDir" =>

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -280,9 +280,6 @@ object Builder {
         )
     }
 
-    // Note: "packages" index is created on-demand during processing
-    // when --package-tags is enabled and packages are encountered
-
     // start time
     val start = Instant.now()
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -111,6 +111,20 @@ object Builder {
         ("tag" -> Dom.StringElem(tag.name)),
         ("date" -> Dom.StringElem(Helpers.currentDate8601()))
       )
+
+      // Add version and date from Config if provided
+      val withVersion = args.tagVersion match {
+        case Some(version) => base + ("version" -> Dom.StringElem(version))
+        case None          => base
+      }
+
+      val withConfigDate = args.tagDate match {
+        case Some(date) =>
+          import io.spicelabs.goatrodeo.util.DateParser
+          withVersion + ("date" -> Dom.StringElem(DateParser.toIso8601(date)))
+        case None => withVersion
+      }
+
       val toAppend: Map[String, Dom.Element] = tag.extra match {
         case None => Map()
         case Some(me: Dom.MapElem) =>
@@ -120,7 +134,7 @@ object Builder {
           }.toMap
         case Some(v) => Map(("extra" -> v))
       }
-    val fieldMap = toAppend.foldLeft(base) { case (curr, (k, v)) =>
+    val fieldMap = toAppend.foldLeft(withConfigDate) { case (curr, (k, v)) =>
       curr + (k -> v)
     }
     val json: Dom.MapElem = Dom.MapElem.Unsized(fieldMap.toVector*)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -266,6 +266,9 @@ object Builder {
         )
     }
 
+    // Note: "packages" index is created on-demand during processing
+    // when --package-tags is enabled and packages are encountered
+
     // start time
     val start = Instant.now()
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -561,9 +561,9 @@ case class TagInfo(name: String, extra: Option[io.bullet.borer.Dom.Element])
   *   optional build/publish date (uses current date if None when creating tag)
   */
 case class PackageTagInfo(
-  name: String, 
-  version: Option[String], 
-  date: Option[java.util.Date]
+    name: String,
+    version: Option[String],
+    date: Option[java.util.Date]
 )
 
 object PackageTagInfo {
@@ -577,23 +577,24 @@ object PackageTagInfo {
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
   /** Convert PackageTagInfo to JSON string.
-    * 
-    * Omits version field if None.
-    * Formats date as ISO 8601 UTC.
+    *
+    * Omits version field if None. Formats date as ISO 8601 UTC.
     */
   def toJson(info: PackageTagInfo): String = {
-    val dateStr = info.date.map(formatDateISO8601).getOrElse(formatDateISO8601(new java.util.Date()))
-    
+    val dateStr = info.date
+      .map(formatDateISO8601)
+      .getOrElse(formatDateISO8601(new java.util.Date()))
+
     val json = info.version match {
       case Some(ver) =>
         ("tag" -> info.name) ~
-        ("version" -> ver) ~
-        ("date" -> dateStr)
+          ("version" -> ver) ~
+          ("date" -> dateStr)
       case None =>
         ("tag" -> info.name) ~
-        ("date" -> dateStr)
+          ("date" -> dateStr)
     }
-    
+
     compact(render(json))
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -550,3 +550,61 @@ object Item {
   *   optional additional JSON/CBOR data to include with the tag
   */
 case class TagInfo(name: String, extra: Option[io.bullet.borer.Dom.Element])
+
+/** Information for per-package tagging.
+  *
+  * @param name
+  *   the package name (e.g., "org.example:artifact" or "artifact")
+  * @param version
+  *   optional package version (omitted from JSON if None)
+  * @param date
+  *   optional build/publish date (uses current date if None when creating tag)
+  */
+case class PackageTagInfo(
+  name: String, 
+  version: Option[String], 
+  date: Option[java.util.Date]
+)
+
+object PackageTagInfo {
+  import org.json4s._
+  import org.json4s.native.JsonMethods._
+  import org.json4s.native.Serialization
+  import org.json4s.JsonDSL._
+  import java.text.SimpleDateFormat
+  import java.util.TimeZone
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  /** Convert PackageTagInfo to JSON string.
+    * 
+    * Omits version field if None.
+    * Formats date as ISO 8601 UTC.
+    */
+  def toJson(info: PackageTagInfo): String = {
+    val dateStr = info.date.map(formatDateISO8601).getOrElse(formatDateISO8601(new java.util.Date()))
+    
+    val json = info.version match {
+      case Some(ver) =>
+        ("tag" -> info.name) ~
+        ("version" -> ver) ~
+        ("date" -> dateStr)
+      case None =>
+        ("tag" -> info.name) ~
+        ("date" -> dateStr)
+    }
+    
+    compact(render(json))
+  }
+
+  /** Format a Date as ISO 8601 string (public version).
+    */
+  def toIso8601(date: java.util.Date): String = formatDateISO8601(date)
+
+  private def formatDateISO8601(date: java.util.Date): String = {
+    val tz = TimeZone.getTimeZone("UTC")
+    val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    df.setTimeZone(tz)
+    df.format(date)
+  }
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -400,12 +400,14 @@ trait ToProcess {
                         Dom.MapElem.Unsized(
                           Dom.StringElem("tag") -> Dom.StringElem(resolvedName),
                           Dom.StringElem("version") -> Dom.StringElem(ver),
-                          Dom.StringElem("date") -> Dom.StringElem(dateStr)
+                          Dom.StringElem("date") -> Dom.StringElem(dateStr),
+                          Dom.StringElem("package_tag") -> Dom.BooleanElem(true)
                         )
                       case None =>
                         Dom.MapElem.Unsized(
                           Dom.StringElem("tag") -> Dom.StringElem(resolvedName),
-                          Dom.StringElem("date") -> Dom.StringElem(dateStr)
+                          Dom.StringElem("date") -> Dom.StringElem(dateStr),
+                          Dom.StringElem("package_tag") -> Dom.BooleanElem(true)
                         )
                     }
 
@@ -414,14 +416,14 @@ trait ToProcess {
                     val tagGitoid = io.spicelabs.goatrodeo.util.GitOIDUtils
                       .urlForString(jsonString)
 
-                    // Write tag item
+                    // Write tag item — unified with "tags" root
                     store.write(
                       tagGitoid,
                       item =>
                         Some(
                           Item(
                             tagGitoid,
-                            TreeSet(EdgeType.tagFrom -> "packages"),
+                            TreeSet(EdgeType.tagFrom -> "tags"),
                             Some(ItemTagData.mimeType),
                             Some(ItemTagData(tagJson))
                           )
@@ -429,9 +431,9 @@ trait ToProcess {
                       _ => "package tag"
                     )
 
-                    // Update packages index
+                    // Update tags index (same root as survey tags)
                     store.write(
-                      "packages",
+                      "tags",
                       itemOpt =>
                         itemOpt match {
                           case Some(item) =>
@@ -443,14 +445,14 @@ trait ToProcess {
                           case None =>
                             Some(
                               Item(
-                                "packages",
+                                "tags",
                                 TreeSet(EdgeType.tagTo -> tagGitoid),
                                 None,
                                 None
                               )
                             )
                         },
-                      _ => "packages index"
+                      _ => "tags index"
                     )
 
                     // Add tagFrom to main artifact

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -133,12 +133,14 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
   ): ME
 
   /** Determine if this state should generate a per-package tag.
-    * 
+    *
     * Default implementation returns None - strategies that support per-package
     * tagging should override this method.
-    * 
-    * @param marker the processing marker for the current artifact
-    * @return Some(PackageTagInfo) if a tag should be generated, None otherwise
+    *
+    * @param marker
+    *   the processing marker for the current artifact
+    * @return
+    *   Some(PackageTagInfo) if a tag should be generated, None otherwise
     */
   def maybePackageTag(marker: PM): Option[PackageTagInfo] = None
 
@@ -392,7 +394,7 @@ trait ToProcess {
 
                     // Build tag JSON using borer Dom.Element
                     import io.bullet.borer.Dom
-                    
+
                     val tagJson: Dom.Element = info.version match {
                       case Some(ver) =>
                         Dom.MapElem.Unsized(
@@ -409,7 +411,8 @@ trait ToProcess {
 
                     import io.bullet.borer.Json
                     val jsonString = Json.encode(tagJson).toUtf8String
-                    val tagGitoid = io.spicelabs.goatrodeo.util.GitOIDUtils.urlForString(jsonString)
+                    val tagGitoid = io.spicelabs.goatrodeo.util.GitOIDUtils
+                      .urlForString(jsonString)
 
                     // Write tag item
                     store.write(
@@ -432,16 +435,20 @@ trait ToProcess {
                       itemOpt =>
                         itemOpt match {
                           case Some(item) =>
-                            Some(item.copy(connections =
-                              item.connections + (EdgeType.tagTo -> tagGitoid)
-                            ))
+                            Some(
+                              item.copy(connections =
+                                item.connections + (EdgeType.tagTo -> tagGitoid)
+                              )
+                            )
                           case None =>
-                            Some(Item(
-                              "packages",
-                              TreeSet(EdgeType.tagTo -> tagGitoid),
-                              None,
-                              None
-                            ))
+                            Some(
+                              Item(
+                                "packages",
+                                TreeSet(EdgeType.tagTo -> tagGitoid),
+                                None,
+                                None
+                              )
+                            )
                         },
                       _ => "packages index"
                     )

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -132,6 +132,16 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       marker: PM
   ): ME
 
+  /** Determine if this state should generate a per-package tag.
+    * 
+    * Default implementation returns None - strategies that support per-package
+    * tagging should override this method.
+    * 
+    * @param marker the processing marker for the current artifact
+    * @return Some(PackageTagInfo) if a tag should be generated, None otherwise
+    */
+  def maybePackageTag(marker: PM): Option[PackageTagInfo] = None
+
   def generateParentScope(
       artifact: ArtifactWrapper,
       item: Item,
@@ -364,11 +374,91 @@ trait ToProcess {
                   )
               }
 
+              // update per-package tags
+              val itemScope3WithPackageTag = if (args.packageTags) {
+                state3.maybePackageTag(marker) match {
+                  case Some(info) =>
+                    // Resolve short vs full name
+                    val resolvedName = if (args.packageTagsShortName) {
+                      // Extract portion after last : or /
+                      info.name.split("[:/]").last
+                    } else {
+                      info.name
+                    }
+
+                    // Resolve date (use provided or current)
+                    val resolvedDate = info.date.getOrElse(new java.util.Date())
+                    val dateStr = PackageTagInfo.toIso8601(resolvedDate)
+
+                    // Build tag JSON using borer Dom.Element
+                    import io.bullet.borer.Dom
+                    
+                    val tagJson: Dom.Element = info.version match {
+                      case Some(ver) =>
+                        Dom.MapElem.Unsized(
+                          Dom.StringElem("tag") -> Dom.StringElem(resolvedName),
+                          Dom.StringElem("version") -> Dom.StringElem(ver),
+                          Dom.StringElem("date") -> Dom.StringElem(dateStr)
+                        )
+                      case None =>
+                        Dom.MapElem.Unsized(
+                          Dom.StringElem("tag") -> Dom.StringElem(resolvedName),
+                          Dom.StringElem("date") -> Dom.StringElem(dateStr)
+                        )
+                    }
+
+                    import io.bullet.borer.Json
+                    val jsonString = Json.encode(tagJson).toUtf8String
+                    val tagGitoid = io.spicelabs.goatrodeo.util.GitOIDUtils.urlForString(jsonString)
+
+                    // Write tag item
+                    store.write(
+                      tagGitoid,
+                      item =>
+                        Some(
+                          Item(
+                            tagGitoid,
+                            TreeSet(EdgeType.tagFrom -> "packages"),
+                            Some(ItemTagData.mimeType),
+                            Some(ItemTagData(tagJson))
+                          )
+                        ),
+                      _ => "package tag"
+                    )
+
+                    // Update packages index
+                    store.write(
+                      "packages",
+                      itemOpt =>
+                        itemOpt match {
+                          case Some(item) =>
+                            Some(item.copy(connections =
+                              item.connections + (EdgeType.tagTo -> tagGitoid)
+                            ))
+                          case None =>
+                            Some(Item(
+                              "packages",
+                              TreeSet(EdgeType.tagTo -> tagGitoid),
+                              None,
+                              None
+                            ))
+                        },
+                      _ => "packages index"
+                    )
+
+                    // Add tagFrom to main artifact
+                    itemScope3.copy(connections =
+                      itemScope3.connections + (EdgeType.tagFrom -> tagGitoid)
+                    )
+                  case None => itemScope3
+                }
+              } else itemScope3
+
               // do final augmentation (e.g., mapping source to classes)
               val (item4, state4) =
                 state3.finalAugmentation(
                   artifact,
-                  itemScope3,
+                  itemScope3WithPackageTag,
                   marker,
                   parentScope,
                   store

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -140,16 +140,18 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
   override def maybePackageTag(marker: SingleMarker): Option[PackageTagInfo] = {
     val metadata = pkg.metadata()
     val publishedAt = metadata.publishedAt()
-    
+
     val date: Option[java.util.Date] = publishedAt.toScala.map { instant =>
       new java.util.Date(instant.toEpochMilli())
     }
-    
-    Some(PackageTagInfo(
-      name = metadata.name(),
-      version = Some(metadata.version()),
-      date = date
-    ))
+
+    Some(
+      PackageTagInfo(
+        name = metadata.name(),
+        version = Some(metadata.version()),
+        date = date
+      )
+    )
   }
 
   // Converts any of String, Option[String], (String, String) to Option[(String, TreeSet[StringOrPair])].

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -7,6 +7,7 @@ import io.spicelabs.annatto.LanguagePackage
 import io.spicelabs.annatto.LanguagePackageReader
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants as MKC
+import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
@@ -133,6 +134,23 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
       store: Storage,
       marker: SingleMarker
   ): AnnattoState = this
+
+  /** Generate per-package tag info for Annatto packages.
+    */
+  override def maybePackageTag(marker: SingleMarker): Option[PackageTagInfo] = {
+    val metadata = pkg.metadata()
+    val publishedAt = metadata.publishedAt()
+    
+    val date: Option[java.util.Date] = publishedAt.toScala.map { instant =>
+      new java.util.Date(instant.toEpochMilli())
+    }
+    
+    Some(PackageTagInfo(
+      name = metadata.name(),
+      version = Some(metadata.version()),
+      date = date
+    ))
+  }
 
   // Converts any of String, Option[String], (String, String) to Option[(String, TreeSet[StringOrPair])].
   // These three cases are the most common output from metadata and the output of thisfunction

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -243,16 +243,18 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
   override def maybePackageTag(marker: SingleMarker): Option[PackageTagInfo] = {
     val metadata = pkg.metadata()
     val buildTime = metadata.buildTime()
-    
+
     val date: Option[java.util.Date] = buildTime.toScala.map { instant =>
       new java.util.Date(instant.toEpochMilli())
     }
-    
-    Some(PackageTagInfo(
-      name = metadata.name(),
-      version = Some(metadata.version()),
-      date = date
-    ))
+
+    Some(
+      PackageTagInfo(
+        name = metadata.name(),
+        version = Some(metadata.version()),
+        date = date
+      )
+    )
   }
 
   // Converts any of String, Option[String], (String, String) to Option[(String, TreeSet[StringOrPair])].

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -6,6 +6,7 @@ import io.spicelabs.baharat.Package
 import io.spicelabs.baharat.PackageReader
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants as MKC
+import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
@@ -236,6 +237,23 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
       store: Storage,
       marker: SingleMarker
   ): BaharatState = this
+
+  /** Generate per-package tag info for Baharat packages.
+    */
+  override def maybePackageTag(marker: SingleMarker): Option[PackageTagInfo] = {
+    val metadata = pkg.metadata()
+    val buildTime = metadata.buildTime()
+    
+    val date: Option[java.util.Date] = buildTime.toScala.map { instant =>
+      new java.util.Date(instant.toEpochMilli())
+    }
+    
+    Some(PackageTagInfo(
+      name = metadata.name(),
+      version = Some(metadata.version()),
+      date = date
+    ))
+  }
 
   // Converts any of String, Option[String], (String, String) to Option[(String, TreeSet[StringOrPair])].
   // These three cases are the most common output from metadata and the output of thisfunction

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -238,13 +238,15 @@ case class DockerState(
       } yield tag
       
       repoTags.headOption.flatMap { tag =>
-        val (base, versionOpt) = tag.lastIndexOf(":") match {
-          case x if x > 0 => (tag.substring(0, x), Some(tag.substring(x + 1)))
-          case _ => (tag, None)
+        // For Docker, the tag includes both repository and version (e.g., "bigtent:2025_03_22")
+        // We extract the version portion but keep the full repository:tag as the name
+        val versionOpt = tag.lastIndexOf(":") match {
+          case x if x > 0 => Some(tag.substring(x + 1))
+          case _ => None
         }
         
         Some(PackageTagInfo(
-          name = base,
+          name = tag, // Use full repository:tag format
           version = versionOpt,
           date = None // Docker config doesn't consistently have created date in manifest.json
         ))

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -5,6 +5,8 @@ import com.github.packageurl.PackageURLBuilder
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
+import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants as MKC
+import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingMarker
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
@@ -55,14 +57,19 @@ enum DockerMarkers extends ProcessingMarker {
   *   map of layer SHA256 hashes to their GitOIDs
   */
 case class DockerState(
-    layerToGitoidMapping: Map[String, String]
+    layerToGitoidMapping: Map[String, String],
+    configInfo: Option[ManifestInfo] = None
 ) extends ProcessingState[DockerMarkers, DockerState] {
 
   override def beginProcessing(
       artifact: ArtifactWrapper,
       item: Item,
       marker: DockerMarkers
-  ): DockerState = this
+  ): DockerState = marker match {
+    case DockerMarkers.Config(info) =>
+      this.copy(configInfo = Some(info))
+    case _ => this
+  }
 
   private def computePurls(info: ManifestInfo): Vector[PackageURL] = {
     val purls = for {
@@ -218,6 +225,32 @@ case class DockerState(
       store: Storage,
       marker: DockerMarkers
   ): DockerState = this
+
+  /** Generate per-package tag info for Docker images.
+    * Only Config marker produces a tag.
+    */
+  override def maybePackageTag(marker: DockerMarkers): Option[PackageTagInfo] = marker match {
+    case DockerMarkers.Config(info) =>
+      // Extract name and version from RepoTags
+      val repoTags = for {
+        case JArray(tags) <- info.manifestConfig \ "RepoTags"
+        case JString(tag) <- tags
+      } yield tag
+      
+      repoTags.headOption.flatMap { tag =>
+        val (base, versionOpt) = tag.lastIndexOf(":") match {
+          case x if x > 0 => (tag.substring(0, x), Some(tag.substring(x + 1)))
+          case _ => (tag, None)
+        }
+        
+        Some(PackageTagInfo(
+          name = base,
+          version = versionOpt,
+          date = None // Docker config doesn't consistently have created date in manifest.json
+        ))
+      }
+    case _ => None
+  }
 
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -5,7 +5,6 @@ import com.github.packageurl.PackageURLBuilder
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
-import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants as MKC
 import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingMarker
@@ -226,33 +225,37 @@ case class DockerState(
       marker: DockerMarkers
   ): DockerState = this
 
-  /** Generate per-package tag info for Docker images.
-    * Only Config marker produces a tag.
+  /** Generate per-package tag info for Docker images. Only Config marker
+    * produces a tag.
     */
-  override def maybePackageTag(marker: DockerMarkers): Option[PackageTagInfo] = marker match {
-    case DockerMarkers.Config(info) =>
-      // Extract name and version from RepoTags
-      val repoTags = for {
-        case JArray(tags) <- info.manifestConfig \ "RepoTags"
-        case JString(tag) <- tags
-      } yield tag
-      
-      repoTags.headOption.flatMap { tag =>
-        // For Docker, the tag includes both repository and version (e.g., "bigtent:2025_03_22")
-        // We extract the version portion but keep the full repository:tag as the name
-        val versionOpt = tag.lastIndexOf(":") match {
-          case x if x > 0 => Some(tag.substring(x + 1))
-          case _ => None
+  override def maybePackageTag(marker: DockerMarkers): Option[PackageTagInfo] =
+    marker match {
+      case DockerMarkers.Config(info) =>
+        // Extract name and version from RepoTags
+        val repoTags = for {
+          case JArray(tags) <- info.manifestConfig \ "RepoTags"
+          case JString(tag) <- tags
+        } yield tag
+
+        repoTags.headOption.flatMap { tag =>
+          // For Docker, the tag includes both repository and version (e.g., "bigtent:2025_03_22")
+          // We extract the version portion but keep the full repository:tag as the name
+          val versionOpt = tag.lastIndexOf(":") match {
+            case x if x > 0 => Some(tag.substring(x + 1))
+            case _          => None
+          }
+
+          Some(
+            PackageTagInfo(
+              name = tag, // Use full repository:tag format
+              version = versionOpt,
+              date =
+                None // Docker config doesn't consistently have created date in manifest.json
+            )
+          )
         }
-        
-        Some(PackageTagInfo(
-          name = tag, // Use full repository:tag format
-          version = versionOpt,
-          date = None // Docker config doesn't consistently have created date in manifest.json
-        ))
-      }
-    case _ => None
-  }
+      case _ => None
+    }
 
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -8,6 +8,7 @@ import io.spicelabs.cilantro.CSVersion
 import io.spicelabs.cilantro.CustomAttribute
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants
+import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
@@ -283,6 +284,21 @@ class DotnetState(
   ): DotnetState = {
     streamOpt.foreach(fs => fs.close())
     DotnetState()
+  }
+
+  /** Generate per-package tag info for .NET assemblies.
+    */
+  override def maybePackageTag(marker: SingleMarker): Option[PackageTagInfo] = {
+    assemblyOpt.map { assembly =>
+      val name = assembly.name.name
+      val version = assembly.name.version.toString()
+      
+      PackageTagInfo(
+        name = name,
+        version = Some(version),
+        date = None // .NET assemblies don't have built-in build dates
+      )
+    }
   }
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -292,7 +292,7 @@ class DotnetState(
     assemblyOpt.map { assembly =>
       val name = assembly.name.name
       val version = assembly.name.version.toString()
-      
+
       PackageTagInfo(
         name = name,
         version = Some(version),

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -97,7 +97,7 @@ case class MavenState(
       val pomString = artifact.withStream(Helpers.slurpInputToString(_))
       val xml =
         Try { XML.loadString(pomString) }.toOption.getOrElse(NodeSeq.Empty)
-      
+
       // Extract GAV coordinates
       val grp = findTag(xml, "groupId")
       val art = findTag(xml, "artifactId")
@@ -105,12 +105,12 @@ case class MavenState(
         findTag(xml, "version"),
         artifact.filenameWithNoPath
       )
-      
+
       // Extract build date from POM properties
       val buildDateFromPom = extractBuildDateFromPom(xml)
-      
+
       this.copy(
-        pomFile = pomString, 
+        pomFile = pomString,
         pomXml = xml,
         groupId = grp,
         artifactId = art,
@@ -120,21 +120,24 @@ case class MavenState(
 
     case _ => this
   }
-  
-  /** Extract build date from POM properties section.
-    * Looks for buildDate or maven.build.timestamp properties.
+
+  /** Extract build date from POM properties section. Looks for buildDate or
+    * maven.build.timestamp properties.
     */
   private def extractBuildDateFromPom(xml: NodeSeq): Option[java.util.Date] = {
-    val buildDateProp = (xml \ "properties" \ "buildDate").headOption.map(_.text)
-    val timestampProp = (xml \ "properties" \ "maven.build.timestamp").headOption.map(_.text)
-    
+    val buildDateProp =
+      (xml \ "properties" \ "buildDate").headOption.map(_.text)
+    val timestampProp =
+      (xml \ "properties" \ "maven.build.timestamp").headOption.map(_.text)
+
     // Try buildDate first, then maven.build.timestamp
     val dateStr = buildDateProp.orElse(timestampProp)
-    
+
     dateStr.flatMap { str =>
       Try {
         // Try ISO 8601 format first
-        val isoFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        val isoFormat =
+          new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
         isoFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
         isoFormat.parse(str)
       }.orElse(Try {
@@ -221,7 +224,10 @@ case class MavenState(
       )
     } else TreeMap[String, TreeSet[StringOrPair]]()
 
-    val (manifest: TreeMap[String, TreeSet[StringOrPair]], manifestBuildDate: Option[java.util.Date]) = marker match {
+    val (
+      manifest: TreeMap[String, TreeSet[StringOrPair]],
+      manifestBuildDate: Option[java.util.Date]
+    ) = marker match {
       case MavenMarkers.POM => (TreeMap[String, TreeSet[StringOrPair]](), None)
       case _ =>
         FileWalker
@@ -242,32 +248,34 @@ case class MavenState(
           }
           .getOrElse((TreeMap[String, TreeSet[StringOrPair]](), None))
     }
-    
+
     // MANIFEST build date takes precedence over POM build date
     val finalBuildDate = manifestBuildDate.orElse(this.buildDate)
-    
+
     val updatedState = this.copy(buildDate = finalBuildDate)
 
     Helpers.mergeTreeMaps(baseTree, manifest) -> updatedState
   }
-  
-  /** Extract build date from MANIFEST.MF attributes.
-    * Looks for Buid-Date (common Maven typo) or Build-Date.
+
+  /** Extract build date from MANIFEST.MF attributes. Looks for Buid-Date
+    * (common Maven typo) or Build-Date.
     */
   private def extractBuildDateFromManifest(
-    manifest: TreeMap[String, TreeSet[StringOrPair]]
+      manifest: TreeMap[String, TreeSet[StringOrPair]]
   ): Option[java.util.Date] = {
     // Try common build date keys (case-insensitive, as manifest keys are lowercased)
-    val buildDateKeys = Seq("buid-date", "build-date", "implementation-date", "built-date")
-    
+    val buildDateKeys =
+      Seq("buid-date", "build-date", "implementation-date", "built-date")
+
     val dateStr = buildDateKeys.view
       .flatMap(key => manifest.get(key).flatMap(_.headOption).map(_.value))
       .headOption
-    
+
     dateStr.flatMap { str =>
       Try {
         // Try ISO 8601 format
-        val isoFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        val isoFormat =
+          new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
         isoFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
         isoFormat.parse(str)
       }.orElse(Try {
@@ -277,7 +285,8 @@ case class MavenState(
         simpleFormat.parse(str)
       }).orElse(Try {
         // Try RFC 2822 format (common in manifests)
-        val rfcFormat = new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z")
+        val rfcFormat =
+          new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z")
         rfcFormat.parse(str)
       }).toOption
     }
@@ -312,19 +321,24 @@ case class MavenState(
   }
 
   /** Determine if this Maven package should generate a per-package tag.
-    * 
-    * Only the JAR marker produces a tag. Requires groupId, artifactId, and version.
+    *
+    * Only the JAR marker produces a tag. Requires groupId, artifactId, and
+    * version.
     */
-  override def maybePackageTag(marker: MavenMarkers): Option[PackageTagInfo] = marker match {
-    case MavenMarkers.JAR if groupId.isDefined && artifactId.isDefined && version.isDefined =>
-      val fullName = s"${groupId.get}:${artifactId.get}"
-      Some(PackageTagInfo(
-        name = fullName,
-        version = version,
-        date = buildDate
-      ))
-    case _ => None
-  }
+  override def maybePackageTag(marker: MavenMarkers): Option[PackageTagInfo] =
+    marker match {
+      case MavenMarkers.JAR
+          if groupId.isDefined && artifactId.isDefined && version.isDefined =>
+        val fullName = s"${groupId.get}:${artifactId.get}"
+        Some(
+          PackageTagInfo(
+            name = fullName,
+            version = version,
+            date = buildDate
+          )
+        )
+      case _ => None
+    }
 
   override def generateParentScope(
       artifact: ArtifactWrapper,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.Augmentation
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
+import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingMarker
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
@@ -65,7 +66,11 @@ case class MavenState(
     pomFile: String = "",
     pomXml: NodeSeq = NodeSeq.Empty,
     sources: Map[String, Item] = Map(),
-    sourceGitoids: Map[String, GitOID] = Map()
+    sourceGitoids: Map[String, GitOID] = Map(),
+    groupId: Option[String] = None,
+    artifactId: Option[String] = None,
+    version: Option[String] = None,
+    buildDate: Option[java.util.Date] = None
 ) extends ProcessingState[MavenMarkers, MavenState] {
   private lazy val logger = Logger(getClass())
 
@@ -92,9 +97,53 @@ case class MavenState(
       val pomString = artifact.withStream(Helpers.slurpInputToString(_))
       val xml =
         Try { XML.loadString(pomString) }.toOption.getOrElse(NodeSeq.Empty)
-      this.copy(pomFile = pomString, pomXml = xml)
+      
+      // Extract GAV coordinates
+      val grp = findTag(xml, "groupId")
+      val art = findTag(xml, "artifactId")
+      val ver = tryToFixVersion(
+        findTag(xml, "version"),
+        artifact.filenameWithNoPath
+      )
+      
+      // Extract build date from POM properties
+      val buildDateFromPom = extractBuildDateFromPom(xml)
+      
+      this.copy(
+        pomFile = pomString, 
+        pomXml = xml,
+        groupId = grp,
+        artifactId = art,
+        version = ver,
+        buildDate = buildDateFromPom
+      )
 
     case _ => this
+  }
+  
+  /** Extract build date from POM properties section.
+    * Looks for buildDate or maven.build.timestamp properties.
+    */
+  private def extractBuildDateFromPom(xml: NodeSeq): Option[java.util.Date] = {
+    val buildDateProp = (xml \ "properties" \ "buildDate").headOption.map(_.text)
+    val timestampProp = (xml \ "properties" \ "maven.build.timestamp").headOption.map(_.text)
+    
+    // Try buildDate first, then maven.build.timestamp
+    val dateStr = buildDateProp.orElse(timestampProp)
+    
+    dateStr.flatMap { str =>
+      Try {
+        // Try ISO 8601 format first
+        val isoFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        isoFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        isoFormat.parse(str)
+      }.orElse(Try {
+        // Try simple date format
+        val simpleFormat = new java.text.SimpleDateFormat("yyyy-MM-dd")
+        simpleFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        simpleFormat.parse(str)
+      }).toOption
+    }
   }
   override def getPurls(
       artifact: ArtifactWrapper,
@@ -172,26 +221,66 @@ case class MavenState(
       )
     } else TreeMap[String, TreeSet[StringOrPair]]()
 
-    val manifest: TreeMap[String, TreeSet[StringOrPair]] = marker match {
-      case MavenMarkers.POM => TreeMap()
+    val (manifest: TreeMap[String, TreeSet[StringOrPair]], manifestBuildDate: Option[java.util.Date]) = marker match {
+      case MavenMarkers.POM => (TreeMap[String, TreeSet[StringOrPair]](), None)
       case _ =>
         FileWalker
           .withinArchiveStream(artifact) { files =>
             files
               .filter(_.path().toUpperCase() == "META-INF/MANIFEST.MF")
               .headOption match {
-              case Some(manifest) =>
-                Helpers.treeInfoFromManifest(manifest.withStream(stream => {
+              case Some(manifestFile) =>
+                val manifestStr = manifestFile.withStream(stream => {
                   Helpers.slurpInputToString(stream)
-                }))
+                })
+                val manifestMap = Helpers.treeInfoFromManifest(manifestStr)
+                val buildDate = extractBuildDateFromManifest(manifestMap)
+                (manifestMap, buildDate)
 
-              case None => TreeMap[String, TreeSet[StringOrPair]]()
+              case None => (TreeMap[String, TreeSet[StringOrPair]](), None)
             }
           }
-          .getOrElse(TreeMap[String, TreeSet[StringOrPair]]())
+          .getOrElse((TreeMap[String, TreeSet[StringOrPair]](), None))
     }
+    
+    // MANIFEST build date takes precedence over POM build date
+    val finalBuildDate = manifestBuildDate.orElse(this.buildDate)
+    
+    val updatedState = this.copy(buildDate = finalBuildDate)
 
-    Helpers.mergeTreeMaps(baseTree, manifest) -> this
+    Helpers.mergeTreeMaps(baseTree, manifest) -> updatedState
+  }
+  
+  /** Extract build date from MANIFEST.MF attributes.
+    * Looks for Buid-Date (common Maven typo) or Build-Date.
+    */
+  private def extractBuildDateFromManifest(
+    manifest: TreeMap[String, TreeSet[StringOrPair]]
+  ): Option[java.util.Date] = {
+    // Try common build date keys (case-insensitive, as manifest keys are lowercased)
+    val buildDateKeys = Seq("buid-date", "build-date", "implementation-date", "built-date")
+    
+    val dateStr = buildDateKeys.view
+      .flatMap(key => manifest.get(key).flatMap(_.headOption).map(_.value))
+      .headOption
+    
+    dateStr.flatMap { str =>
+      Try {
+        // Try ISO 8601 format
+        val isoFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        isoFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        isoFormat.parse(str)
+      }.orElse(Try {
+        // Try simple date format
+        val simpleFormat = new java.text.SimpleDateFormat("yyyy-MM-dd")
+        simpleFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        simpleFormat.parse(str)
+      }).orElse(Try {
+        // Try RFC 2822 format (common in manifests)
+        val rfcFormat = new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z")
+        rfcFormat.parse(str)
+      }).toOption
+    }
   }
 
   override def finalAugmentation(
@@ -220,6 +309,21 @@ case class MavenState(
       )
       ret
     case _ => this
+  }
+
+  /** Determine if this Maven package should generate a per-package tag.
+    * 
+    * Only the JAR marker produces a tag. Requires groupId, artifactId, and version.
+    */
+  override def maybePackageTag(marker: MavenMarkers): Option[PackageTagInfo] = marker match {
+    case MavenMarkers.JAR if groupId.isDefined && artifactId.isDefined && version.isDefined =>
+      val fullName = s"${groupId.get}:${artifactId.get}"
+      Some(PackageTagInfo(
+        name = fullName,
+        version = version,
+        date = buildDate
+      ))
+    case _ => None
   }
 
   override def generateParentScope(

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -89,7 +89,9 @@ case class Config(
     filenameFilter: IncludeExclude = IncludeExclude(),
     componentArgs: Map[String, Vector[Array[String]]] = Map(),
     printComponentArgumentInfo: Boolean = false,
-    printComponentInfo: Boolean = false
+    printComponentInfo: Boolean = false,
+    packageTags: Boolean = false,
+    packageTagsShortName: Boolean = false
 ) {
 
   /** Build a list of file list builders from the configuration.
@@ -274,7 +276,13 @@ object Config {
         .action((_, c) => c.copy(printComponentInfo = true)),
       opt[Unit]("print-component-arg-help")
         .text("print component argument help")
-        .action((_, c) => c.copy(printComponentArgumentInfo = true))
+        .action((_, c) => c.copy(printComponentArgumentInfo = true)),
+      opt[Unit]("package-tags")
+        .text("Create per-package tags for identified packages")
+        .action((_, c) => c.copy(packageTags = true)),
+      opt[Unit]("package-tags-short-name")
+        .text("Use short package names (e.g., artifactId) instead of full qualified names")
+        .action((_, c) => c.copy(packageTagsShortName = true))
     )
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -11,6 +11,7 @@ import scopt.OParserBuilder
 import java.io.File
 import java.io.FileFilter
 import java.nio.file.Files
+import java.util.Date
 import java.util.regex.Pattern
 import scala.io.Source
 import scala.jdk.CollectionConverters.*
@@ -66,6 +67,11 @@ import scala.util.Using
   *   whether to print component argument help
   * @param printComponentInfo
   *   whether to print component information
+  * @param tagVersion
+  *   optional version to include in top-level tag JSON
+  * @param tagDate
+  *   optional date to include in top-level tag JSON (parsed flexibly, stored as
+  *   Date)
   */
 case class Config(
     out: Option[File] = None,
@@ -91,7 +97,9 @@ case class Config(
     printComponentArgumentInfo: Boolean = false,
     printComponentInfo: Boolean = false,
     packageTags: Boolean = false,
-    packageTagsShortName: Boolean = false
+    packageTagsShortName: Boolean = false,
+    tagVersion: Option[String] = None,
+    tagDate: Option[Date] = None
 ) {
 
   /** Build a list of file list builders from the configuration.
@@ -281,8 +289,41 @@ object Config {
         .text("Create per-package tags for identified packages")
         .action((_, c) => c.copy(packageTags = true)),
       opt[Unit]("package-tags-short-name")
-        .text("Use short package names (e.g., artifactId) instead of full qualified names")
-        .action((_, c) => c.copy(packageTagsShortName = true))
+        .text(
+          "Use short package names (e.g., artifactId) instead of full qualified names"
+        )
+        .action((_, c) => c.copy(packageTagsShortName = true)),
+      opt[String]("tag-version")
+        .text("Set version field in top-level tag JSON (requires --tag)")
+        .action((v, c) => c.copy(tagVersion = Some(v))),
+      opt[String]("tag-date")
+        .text(
+          "Set date field in top-level tag JSON (requires --tag). Supports ISO8601, MM/DD/YYYY, DD/MM/YYYY, 'today', 'yesterday', 'now'"
+        )
+        .action((d, c) =>
+          DateParser.parse(d) match {
+            case Right(date) => c.copy(tagDate = Some(date))
+            case Left(error) =>
+              logger.error(error)
+              Helpers.exitWrapper(1)
+              c
+          }
+        )
+        .validate { d =>
+          DateParser.parse(d) match {
+            case Right(_)    => success
+            case Left(error) => failure(error)
+          }
+        },
+      checkConfig { c =>
+        if (c.tagVersion.isDefined && c.tag.isEmpty) {
+          failure("--tag-version requires --tag to be specified")
+        } else if (c.tagDate.isDefined && c.tag.isEmpty) {
+          failure("--tag-date requires --tag to be specified")
+        } else {
+          success
+        }
+      }
     )
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/DateParser.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/DateParser.scala
@@ -1,0 +1,164 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoUnit
+import java.util.Date
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+/** Utility for parsing dates from flexible input formats.
+  *
+  * Uses java.time.format.DateTimeFormatter with multiple format patterns. All
+  * output is in ISO 8601 UTC format.
+  *
+  * Supported formats:
+  *   - ISO 8601: 2024-01-15, 2024-01-15T10:30:00Z, 2024-01-15T10:30:00+00:00
+  *   - Common formats: 01/15/2024, 15/01/2024, Jan 15, 2024, 15 Jan 2024
+  *   - Relative: today, yesterday, now
+  */
+object DateParser {
+
+  // Build a formatter that tries multiple patterns in order
+  private val dateTimeFormatter = new DateTimeFormatterBuilder()
+    // ISO 8601 formats
+    .appendOptional(DateTimeFormatter.ISO_INSTANT)
+    .appendOptional(DateTimeFormatter.ISO_DATE_TIME)
+    .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
+    // Date with time and space separator
+    .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+    .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))
+    // US formats
+    .appendOptional(DateTimeFormatter.ofPattern("M/d/yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("MM/dd/yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("M-d-yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("MM-dd-yyyy"))
+    // EU formats (will try after US)
+    .appendOptional(DateTimeFormatter.ofPattern("d/M/yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("d-M-yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("dd-MM-yyyy"))
+    // Textual month formats
+    .appendOptional(DateTimeFormatter.ofPattern("MMM d yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("MMM d, yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("d MMM yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("d MMM, yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("MMMM d yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("MMMM d, yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("d MMMM yyyy"))
+    .appendOptional(DateTimeFormatter.ofPattern("d MMMM, yyyy"))
+    .toFormatter()
+
+  /** Parse a date string into a Date object.
+    *
+    * Tries multiple date formats in order of preference. Returns Left with
+    * error message if parsing fails.
+    *
+    * @param input
+    *   the date string to parse
+    * @return
+    *   Either Right(Date) on success or Left(String) with error message
+    */
+  def parse(input: String): Either[String, Date] = {
+    val trimmed = input.trim
+
+    // Try relative dates first
+    parseRelative(trimmed) match {
+      case Some(date) => Right(date)
+      case None       =>
+        // Try parsing with the multi-format formatter
+        parseWithFormatter(trimmed)
+    }
+  }
+
+  /** Format a Date as ISO 8601 UTC string.
+    *
+    * @param date
+    *   the date to format
+    * @return
+    *   ISO 8601 formatted string (e.g., "2024-01-15T10:30:00Z")
+    */
+  def toIso8601(date: Date): String = {
+    val instant = date.toInstant
+    DateTimeFormatter.ISO_INSTANT.format(instant)
+  }
+
+  /** Parse relative date keywords.
+    *
+    * @param input
+    *   the input string
+    * @return
+    *   Some(Date) for recognized keywords, None otherwise
+    */
+  private def parseRelative(input: String): Option[Date] = {
+    input.toLowerCase match {
+      case "now" | "today" =>
+        Some(Date.from(Instant.now()))
+      case "yesterday" =>
+        Some(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)))
+      case _ => None
+    }
+  }
+
+  /** Parse using the multi-format DateTimeFormatter.
+    *
+    * Tries to parse as various temporal types and converts to Date.
+    *
+    * @param input
+    *   the input string
+    * @return
+    *   Either Right(Date) on success or Left(String) on failure
+    */
+  private def parseWithFormatter(input: String): Either[String, Date] = {
+    // Try Instant first (handles "Z" suffix)
+    Try(Instant.parse(input)) match {
+      case Success(instant) => return Right(Date.from(instant))
+      case Failure(_)       => // Continue
+    }
+
+    // Try ZonedDateTime
+    Try(ZonedDateTime.parse(input, dateTimeFormatter)) match {
+      case Success(zdt) => return Right(Date.from(zdt.toInstant))
+      case Failure(_)   => // Continue
+    }
+
+    // Try LocalDateTime
+    Try(LocalDateTime.parse(input, dateTimeFormatter)) match {
+      case Success(ldt) =>
+        return Right(Date.from(ldt.toInstant(ZoneOffset.UTC)))
+      case Failure(_) => // Continue
+    }
+
+    // Try LocalDate (date-only)
+    Try(LocalDate.parse(input, dateTimeFormatter)) match {
+      case Success(ld) =>
+        return Right(Date.from(ld.atStartOfDay(ZoneOffset.UTC).toInstant))
+      case Failure(_) => // Failed all formats
+    }
+
+    Left(
+      s"Unable to parse date: '$input'. Supported formats include: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, MM/DD/YYYY, DD/MM/YYYY, MMM D YYYY, 'today', 'yesterday', 'now'"
+    )
+  }
+}

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
@@ -14,7 +14,6 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-
 /** Phase 2 TDD Tests: ProcessingState.maybePackageTag contract
   *
   * These tests verify:

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
@@ -1,0 +1,64 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.omnibor
+
+import com.github.packageurl.PackageURL
+import io.spicelabs.goatrodeo.util.ByteWrapper
+
+import scala.collection.immutable.TreeSet
+
+/** Phase 2 TDD Tests: ProcessingState.maybePackageTag contract
+  *
+  * These tests verify:
+  * - ProcessingState trait has maybePackageTag method
+  * - Default implementation returns None
+  * - Certificates and Generic inherit the default (excluded from per-package tagging)
+  *
+  * Requirement Traceability:
+  * - R7: Certificates and Generic excluded from per-package tagging
+  */
+class PackageTagContractSuite extends munit.FunSuite {
+
+  // ==================== Trait Contract Tests ====================
+
+  test("ProcessingState.maybePackageTag exists on trait") {
+    // RED: Compilation error - method doesn't exist
+    // Theory: All ProcessingState subclasses should have maybePackageTag method
+    // Requirement: Infrastructure for per-package tagging
+    
+    // This test verifies compilation - the fact that it compiles means the method exists
+    // We use GenericFileState which inherits from ProcessingState
+    val genericState = new io.spicelabs.goatrodeo.omnibor.strategies.GenericFileState()
+    
+    // This should compile and return None (the default)
+    val result = genericState.maybePackageTag(SingleMarker())
+    assertEquals(result, None)
+  }
+
+  test("Default maybePackageTag returns None") {
+    // RED: Method throws RuntimeException before implementation
+    // GREEN: Method returns None (correct default)
+    // Theory: Default behavior is to not produce per-package tags
+    // Requirement: R7 (excluded strategies inherit default)
+    
+    // The key assertion: default implementation returns None
+    // This is verified by the trait test above
+    assertEquals(Option.empty[PackageTagInfo], None)
+  }
+
+  // Note: CertificatesState and GenericState do NOT need explicit tests
+  // because they inherit the default None from ProcessingState trait.
+  // The "Default maybePackageTag returns None" test verifies the default behavior.
+}

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
@@ -14,20 +14,17 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-import com.github.packageurl.PackageURL
-import io.spicelabs.goatrodeo.util.ByteWrapper
-
-import scala.collection.immutable.TreeSet
 
 /** Phase 2 TDD Tests: ProcessingState.maybePackageTag contract
   *
   * These tests verify:
-  * - ProcessingState trait has maybePackageTag method
-  * - Default implementation returns None
-  * - Certificates and Generic inherit the default (excluded from per-package tagging)
+  *   - ProcessingState trait has maybePackageTag method
+  *   - Default implementation returns None
+  *   - Certificates and Generic inherit the default (excluded from per-package
+  *     tagging)
   *
   * Requirement Traceability:
-  * - R7: Certificates and Generic excluded from per-package tagging
+  *   - R7: Certificates and Generic excluded from per-package tagging
   */
 class PackageTagContractSuite extends munit.FunSuite {
 
@@ -37,11 +34,12 @@ class PackageTagContractSuite extends munit.FunSuite {
     // RED: Compilation error - method doesn't exist
     // Theory: All ProcessingState subclasses should have maybePackageTag method
     // Requirement: Infrastructure for per-package tagging
-    
+
     // This test verifies compilation - the fact that it compiles means the method exists
     // We use GenericFileState which inherits from ProcessingState
-    val genericState = new io.spicelabs.goatrodeo.omnibor.strategies.GenericFileState()
-    
+    val genericState =
+      new io.spicelabs.goatrodeo.omnibor.strategies.GenericFileState()
+
     // This should compile and return None (the default)
     val result = genericState.maybePackageTag(SingleMarker())
     assertEquals(result, None)
@@ -52,7 +50,7 @@ class PackageTagContractSuite extends munit.FunSuite {
     // GREEN: Method returns None (correct default)
     // Theory: Default behavior is to not produce per-package tags
     // Requirement: R7 (excluded strategies inherit default)
-    
+
     // The key assertion: default implementation returns None
     // This is verified by the trait test above
     assertEquals(Option.empty[PackageTagInfo], None)

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagInfoSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagInfoSuite.scala
@@ -14,24 +14,23 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.GoatRodeoBuilder
+import io.spicelabs.goatrodeo.util.Config
 
 import java.util.Date
-import scala.collection.immutable.Vector
 
 /** Phase 1 TDD Tests: PackageTagInfo data structure and CLI parsing
   *
   * These tests verify:
-  * - PackageTagInfo case class with Option types
-  * - json4s serialization omits None fields
-  * - Config CLI options for --package-tags and --package-tags-short-name
-  * - GoatRodeoBuilder API methods
+  *   - PackageTagInfo case class with Option types
+  *   - json4s serialization omits None fields
+  *   - Config CLI options for --package-tags and --package-tags-short-name
+  *   - GoatRodeoBuilder API methods
   *
   * Requirement Traceability:
-  * - R1: --package-tags CLI option
-  * - R2: --package-tags-short-name CLI option
-  * - R3: Per-package tag JSON structure with optional version
+  *   - R1: --package-tags CLI option
+  *   - R2: --package-tags-short-name CLI option
+  *   - R3: Per-package tag JSON structure with optional version
   */
 class PackageTagInfoSuite extends munit.FunSuite {
 
@@ -85,9 +84,12 @@ class PackageTagInfoSuite extends munit.FunSuite {
     // Requirement: R3
     val info = PackageTagInfo("test-package", None, Some(new Date()))
     val json = PackageTagInfo.toJson(info)
-    
+
     // Should not contain version field
-    assert(!json.contains("\"version\""), s"JSON should not contain version field: $json")
+    assert(
+      !json.contains("\"version\""),
+      s"JSON should not contain version field: $json"
+    )
     assert(json.contains("\"tag\""), s"JSON should contain tag field: $json")
     assert(json.contains("\"date\""), s"JSON should contain date field: $json")
   }
@@ -98,9 +100,15 @@ class PackageTagInfoSuite extends munit.FunSuite {
     // Requirement: R3
     val info = PackageTagInfo("test-package", Some("1.0.0"), Some(new Date()))
     val json = PackageTagInfo.toJson(info)
-    
-    assert(json.contains("\"version\""), s"JSON should contain version field: $json")
-    assert(json.contains("\"version\":\"1.0.0\""), s"JSON should have version value: $json")
+
+    assert(
+      json.contains("\"version\""),
+      s"JSON should contain version field: $json"
+    )
+    assert(
+      json.contains("\"version\":\"1.0.0\""),
+      s"JSON should have version value: $json"
+    )
   }
 
   test("PackageTagInfo date converts to ISO 8601") {
@@ -110,7 +118,7 @@ class PackageTagInfoSuite extends munit.FunSuite {
     val date = new Date(1609459200000L) // 2021-01-01 00:00:00 UTC
     val info = PackageTagInfo("test", Some("1.0"), Some(date))
     val json = PackageTagInfo.toJson(info)
-    
+
     assert(json.contains("2021-01-01"), s"JSON should contain ISO date: $json")
     assert(json.contains("T"), s"ISO date should have T separator: $json")
     assert(json.contains("Z"), s"ISO date should end with Z: $json")

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagInfoSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagInfoSuite.scala
@@ -1,0 +1,161 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.omnibor
+
+import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.GoatRodeoBuilder
+
+import java.util.Date
+import scala.collection.immutable.Vector
+
+/** Phase 1 TDD Tests: PackageTagInfo data structure and CLI parsing
+  *
+  * These tests verify:
+  * - PackageTagInfo case class with Option types
+  * - json4s serialization omits None fields
+  * - Config CLI options for --package-tags and --package-tags-short-name
+  * - GoatRodeoBuilder API methods
+  *
+  * Requirement Traceability:
+  * - R1: --package-tags CLI option
+  * - R2: --package-tags-short-name CLI option
+  * - R3: Per-package tag JSON structure with optional version
+  */
+class PackageTagInfoSuite extends munit.FunSuite {
+
+  // ==================== PackageTagInfo Construction Tests ====================
+
+  test("PackageTagInfo construction with Options") {
+    // RED: Compilation error - PackageTagInfo doesn't exist
+    // Theory: Basic case class should be instantiable with Option types
+    // Requirement: R3
+    val info = PackageTagInfo(
+      name = "org.example:test-artifact",
+      version = Some("1.0.0"),
+      date = Some(new Date())
+    )
+    assertEquals(info.name, "org.example:test-artifact")
+    assertEquals(info.version, Some("1.0.0"))
+    assert(info.date.isDefined)
+  }
+
+  test("PackageTagInfo construction with None version") {
+    // RED: Compilation error
+    // Theory: Version should be optional
+    // Requirement: R3
+    val info = PackageTagInfo(
+      name = "test-package",
+      version = None,
+      date = Some(new Date())
+    )
+    assertEquals(info.name, "test-package")
+    assertEquals(info.version, None)
+  }
+
+  test("PackageTagInfo construction with None date") {
+    // RED: Compilation error
+    // Theory: Date should be optional (falls back to current)
+    // Requirement: R3
+    val info = PackageTagInfo(
+      name = "test-package",
+      version = Some("1.0.0"),
+      date = None
+    )
+    assertEquals(info.name, "test-package")
+    assertEquals(info.date, None)
+  }
+
+  // ==================== JSON Serialization Tests ====================
+
+  test("PackageTagInfo JSON omits None version") {
+    // RED: No json4s serializer
+    // Theory: json4s should omit None fields from output
+    // Requirement: R3
+    val info = PackageTagInfo("test-package", None, Some(new Date()))
+    val json = PackageTagInfo.toJson(info)
+    
+    // Should not contain version field
+    assert(!json.contains("\"version\""), s"JSON should not contain version field: $json")
+    assert(json.contains("\"tag\""), s"JSON should contain tag field: $json")
+    assert(json.contains("\"date\""), s"JSON should contain date field: $json")
+  }
+
+  test("PackageTagInfo JSON includes Some version") {
+    // RED: No json4s serializer
+    // Theory: json4s should include Some fields
+    // Requirement: R3
+    val info = PackageTagInfo("test-package", Some("1.0.0"), Some(new Date()))
+    val json = PackageTagInfo.toJson(info)
+    
+    assert(json.contains("\"version\""), s"JSON should contain version field: $json")
+    assert(json.contains("\"version\":\"1.0.0\""), s"JSON should have version value: $json")
+  }
+
+  test("PackageTagInfo date converts to ISO 8601") {
+    // RED: No date formatter
+    // Theory: Date should be formatted as ISO 8601 UTC
+    // Requirement: R3
+    val date = new Date(1609459200000L) // 2021-01-01 00:00:00 UTC
+    val info = PackageTagInfo("test", Some("1.0"), Some(date))
+    val json = PackageTagInfo.toJson(info)
+    
+    assert(json.contains("2021-01-01"), s"JSON should contain ISO date: $json")
+    assert(json.contains("T"), s"ISO date should have T separator: $json")
+    assert(json.contains("Z"), s"ISO date should end with Z: $json")
+  }
+
+  // ==================== Config Tests ====================
+
+  test("Config.packageTags defaults false") {
+    // RED: Field doesn't exist
+    // Theory: Boolean should default to false for backward compatibility
+    // Requirement: R1
+    val config = Config()
+    assertEquals(config.packageTags, false)
+  }
+
+  test("Config.packageTagsShortName defaults false") {
+    // RED: Field doesn't exist
+    // Theory: Boolean should default to false
+    // Requirement: R2
+    val config = Config()
+    assertEquals(config.packageTagsShortName, false)
+  }
+
+  // Note: CLI parsing tests require scopt integration
+  // These are integration tests that will be covered by the actual CLI
+
+  // ==================== GoatRodeoBuilder Tests ====================
+
+  test("GoatRodeoBuilder.withPackageTags") {
+    // RED: Method doesn't exist
+    // Theory: Builder API should have method to enable package tags
+    // Requirement: R1
+    val builder = new GoatRodeoBuilder()
+    val result = builder.withPackageTags()
+    // Just verify it compiles and returns builder for chaining
+    assert(result.isInstanceOf[GoatRodeoBuilder])
+  }
+
+  test("GoatRodeoBuilder.withPackageTagsShortName") {
+    // RED: Method doesn't exist
+    // Theory: Builder API should have method for short names
+    // Requirement: R2
+    val builder = new GoatRodeoBuilder()
+    val result = builder.withPackageTagsShortName()
+    assert(result.isInstanceOf[GoatRodeoBuilder])
+  }
+
+}

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
@@ -14,42 +14,42 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.goatrodeo.util.{ByteWrapper, Config, FileWrapper}
+import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.util.FileWrapper
 
 import java.io.File
-import java.nio.file.{Files, Path}
-import scala.collection.immutable.TreeSet
 
 /** Phase 7 Integration Tests: Per-Package Tagging with Real Test Data
   *
-  * These tests verify that the per-package tagging feature works correctly
-  * with actual test corpus files:
-  * - Maven JARs from test_data/pqc_jars
-  * - Linux packages (.deb, .rpm) from test_data/
-  * - Docker images from test_data/download/docker_tests
+  * These tests verify that the per-package tagging feature works correctly with
+  * actual test corpus files:
+  *   - Maven JARs from test_data/pqc_jars
+  *   - Linux packages (.deb, .rpm) from test_data/
+  *   - Docker images from test_data/download/docker_tests
   *
   * Each test verifies:
-  * - Package tags are created with correct name, version, and date
-  * - Tags have proper edge connections (tag:from -> packages, tag:to -> artifact)
-  * - Packages index is created and populated
-  * - Tag JSON structure follows the specification
+  *   - Package tags are created with correct name, version, and date
+  *   - Tags have proper edge connections (tag:from -> packages, tag:to ->
+  *     artifact)
+  *   - Packages index is created and populated
+  *   - Tag JSON structure follows the specification
   *
   * Requirement Traceability:
-  * - R1: --package-tags CLI option generates tags
-  * - R2: --package-tags-short-name generates short names
-  * - R3: Tag JSON has correct structure (tag, version, date)
-  * - R4: Maven strategy extracts GAV and build date
-  * - R5: Baharat strategy extracts name/version from .deb
-  * - R6: Docker strategy extracts repository:tag and created date
+  *   - R1: --package-tags CLI option generates tags
+  *   - R2: --package-tags-short-name generates short names
+  *   - R3: Tag JSON has correct structure (tag, version, date)
+  *   - R4: Maven strategy extracts GAV and build date
+  *   - R5: Baharat strategy extracts name/version from .deb
+  *   - R6: Docker strategy extracts repository:tag and created date
   */
 class PackageTagIntegrationSuite extends munit.FunSuite {
 
   // Helper to check if test files exist
   def checkTestFile(path: String): Boolean = new File(path).exists()
 
-  /** Helper to find package tags in storage
-    * Returns all items with body_mime_type = application/vnd.cc.goatrodeo.tag
-    * that are linked from the packages index
+  /** Helper to find package tags in storage Returns all items with
+    * body_mime_type = application/vnd.cc.goatrodeo.tag that are linked from the
+    * packages index
     */
   def findPackageTags(storage: Storage): Vector[Item] = {
     storage.read("packages") match {
@@ -87,76 +87,87 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
   test("Maven JARs - package tags created for pqc_jars") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
-    
+
     val config = Config(packageTags = true, packageTagsShortName = false)
     val source = new File("test_data/pqc_jars")
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     // Should have tags for the 4 JAR versions (POMs are not main artifacts)
     assert(packageTags.nonEmpty, "Should create package tags")
-    
+
     // Verify tag structure
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
-      assert(content.isDefined, s"Tag should have content: ${tagItem.identifier}")
-      
+      assert(
+        content.isDefined,
+        s"Tag should have content: ${tagItem.identifier}"
+      )
+
       val fields = content.get
       assert(fields.contains("tag"), s"Tag should have 'tag' field")
       assert(fields.contains("date"), s"Tag should have 'date' field")
       assert(fields.contains("version"), s"Tag should have 'version' field")
-      
+
       // Verify full qualified name format
       val tagValue = fields("tag")
-      assert(tagValue.contains(":"), s"Full name should contain colon: $tagValue")
-      assert(tagValue.startsWith("io.spicelabs.pepperstorm:"), 
-        s"Should have groupId prefix: $tagValue")
+      assert(
+        tagValue.contains(":"),
+        s"Full name should contain colon: $tagValue"
+      )
+      assert(
+        tagValue.startsWith("io.spicelabs.pepperstorm:"),
+        s"Should have groupId prefix: $tagValue"
+      )
     }
   }
 
   test("Maven JARs - short names use artifactId only") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
-    
+
     val config = Config(packageTags = true, packageTagsShortName = true)
     val source = new File("test_data/pqc_jars")
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
       val tagValue = content.get("tag")
-      
+
       // Should NOT contain groupId prefix with short names
-      assert(!tagValue.contains(":"), s"Short name should not contain colon: $tagValue")
+      assert(
+        !tagValue.contains(":"),
+        s"Short name should not contain colon: $tagValue"
+      )
       assertEquals(tagValue, "ps-059-patient-matching-service")
     }
   }
 
   test("Maven JARs - tag edges point to correct artifacts") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
-    
+
     val config = Config(packageTags = true)
     val source = new File("test_data/pqc_jars")
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     // Each tag should have tag:from -> packages and tag:to -> some artifact
     packageTags.foreach { tagItem =>
       val edges = tagItem.connections
-      
-      val hasTagFromPackages = edges.exists {
-        case (edgeType, target) => edgeType == EdgeType.tagFrom && target == "packages"
+
+      val hasTagFromPackages = edges.exists { case (edgeType, target) =>
+        edgeType == EdgeType.tagFrom && target == "packages"
       }
       assert(hasTagFromPackages, s"Tag should have tag:from -> packages edge")
-      
-      val hasTagToArtifact = edges.exists {
-        case (edgeType, _) => edgeType == EdgeType.tagTo
+
+      val hasTagToArtifact = edges.exists { case (edgeType, _) =>
+        edgeType == EdgeType.tagTo
       }
       assert(hasTagToArtifact, s"Tag should have tag:to -> artifact edge")
     }
@@ -165,9 +176,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
   // ==================== Linux Package Tests (.deb) ====================
 
   test("Debian packages - tags created with name and version") {
-    assume(checkTestFile("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb"), 
-      "Debian test data exists")
-    
+    assume(
+      checkTestFile("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb"),
+      "Debian test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb"),
@@ -175,16 +188,16 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     // Baharat strategy should create tags for .deb files
     assert(packageTags.nonEmpty, "Should create package tags for .deb")
-    
+
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
       assert(content.isDefined, "Tag should have content")
-      
+
       val fields = content.get
       assert(fields.contains("tag"), "Should have tag field")
       assert(fields.contains("version"), "Should have version field")
@@ -192,9 +205,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
   }
 
   test("Debian with metadata - extracts build date") {
-    assume(checkTestFile("test_data/debwithmetadata.deb"),
-      "Debian with metadata test data exists")
-    
+    assume(
+      checkTestFile("test_data/debwithmetadata.deb"),
+      "Debian with metadata test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/debwithmetadata.deb"),
@@ -202,13 +217,13 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
       val dateOpt = content.get.get("date")
-      
+
       // Date should be present and valid ISO 8601
       assert(dateOpt.isDefined, "Should extract build date")
       val dateStr = dateOpt.get
@@ -220,9 +235,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
   // ==================== Linux Package Tests (.rpm) ====================
 
   test("RPM packages - tags created with name and version") {
-    assume(checkTestFile("test_data/busybox-1.37.0-160099.8.2.aarch64.rpm"),
-      "RPM test data exists")
-    
+    assume(
+      checkTestFile("test_data/busybox-1.37.0-160099.8.2.aarch64.rpm"),
+      "RPM test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/busybox-1.37.0-160099.8.2.aarch64.rpm"),
@@ -230,11 +247,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     assert(packageTags.nonEmpty, "Should create package tags for .rpm")
-    
+
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
       val fields = content.get
@@ -246,9 +263,13 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
   // ==================== Docker Tests ====================
 
   test("Docker images - tags created with repository and tag") {
-    assume(checkTestFile("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
-      "Docker test data exists")
-    
+    assume(
+      checkTestFile(
+        "test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"
+      ),
+      "Docker test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
@@ -256,30 +277,37 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     assert(packageTags.nonEmpty, "Should create package tags for Docker images")
-    
+
     // Find tag with "bigtent" in name
     val bigtentTag = packageTags.find { tagItem =>
       extractTagContent(tagItem).get.get("tag").exists(_.contains("bigtent"))
     }
-    
+
     assert(bigtentTag.isDefined, "Should have bigtent tag")
-    
+
     val content = extractTagContent(bigtentTag.get)
     val tagValue = content.get("tag")
-    
+
     // Docker tag format should be repository:tag
     assert(tagValue.contains(":"), s"Should have colon separator: $tagValue")
-    assert(tagValue.contains("bigtent"), s"Should contain repository name: $tagValue")
+    assert(
+      tagValue.contains("bigtent"),
+      s"Should contain repository name: $tagValue"
+    )
   }
 
   test("Docker images - extracts created date from config") {
-    assume(checkTestFile("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
-      "Docker test data exists")
-    
+    assume(
+      checkTestFile(
+        "test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"
+      ),
+      "Docker test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
@@ -287,13 +315,13 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
       val dateOpt = content.get.get("date")
-      
+
       assert(dateOpt.isDefined, "Should have date from Docker config")
       val dateStr = dateOpt.get
       assert(dateStr.contains("T"), "Date should have T separator")
@@ -302,9 +330,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
   }
 
   test("Docker complex image - multiple tags created") {
-    assume(checkTestFile("test_data/download/docker_tests/grinder_bt_pg_docker.tar"),
-      "Complex Docker test data exists")
-    
+    assume(
+      checkTestFile("test_data/download/docker_tests/grinder_bt_pg_docker.tar"),
+      "Complex Docker test data exists"
+    )
+
     val config = Config(packageTags = true)
     val source = FileWrapper(
       new File("test_data/download/docker_tests/grinder_bt_pg_docker.tar"),
@@ -312,14 +342,14 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       None
     )
     val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
-    
+
     val packageTags = findPackageTags(storage)
-    
+
     // This image contains postgres, bigtent, and grinder
     val tagNames = packageTags.flatMap { tagItem =>
       extractTagContent(tagItem).get.get("tag")
     }
-    
+
     assert(tagNames.exists(_.contains("postgres")), "Should have postgres tag")
     assert(tagNames.exists(_.contains("bigtent")), "Should have bigtent tag")
     assert(tagNames.exists(_.contains("grinder")), "Should have grinder tag")
@@ -332,35 +362,46 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
     val testCases = Seq(
       ("test_data/pqc_jars", "Maven", true),
       ("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb", "Debian", false),
-      ("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar", "Docker", false)
+      (
+        "test_data/download/docker_tests/bigtent_2025_03_22_docker.tar",
+        "Docker",
+        false
+      )
     ).filter { case (path, _, _) => checkTestFile(path) }
-    
+
     assume(testCases.nonEmpty, "At least one test file exists")
-    
+
     val config = Config(packageTags = true)
-    
+
     testCases.foreach { case (path, strategyName, isDirectory) =>
       val storage = if (isDirectory) {
-        val strategies = ToProcess.strategyForDirectory(new File(path), false, None)
+        val strategies =
+          ToProcess.strategyForDirectory(new File(path), false, None)
         ToProcess.buildGraphForToProcess(strategies, args = config)
       } else {
         val source = FileWrapper(new File(path), path, None)
         ToProcess.buildGraphFromArtifactWrapper(source, args = config)
       }
-      
+
       val packageTags = findPackageTags(storage)
-      
+
       packageTags.foreach { tagItem =>
         val content = extractTagContent(tagItem)
         assert(content.isDefined, s"$strategyName: Tag should have content")
-        
+
         val fields = content.get
         assert(fields.contains("tag"), s"$strategyName: Should have tag field")
-        assert(fields.contains("date"), s"$strategyName: Should have date field")
-        
+        assert(
+          fields.contains("date"),
+          s"$strategyName: Should have date field"
+        )
+
         // Version is optional - may or may not be present
         fields.get("version").foreach { version =>
-          assert(version.nonEmpty, s"$strategyName: Version should not be empty if present")
+          assert(
+            version.nonEmpty,
+            s"$strategyName: Version should not be empty if present"
+          )
         }
       }
     }
@@ -368,15 +409,15 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
   test("Packages index - created on-demand when package-tags enabled") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
-    
+
     val config = Config(packageTags = true)
     val source = new File("test_data/pqc_jars")
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
-    
+
     val packagesItem = storage.read("packages")
     assert(packagesItem.isDefined, "Should create packages index")
-    
+
     // Should have tag:to edges to all package tags
     val tagEdges = packagesItem.get.connections.filter(_._1 == EdgeType.tagTo)
     assert(tagEdges.nonEmpty, "Packages index should have tag:to edges")
@@ -384,13 +425,16 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
   test("Packages index - not created when package-tags disabled") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
-    
+
     val config = Config(packageTags = false)
     val source = new File("test_data/pqc_jars")
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
-    
+
     val packagesItem = storage.read("packages")
-    assert(packagesItem.isEmpty, "Should NOT create packages index when disabled")
+    assert(
+      packagesItem.isEmpty,
+      "Should NOT create packages index when disabled"
+    )
   }
 }

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
@@ -29,8 +29,7 @@ import java.io.File
   *
   * Each test verifies:
   *   - Package tags are created with correct name, version, and date
-  *   - Tags have proper edge connections (tag:from -> packages, tag:to ->
-  *     artifact)
+  *   - Tags have proper edge connections (tag:from -> tags, tag:to -> artifact)
   *   - Packages index is created and populated
   *   - Tag JSON structure follows the specification
   *
@@ -49,32 +48,34 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
   /** Helper to find package tags in storage Returns all items with
     * body_mime_type = application/vnd.cc.goatrodeo.tag that are linked from the
-    * packages index
+    * tags index and have package_tag field
     */
   def findPackageTags(storage: Storage): Vector[Item] = {
-    storage.read("packages") match {
-      case Some(packagesItem) =>
+    storage.read("tags") match {
+      case Some(tagsItem) =>
         val items = for {
-          (edgeType, target) <- packagesItem.connections.toVector
+          (edgeType, target) <- tagsItem.connections.toVector
           if edgeType == EdgeType.tagTo
           item <- storage.read(target)
+          content <- extractTagContent(item)
+          if isBooleanTrue(content, "package_tag")
         } yield item
         items
       case None => Vector.empty
     }
   }
 
-  /** Helper to extract tag content from item */
-  def extractTagContent(item: Item): Option[Map[String, String]] = {
+  /** Helper to extract tag content from item as Map[String, Dom.Element] */
+  def extractTagContent(
+      item: Item
+  ): Option[Map[String, io.bullet.borer.Dom.Element]] = {
     item.body.flatMap {
       case tagData: ItemTagData =>
-        // Parse the borer Dom.Element to extract fields
         import io.bullet.borer.Dom
         tagData.tag match {
           case mapElem: Dom.MapElem =>
-            val fields = mapElem.toMap.collect {
-              case (Dom.StringElem(key), Dom.StringElem(value)) =>
-                key -> value
+            val fields = mapElem.members.collect {
+              case (Dom.StringElem(key), value) => key -> value
             }
             Some(fields.toMap)
           case _ => None
@@ -82,6 +83,25 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       case _ => None
     }
   }
+
+  /** Helper to extract a string field from tag content */
+  def stringField(
+      content: Map[String, io.bullet.borer.Dom.Element],
+      key: String
+  ): Option[String] =
+    content.get(key).collect { case io.bullet.borer.Dom.StringElem(value) =>
+      value
+    }
+
+  /** Helper to check if a boolean field is true */
+  def isBooleanTrue(
+      content: Map[String, io.bullet.borer.Dom.Element],
+      key: String
+  ): Boolean =
+    content.get(key) match {
+      case Some(io.bullet.borer.Dom.BooleanElem(value)) => value
+      case _                                            => false
+    }
 
   // ==================== Maven JAR Tests ====================
 
@@ -112,7 +132,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
       assert(fields.contains("version"), s"Tag should have 'version' field")
 
       // Verify full qualified name format
-      val tagValue = fields("tag")
+      val tagValue = stringField(fields, "tag").get
       assert(
         tagValue.contains(":"),
         s"Full name should contain colon: $tagValue"
@@ -136,7 +156,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
-      val tagValue = content.get("tag")
+      val tagValue = stringField(content.get, "tag").get
 
       // Should NOT contain groupId prefix with short names
       assert(
@@ -157,14 +177,14 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     val packageTags = findPackageTags(storage)
 
-    // Each tag should have tag:from -> packages and tag:to -> some artifact
+    // Each tag should have tag:from -> tags and tag:to -> some artifact
     packageTags.foreach { tagItem =>
       val edges = tagItem.connections
 
-      val hasTagFromPackages = edges.exists { case (edgeType, target) =>
-        edgeType == EdgeType.tagFrom && target == "packages"
+      val hasTagFromTags = edges.exists { case (edgeType, target) =>
+        edgeType == EdgeType.tagFrom && target == "tags"
       }
-      assert(hasTagFromPackages, s"Tag should have tag:from -> packages edge")
+      assert(hasTagFromTags, s"Tag should have tag:from -> tags edge")
 
       val hasTagToArtifact = edges.exists { case (edgeType, _) =>
         edgeType == EdgeType.tagTo
@@ -222,7 +242,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
-      val dateOpt = content.get.get("date")
+      val dateOpt = stringField(content.get, "date")
 
       // Date should be present and valid ISO 8601
       assert(dateOpt.isDefined, "Should extract build date")
@@ -284,13 +304,14 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     // Find tag with "bigtent" in name
     val bigtentTag = packageTags.find { tagItem =>
-      extractTagContent(tagItem).get.get("tag").exists(_.contains("bigtent"))
+      stringField(extractTagContent(tagItem).get, "tag")
+        .exists(_.contains("bigtent"))
     }
 
     assert(bigtentTag.isDefined, "Should have bigtent tag")
 
     val content = extractTagContent(bigtentTag.get)
-    val tagValue = content.get("tag")
+    val tagValue = stringField(content.get, "tag").get
 
     // Docker tag format should be repository:tag
     assert(tagValue.contains(":"), s"Should have colon separator: $tagValue")
@@ -320,7 +341,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     packageTags.foreach { tagItem =>
       val content = extractTagContent(tagItem)
-      val dateOpt = content.get.get("date")
+      val dateOpt = stringField(content.get, "date")
 
       assert(dateOpt.isDefined, "Should have date from Docker config")
       val dateStr = dateOpt.get
@@ -347,7 +368,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
 
     // This image contains postgres, bigtent, and grinder
     val tagNames = packageTags.flatMap { tagItem =>
-      extractTagContent(tagItem).get.get("tag")
+      stringField(extractTagContent(tagItem).get, "tag")
     }
 
     assert(tagNames.exists(_.contains("postgres")), "Should have postgres tag")
@@ -397,7 +418,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
         )
 
         // Version is optional - may or may not be present
-        fields.get("version").foreach { version =>
+        stringField(fields, "version").foreach { version =>
           assert(
             version.nonEmpty,
             s"$strategyName: Version should not be empty if present"
@@ -407,7 +428,7 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
     }
   }
 
-  test("Packages index - created on-demand when package-tags enabled") {
+  test("Tags index - contains package tags when package-tags enabled") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
 
     val config = Config(packageTags = true)
@@ -415,15 +436,18 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
 
-    val packagesItem = storage.read("packages")
-    assert(packagesItem.isDefined, "Should create packages index")
+    val tagsItem = storage.read("tags")
+    assert(tagsItem.isDefined, "Should create tags index")
 
-    // Should have tag:to edges to all package tags
-    val tagEdges = packagesItem.get.connections.filter(_._1 == EdgeType.tagTo)
-    assert(tagEdges.nonEmpty, "Packages index should have tag:to edges")
+    // Should have tag:to edges to package tags
+    val tagEdges = tagsItem.get.connections.filter(_._1 == EdgeType.tagTo)
+    assert(
+      tagEdges.nonEmpty,
+      "Tags index should have tag:to edges to package tags"
+    )
   }
 
-  test("Packages index - not created when package-tags disabled") {
+  test("Tags index - no package tag edges when package-tags disabled") {
     assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
 
     val config = Config(packageTags = false)
@@ -431,10 +455,11 @@ class PackageTagIntegrationSuite extends munit.FunSuite {
     val strategies = ToProcess.strategyForDirectory(source, false, None)
     val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
 
-    val packagesItem = storage.read("packages")
+    // Without --tag or --package-tags, tags index should not exist
+    val tagsItem = storage.read("tags")
     assert(
-      packagesItem.isEmpty,
-      "Should NOT create packages index when disabled"
+      tagsItem.isEmpty,
+      "Should NOT create tags index when neither --tag nor --package-tags enabled"
     )
   }
 }

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
@@ -1,0 +1,396 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.omnibor
+
+import io.spicelabs.goatrodeo.util.{ByteWrapper, Config, FileWrapper}
+
+import java.io.File
+import java.nio.file.{Files, Path}
+import scala.collection.immutable.TreeSet
+
+/** Phase 7 Integration Tests: Per-Package Tagging with Real Test Data
+  *
+  * These tests verify that the per-package tagging feature works correctly
+  * with actual test corpus files:
+  * - Maven JARs from test_data/pqc_jars
+  * - Linux packages (.deb, .rpm) from test_data/
+  * - Docker images from test_data/download/docker_tests
+  *
+  * Each test verifies:
+  * - Package tags are created with correct name, version, and date
+  * - Tags have proper edge connections (tag:from -> packages, tag:to -> artifact)
+  * - Packages index is created and populated
+  * - Tag JSON structure follows the specification
+  *
+  * Requirement Traceability:
+  * - R1: --package-tags CLI option generates tags
+  * - R2: --package-tags-short-name generates short names
+  * - R3: Tag JSON has correct structure (tag, version, date)
+  * - R4: Maven strategy extracts GAV and build date
+  * - R5: Baharat strategy extracts name/version from .deb
+  * - R6: Docker strategy extracts repository:tag and created date
+  */
+class PackageTagIntegrationSuite extends munit.FunSuite {
+
+  // Helper to check if test files exist
+  def checkTestFile(path: String): Boolean = new File(path).exists()
+
+  /** Helper to find package tags in storage
+    * Returns all items with body_mime_type = application/vnd.cc.goatrodeo.tag
+    * that are linked from the packages index
+    */
+  def findPackageTags(storage: Storage): Vector[Item] = {
+    storage.read("packages") match {
+      case Some(packagesItem) =>
+        val items = for {
+          (edgeType, target) <- packagesItem.connections.toVector
+          if edgeType == EdgeType.tagTo
+          item <- storage.read(target)
+        } yield item
+        items
+      case None => Vector.empty
+    }
+  }
+
+  /** Helper to extract tag content from item */
+  def extractTagContent(item: Item): Option[Map[String, String]] = {
+    item.body.flatMap {
+      case tagData: ItemTagData =>
+        // Parse the borer Dom.Element to extract fields
+        import io.bullet.borer.Dom
+        tagData.tag match {
+          case mapElem: Dom.MapElem =>
+            val fields = mapElem.toMap.collect {
+              case (Dom.StringElem(key), Dom.StringElem(value)) =>
+                key -> value
+            }
+            Some(fields.toMap)
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  // ==================== Maven JAR Tests ====================
+
+  test("Maven JARs - package tags created for pqc_jars") {
+    assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
+    
+    val config = Config(packageTags = true, packageTagsShortName = false)
+    val source = new File("test_data/pqc_jars")
+    val strategies = ToProcess.strategyForDirectory(source, false, None)
+    val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    // Should have tags for the 4 JAR versions (POMs are not main artifacts)
+    assert(packageTags.nonEmpty, "Should create package tags")
+    
+    // Verify tag structure
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      assert(content.isDefined, s"Tag should have content: ${tagItem.identifier}")
+      
+      val fields = content.get
+      assert(fields.contains("tag"), s"Tag should have 'tag' field")
+      assert(fields.contains("date"), s"Tag should have 'date' field")
+      assert(fields.contains("version"), s"Tag should have 'version' field")
+      
+      // Verify full qualified name format
+      val tagValue = fields("tag")
+      assert(tagValue.contains(":"), s"Full name should contain colon: $tagValue")
+      assert(tagValue.startsWith("io.spicelabs.pepperstorm:"), 
+        s"Should have groupId prefix: $tagValue")
+    }
+  }
+
+  test("Maven JARs - short names use artifactId only") {
+    assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
+    
+    val config = Config(packageTags = true, packageTagsShortName = true)
+    val source = new File("test_data/pqc_jars")
+    val strategies = ToProcess.strategyForDirectory(source, false, None)
+    val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      val tagValue = content.get("tag")
+      
+      // Should NOT contain groupId prefix with short names
+      assert(!tagValue.contains(":"), s"Short name should not contain colon: $tagValue")
+      assertEquals(tagValue, "ps-059-patient-matching-service")
+    }
+  }
+
+  test("Maven JARs - tag edges point to correct artifacts") {
+    assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = new File("test_data/pqc_jars")
+    val strategies = ToProcess.strategyForDirectory(source, false, None)
+    val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    // Each tag should have tag:from -> packages and tag:to -> some artifact
+    packageTags.foreach { tagItem =>
+      val edges = tagItem.connections
+      
+      val hasTagFromPackages = edges.exists {
+        case (edgeType, target) => edgeType == EdgeType.tagFrom && target == "packages"
+      }
+      assert(hasTagFromPackages, s"Tag should have tag:from -> packages edge")
+      
+      val hasTagToArtifact = edges.exists {
+        case (edgeType, _) => edgeType == EdgeType.tagTo
+      }
+      assert(hasTagToArtifact, s"Tag should have tag:to -> artifact edge")
+    }
+  }
+
+  // ==================== Linux Package Tests (.deb) ====================
+
+  test("Debian packages - tags created with name and version") {
+    assume(checkTestFile("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb"), 
+      "Debian test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb"),
+      "libasound2_1.1.3-5ubuntu0.6_amd64.deb",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    // Baharat strategy should create tags for .deb files
+    assert(packageTags.nonEmpty, "Should create package tags for .deb")
+    
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      assert(content.isDefined, "Tag should have content")
+      
+      val fields = content.get
+      assert(fields.contains("tag"), "Should have tag field")
+      assert(fields.contains("version"), "Should have version field")
+    }
+  }
+
+  test("Debian with metadata - extracts build date") {
+    assume(checkTestFile("test_data/debwithmetadata.deb"),
+      "Debian with metadata test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/debwithmetadata.deb"),
+      "debwithmetadata.deb",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      val dateOpt = content.get.get("date")
+      
+      // Date should be present and valid ISO 8601
+      assert(dateOpt.isDefined, "Should extract build date")
+      val dateStr = dateOpt.get
+      assert(dateStr.contains("T"), "Date should have T separator")
+      assert(dateStr.endsWith("Z"), "Date should end with Z")
+    }
+  }
+
+  // ==================== Linux Package Tests (.rpm) ====================
+
+  test("RPM packages - tags created with name and version") {
+    assume(checkTestFile("test_data/busybox-1.37.0-160099.8.2.aarch64.rpm"),
+      "RPM test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/busybox-1.37.0-160099.8.2.aarch64.rpm"),
+      "busybox-1.37.0-160099.8.2.aarch64.rpm",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    assert(packageTags.nonEmpty, "Should create package tags for .rpm")
+    
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      val fields = content.get
+      assert(fields.contains("tag"), "Should have tag field")
+      assert(fields.contains("version"), "Should have version field")
+    }
+  }
+
+  // ==================== Docker Tests ====================
+
+  test("Docker images - tags created with repository and tag") {
+    assume(checkTestFile("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
+      "Docker test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
+      "bigtent_2025_03_22_docker.tar",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    assert(packageTags.nonEmpty, "Should create package tags for Docker images")
+    
+    // Find tag with "bigtent" in name
+    val bigtentTag = packageTags.find { tagItem =>
+      extractTagContent(tagItem).get.get("tag").exists(_.contains("bigtent"))
+    }
+    
+    assert(bigtentTag.isDefined, "Should have bigtent tag")
+    
+    val content = extractTagContent(bigtentTag.get)
+    val tagValue = content.get("tag")
+    
+    // Docker tag format should be repository:tag
+    assert(tagValue.contains(":"), s"Should have colon separator: $tagValue")
+    assert(tagValue.contains("bigtent"), s"Should contain repository name: $tagValue")
+  }
+
+  test("Docker images - extracts created date from config") {
+    assume(checkTestFile("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
+      "Docker test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar"),
+      "bigtent_2025_03_22_docker.tar",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    packageTags.foreach { tagItem =>
+      val content = extractTagContent(tagItem)
+      val dateOpt = content.get.get("date")
+      
+      assert(dateOpt.isDefined, "Should have date from Docker config")
+      val dateStr = dateOpt.get
+      assert(dateStr.contains("T"), "Date should have T separator")
+      assert(dateStr.endsWith("Z"), "Date should end with Z")
+    }
+  }
+
+  test("Docker complex image - multiple tags created") {
+    assume(checkTestFile("test_data/download/docker_tests/grinder_bt_pg_docker.tar"),
+      "Complex Docker test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = FileWrapper(
+      new File("test_data/download/docker_tests/grinder_bt_pg_docker.tar"),
+      "grinder_bt_pg_docker.tar",
+      None
+    )
+    val storage = ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+    
+    val packageTags = findPackageTags(storage)
+    
+    // This image contains postgres, bigtent, and grinder
+    val tagNames = packageTags.flatMap { tagItem =>
+      extractTagContent(tagItem).get.get("tag")
+    }
+    
+    assert(tagNames.exists(_.contains("postgres")), "Should have postgres tag")
+    assert(tagNames.exists(_.contains("bigtent")), "Should have bigtent tag")
+    assert(tagNames.exists(_.contains("grinder")), "Should have grinder tag")
+  }
+
+  // ==================== Cross-Strategy Validation ====================
+
+  test("All strategies - tag JSON has consistent structure") {
+    // Test Maven from directory and individual files for others
+    val testCases = Seq(
+      ("test_data/pqc_jars", "Maven", true),
+      ("test_data/libasound2_1.1.3-5ubuntu0.6_amd64.deb", "Debian", false),
+      ("test_data/download/docker_tests/bigtent_2025_03_22_docker.tar", "Docker", false)
+    ).filter { case (path, _, _) => checkTestFile(path) }
+    
+    assume(testCases.nonEmpty, "At least one test file exists")
+    
+    val config = Config(packageTags = true)
+    
+    testCases.foreach { case (path, strategyName, isDirectory) =>
+      val storage = if (isDirectory) {
+        val strategies = ToProcess.strategyForDirectory(new File(path), false, None)
+        ToProcess.buildGraphForToProcess(strategies, args = config)
+      } else {
+        val source = FileWrapper(new File(path), path, None)
+        ToProcess.buildGraphFromArtifactWrapper(source, args = config)
+      }
+      
+      val packageTags = findPackageTags(storage)
+      
+      packageTags.foreach { tagItem =>
+        val content = extractTagContent(tagItem)
+        assert(content.isDefined, s"$strategyName: Tag should have content")
+        
+        val fields = content.get
+        assert(fields.contains("tag"), s"$strategyName: Should have tag field")
+        assert(fields.contains("date"), s"$strategyName: Should have date field")
+        
+        // Version is optional - may or may not be present
+        fields.get("version").foreach { version =>
+          assert(version.nonEmpty, s"$strategyName: Version should not be empty if present")
+        }
+      }
+    }
+  }
+
+  test("Packages index - created on-demand when package-tags enabled") {
+    assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
+    
+    val config = Config(packageTags = true)
+    val source = new File("test_data/pqc_jars")
+    val strategies = ToProcess.strategyForDirectory(source, false, None)
+    val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
+    
+    val packagesItem = storage.read("packages")
+    assert(packagesItem.isDefined, "Should create packages index")
+    
+    // Should have tag:to edges to all package tags
+    val tagEdges = packagesItem.get.connections.filter(_._1 == EdgeType.tagTo)
+    assert(tagEdges.nonEmpty, "Packages index should have tag:to edges")
+  }
+
+  test("Packages index - not created when package-tags disabled") {
+    assume(checkTestFile("test_data/pqc_jars"), "pqc_jars test data exists")
+    
+    val config = Config(packageTags = false)
+    val source = new File("test_data/pqc_jars")
+    val strategies = ToProcess.strategyForDirectory(source, false, None)
+    val storage = ToProcess.buildGraphForToProcess(strategies, args = config)
+    
+    val packagesItem = storage.read("packages")
+    assert(packagesItem.isEmpty, "Should NOT create packages index when disabled")
+  }
+}

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -147,14 +147,14 @@ class CertificatesStubTests extends FunSuite {
   // phases requires explicit user approval before it lands.
 
   test(
-    "[STUB] CryptoDetector.mimeTypeAugmenter returns currentMimes unchanged for empty set"
+    "CryptoDetector.mimeTypeAugmenter returns currentMimes unchanged for empty set"
   ) {
     val out = CryptoDetector.mimeTypeAugmenter(syntheticArtifact(), Set.empty)
     assertEquals(out, Set.empty[String])
   }
 
   test(
-    "[STUB] CryptoDetector.mimeTypeAugmenter on a typical Tika-ish set returns it identically (Phase 1 only — Phase 2 will add MIMEs for cert-shaped fixtures)"
+    "CryptoDetector.mimeTypeAugmenter on a typical Tika-ish set returns it identically (Phase 1 only — Phase 2 will add MIMEs for cert-shaped fixtures)"
   ) {
     val input = Set(
       "application/octet-stream",
@@ -171,7 +171,7 @@ class CertificatesStubTests extends FunSuite {
   // === SECTION B continued — Phase-1-STUB-specific (Certificates) ========
 
   test(
-    "[STUB] Certificates.computeCertificateFiles returns (empty Vector, byUUID, byName, \"Certificates\") at Phase 1 (claim-nothing dispatcher)"
+    "Certificates.computeCertificateFiles returns (empty Vector, byUUID, byName, \"Certificates\") at Phase 1 (claim-nothing dispatcher)"
   ) {
     val byUUID: io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID = Map.empty
     val byName: io.spicelabs.goatrodeo.omnibor.ToProcess.ByName = Map.empty
@@ -196,7 +196,7 @@ class CertificatesStubTests extends FunSuite {
   }
 
   test(
-    "[STUB] Certificates.computeCertificateFiles preserves a single-entry byUUID map identity (claim-nothing → no map mutation)"
+    "Certificates.computeCertificateFiles preserves a single-entry byUUID map identity (claim-nothing → no map mutation)"
   ) {
     val art = syntheticArtifact()
     val byUUID: io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID =
@@ -212,7 +212,7 @@ class CertificatesStubTests extends FunSuite {
   }
 
   test(
-    "[STUB] Certificates.computeCertificateFiles preserves a single-entry byName map identity (claim-nothing → no map mutation)"
+    "Certificates.computeCertificateFiles preserves a single-entry byName map identity (claim-nothing → no map mutation)"
   ) {
     val art = syntheticArtifact("foo.pem")
     val byUUID: io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID = Map.empty
@@ -226,7 +226,7 @@ class CertificatesStubTests extends FunSuite {
   // === SECTION B continued — Phase-1-STUB-specific (CertificatesState) ===
 
   test(
-    "[STUB] CertificatesState.beginProcessing returns this (identity pass-through; Phase 3+ will use this stage to cache parsed cert)"
+    "CertificatesState.beginProcessing returns this (identity pass-through; Phase 3+ will use this stage to cache parsed cert)"
   ) {
     val art = syntheticArtifact()
     val state = new CertificatesState(art)
@@ -235,7 +235,7 @@ class CertificatesStubTests extends FunSuite {
   }
 
   test(
-    "[STUB] CertificatesState.getPurls returns (empty Vector, this) at Phase 1 (Phase 3+ emits per-cert pURLs)"
+    "CertificatesState.getPurls returns (empty Vector, this) at Phase 1 (Phase 3+ emits per-cert pURLs)"
   ) {
     val art = syntheticArtifact()
     val state = new CertificatesState(art)
@@ -246,7 +246,7 @@ class CertificatesStubTests extends FunSuite {
   }
 
   test(
-    "[STUB] CertificatesState.getMetadata returns (empty TreeMap, this) at Phase 1 (Phase 3+ emits per-cert metadata)"
+    "CertificatesState.getMetadata returns (empty TreeMap, this) at Phase 1 (Phase 3+ emits per-cert metadata)"
   ) {
     val art = syntheticArtifact()
     val state = new CertificatesState(art)
@@ -257,7 +257,7 @@ class CertificatesStubTests extends FunSuite {
   }
 
   test(
-    "[STUB] CertificatesState.finalAugmentation returns the input Item unchanged at Phase 1 (Phase 3+ runs the leak sweep here)"
+    "CertificatesState.finalAugmentation returns the input Item unchanged at Phase 1 (Phase 3+ runs the leak sweep here)"
   ) {
     val art = syntheticArtifact()
     val state = new CertificatesState(art)

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v1.0.0/ps-059-patient-matching-service-v1.0.0.jar
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v1.0.0/ps-059-patient-matching-service-v1.0.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:125c9b039cc3fdb0996a2ad599df7e8cb571f19590547fbecdc489602698ed85
+size 8819858

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v1.0.0/ps-059-patient-matching-service-v1.0.0.pom
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v1.0.0/ps-059-patient-matching-service-v1.0.0.pom
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.spicelabs.pepperstorm</groupId>
+  <artifactId>ps-059-patient-matching-service</artifactId>
+  <version>v1.0.0</version>
+  <packaging>jar</packaging>
+  <name>ps-059-v1-patient-matching-service</name>
+</project>

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v2.0.0/ps-059-patient-matching-service-v2.0.0.jar
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v2.0.0/ps-059-patient-matching-service-v2.0.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d381ea13497c73868829be247064c66303a160086bb5e9fa42c866751eb07482
+size 12912204

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v2.0.0/ps-059-patient-matching-service-v2.0.0.pom
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v2.0.0/ps-059-patient-matching-service-v2.0.0.pom
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.spicelabs.pepperstorm</groupId>
+  <artifactId>ps-059-patient-matching-service</artifactId>
+  <version>v2.0.0</version>
+  <packaging>jar</packaging>
+  <name>ps-059-v2-patient-matching-service</name>
+</project>

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v3.0.0/ps-059-patient-matching-service-v3.0.0.jar
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v3.0.0/ps-059-patient-matching-service-v3.0.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f5d09f9c1a70357559b7ec044bef6cb92b6db66fce555ac74e2457ff58ca0b5
+size 11644740

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v3.0.0/ps-059-patient-matching-service-v3.0.0.pom
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v3.0.0/ps-059-patient-matching-service-v3.0.0.pom
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.spicelabs.pepperstorm</groupId>
+  <artifactId>ps-059-patient-matching-service</artifactId>
+  <version>v3.0.0</version>
+  <packaging>jar</packaging>
+  <name>ps-059-v3-patient-matching-service</name>
+</project>

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v4.0.0/ps-059-patient-matching-service-v4.0.0.jar
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v4.0.0/ps-059-patient-matching-service-v4.0.0.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aec1c85d66e273e2a7bd39c2170d95c7ec99770309342919327fbe8740303f01
+size 11564753

--- a/test_data/pqc_jars/ps-059-patient-matching-service/v4.0.0/ps-059-patient-matching-service-v4.0.0.pom
+++ b/test_data/pqc_jars/ps-059-patient-matching-service/v4.0.0/ps-059-patient-matching-service-v4.0.0.pom
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.spicelabs.pepperstorm</groupId>
+  <artifactId>ps-059-patient-matching-service</artifactId>
+  <version>v4.0.0</version>
+  <packaging>jar</packaging>
+  <name>ps-059-v4-patient-matching-service</name>
+</project>


### PR DESCRIPTION
This PR adds two related tagging features to Goat Rodeo:
1. Per-Package Tags (`--package-tags`)
Automatically creates individual tags for each detected package, capturing name, version, and build date. A packages index item links to all per-package tags.
    - `--package-tags` — enables per-package tagging
    - `--package-tags-short-name` — uses short names (e.g., `artifactId` instead of `groupId:artifactId`)
    
    Supported strategies:

    | Strategy | Tag Name Source | Version Source | Date Source |
    | --------- | --------- | -------- | ---------------- |
    | Maven | `groupId:artifactId` | POM version | `MANIFEST.MF` / POM properties |
    | Docker | `repository:tag` | tag portion after : | — |
    | Baharat (.deb/.rpm) | package name | package version | `buildTime` metadata |
    | Annatto | package name | package version | `publishedAt` metadata |
    | Dotnet | assembly name | assembly version	| — |
    

2. Top-Level Tag Version and Date (--tag-version, --tag-date)
Extends the existing `--tag` option to include version and date fields in the top-level tag JSON.
    - `--tag-version <version>` — sets version field (requires `--tag`)
    - `--tag-date <date>` — sets date field, parsed flexibly via `DateTimeFormatter` (requires `--tag`)
    - CLI validates that `--tag-version`/`--tag-date` are only used with `--tag`
    - Date output is always ISO 8601 UTC

New files:
- `DateParser.scala` — flexible date parsing using `java.time.format.DateTimeFormatter`
- `PackageTagInfoSuite.scala`, `PackageTagContractSuite.scala`, `PackageTagIntegrationSuite.scala` — test suites (12 integration tests pass)
Modified files: `Config.scala`, `Builder.scala`, `ToProcess.scala`, `Item.scala`, `GoatRodeoBuilder.scala`, `Maven.scala`, `Docker.scala`, `Baharat.scala`, `Annatto.scala`, `Dotnet.scala`