### PR TITLE
Performance enhancements (about 30% faster)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,6 +22,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Free up disk space on the runner
+      # ADGTests downloads repo_ea.tgz (~5.2 GiB) and untars it (~5.2 GiB)
+      # into test_data/download/adg_tests/. On ubuntu-24.04 the default
+      # ~14 GiB of free space is just barely enough; if the runner has
+      # any other consumers (Docker, browser stacks, etc.) the untar
+      # silently truncates and ADGTests later fails with missing-JAR
+      # errors. Reclaim the chunky pre-installed toolchains we don't use
+      # before the test data is materialised.
+      run: |
+        df -h /
+        sudo rm -rf /usr/share/dotnet /usr/share/swift /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+        sudo docker image prune --all --force || true
+        df -h /
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala
@@ -110,27 +110,43 @@ case class DataFileEnvelope(
     previous: Long,
     @key("depends_on") dependsOn: TreeSet[Long],
     @key("built_from_merge") builtFromMerge: Boolean,
-    info: TreeMap[String, String]
+    info: TreeMap[String, String],
+    @key("alias_map") aliasMap: TreeMap[String, TreeSet[String]] = TreeMap.empty
 ) derives Codec {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
 }
 
 object DataFileEnvelope {
-  val DataFileEnvelopeVersion = 1
+  /** v1: legacy edge encoding (each connection is a `(String, String)` tuple
+    * with the target gitoid repeated in full).
+    *
+    * v2: streamed encoding with `WireEdge`. Items are written in topological
+    * order along forward content edges (`contained:up` / `build:down`), and
+    * each connection is encoded as a compact tagged array — `SameFile`,
+    * `CrossFile`, `External`, or `UnknownType` per `WireEdge`.
+    *
+    * v3: adds `aliasMap` (canonical id → set of alternate identifiers).
+    * Alternate-form Items (one per non-canonical identifier) are collapsed
+    * into their canonical at write time; the alias relationships move into
+    * the table. On read, the alias edges (`alias:from` / `alias:to`) are
+    * synthesised back into `Item.connections` from this table. */
+  val DataFileEnvelopeVersion = 3
   def build(
       version: Int = DataFileEnvelopeVersion,
       magic: Int = GraphManager.Consts.DataFileMagicNumber,
       previous: Long,
       dependsOn: TreeSet[Long] = TreeSet(),
       builtFromMerge: Boolean,
-      info: TreeMap[String, String] = TreeMap()
+      info: TreeMap[String, String] = TreeMap(),
+      aliasMap: TreeMap[String, TreeSet[String]] = TreeMap.empty
   ): DataFileEnvelope = DataFileEnvelope(
     version,
     magic,
     previous,
     dependsOn,
     builtFromMerge,
-    info
+    info,
+    aliasMap
   )
 
   def decode(bytes: Array[Byte]): Try[DataFileEnvelope] = {

--- a/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala
@@ -110,8 +110,7 @@ case class DataFileEnvelope(
     previous: Long,
     @key("depends_on") dependsOn: TreeSet[Long],
     @key("built_from_merge") builtFromMerge: Boolean,
-    info: TreeMap[String, String],
-    @key("alias_map") aliasMap: TreeMap[String, TreeSet[String]] = TreeMap.empty
+    info: TreeMap[String, String]
 ) derives Codec {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
 }
@@ -125,28 +124,31 @@ object DataFileEnvelope {
     * each connection is encoded as a compact tagged array — `SameFile`,
     * `CrossFile`, `External`, or `UnknownType` per `WireEdge`.
     *
-    * v3: adds `aliasMap` (canonical id → set of alternate identifiers).
-    * Alternate-form Items (one per non-canonical identifier) are collapsed
-    * into their canonical at write time; the alias relationships move into
-    * the table. On read, the alias edges (`alias:from` / `alias:to`) are
-    * synthesised back into `Item.connections` from this table. */
-  val DataFileEnvelopeVersion = 3
+    * v3: alias collapse — alternate-form Items are merged into their
+    * canonical at write time and the alias relationships move into a
+    * cluster-wide alias map. v3 embedded that table into each DataFile
+    * envelope, which silently corrupted the file once the encoded map
+    * exceeded 64 KiB (the envelope length prefix is a `u16`). v3 should
+    * be considered broken and is no longer produced.
+    *
+    * v4: identical streamed item format as v2/v3, but the alias map now
+    * lives in a separate alias-map sidecar file referenced by hash from
+    * `ClusterFileEnvelope.aliasMapFile`. DataFile envelopes stay small. */
+  val DataFileEnvelopeVersion = 4
   def build(
       version: Int = DataFileEnvelopeVersion,
       magic: Int = GraphManager.Consts.DataFileMagicNumber,
       previous: Long,
       dependsOn: TreeSet[Long] = TreeSet(),
       builtFromMerge: Boolean,
-      info: TreeMap[String, String] = TreeMap(),
-      aliasMap: TreeMap[String, TreeSet[String]] = TreeMap.empty
+      info: TreeMap[String, String] = TreeMap()
   ): DataFileEnvelope = DataFileEnvelope(
     version,
     magic,
     previous,
     dependsOn,
     builtFromMerge,
-    info,
-    aliasMap
+    info
   )
 
   def decode(bytes: Array[Byte]): Try[DataFileEnvelope] = {
@@ -193,27 +195,41 @@ case class ClusterFileEnvelope(
     magic: Int,
     @key("data_files") dataFiles: Vector[Long],
     @key("index_files") indexFiles: Vector[Long],
-    info: TreeMap[String, String]
+    info: TreeMap[String, String],
+    /** Hash of the cluster-wide alias-map sidecar file
+      * (`<hash>.gra`), if one was written. Encoded as a CBOR null when
+      * absent so older readers that don't know about the field default
+      * cleanly. v3 readers see this as an unknown field and silently
+      * ignore it. */
+    @key("alias_map_file") aliasMapFile: Option[Long] = None
 ) {
   def encode(): Array[Byte] = Cbor.encode(this).toByteArray
 
 }
 
 object ClusterFileEnvelope {
-  val ClusterFileEnvelopeVersion = 3
+  /** v3: cluster envelope shipped alongside per-DataFile `aliasMap`
+    *     embedding. Obsolete — see [[DataFileEnvelope]] notes.
+    *
+    * v4: cluster envelope carries an optional `aliasMapFile` hash
+    *     referencing the cluster-wide alias map written as a separate
+    *     `<hash>.gra` sidecar file. */
+  val ClusterFileEnvelopeVersion = 4
 
   def build(
       version: Int = ClusterFileEnvelopeVersion,
       magic: Int = GraphManager.Consts.ClusterFileMagicNumber,
       dataFiles: Vector[Long],
       indexFiles: Vector[Long],
-      info: TreeMap[String, String] = TreeMap()
+      info: TreeMap[String, String] = TreeMap(),
+      aliasMapFile: Option[Long] = None
   ): ClusterFileEnvelope = ClusterFileEnvelope(
     version = version,
     magic = magic,
     dataFiles = dataFiles,
     indexFiles = indexFiles,
-    info = info
+    info = info,
+    aliasMapFile = aliasMapFile
   )
 
   given forOption[T: Encoder]: Encoder.DefaultValueAware[Option[T]] =

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
-import scala.collection.parallel.CollectionConverters.VectorIsParallelizable
 import scala.util.Try
 
 /** Build the GitOIDs the container and all the sub-elements found in the
@@ -271,7 +270,7 @@ object Builder {
           item =>
             Some(
               Item(
-                tag.gitoid(),
+                io.spicelabs.goatrodeo.util.Identifier.fromGitoid(tag.gitoid),
                 TreeSet(EdgeType.tagFrom -> "tags"),
                 Some(ItemTagData.mimeType),
                 Some(ItemTagData(tag.json))
@@ -520,29 +519,18 @@ object Builder {
 
         // make sure the destination exists
         target.getAbsoluteFile().mkdirs()
-        val sorted = {
-          val allItems = store
-            .pathsSortedWithMD5()
-            .flatMap(v => store.read(v._2))
-
-          allItems
-        }
+        val (sorted, aliasMap) = store.prepareForWrite()
 
         logger.info(
-          f"Post-sort at ${Duration.between(start, Instant.now())}"
-        )
-
-        sorted.par.foreach(_.cachedCBOR)
-
-        logger.info(
-          f"Post CBOR cache at ${Duration.between(start, Instant.now())}"
+          f"Post-sort at ${Duration.between(start, Instant.now())} (aliasMap entries: ${aliasMap.size}, items after collapse: ${sorted.length})"
         )
 
         val cnt = sorted.length
 
         val ret = GraphManager.writeEntries(
           target,
-          sorted.iterator
+          sorted.iterator,
+          aliasMap
         )
 
         logger.info(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -262,7 +262,7 @@ object Builder {
           "tags",
           item =>
             Some(
-              Item(Gitoid("tags"), TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
+              Item(Item.tagsRootIdentifier, TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
             ),
           item => "set up tags"
         )
@@ -271,7 +271,7 @@ object Builder {
           item =>
             Some(
               Item(
-                tag.gitoid,
+                tag.gitoid(),
                 TreeSet(EdgeType.tagFrom -> "tags"),
                 Some(ItemTagData.mimeType),
                 Some(ItemTagData(tag.json))

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -18,6 +18,7 @@ import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
 
@@ -144,14 +145,14 @@ object Builder {
     }
 
     // Get the gitoids to block
-    val blockGitoids: Set[String] = blockList match {
+    val blockGitoids: Set[Gitoid] = blockList match {
       case None => Set()
       case Some(file) =>
         Try {
           import scala.jdk.CollectionConverters.CollectionHasAsScala
 
           val lines = Files.readAllLines(file.toPath()).asScala.toSet
-          lines
+          lines.map(Gitoid(_))
         }.toOption match {
           case None    => Set()
           case Some(s) => s
@@ -238,7 +239,7 @@ object Builder {
       maxRecords: Int,
       queue: ConcurrentLinkedQueue[ToProcess],
       stillWorking: AtomicBoolean,
-      blockGitoids: Set[String],
+      blockGitoids: Set[Gitoid],
       cnt: AtomicInteger,
       tag: Option[TagPass],
       runningCnt: AtomicInteger,
@@ -261,12 +262,12 @@ object Builder {
           "tags",
           item =>
             Some(
-              Item("tags", TreeSet(EdgeType.tagTo -> tag.gitoid), None, None)
+              Item(Gitoid("tags"), TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
             ),
           item => "set up tags"
         )
         storage.write(
-          tag.gitoid,
+          tag.gitoid(),
           item =>
             Some(
               Item(
@@ -556,4 +557,4 @@ object Builder {
   }
 }
 
-case class TagPass(gitoid: String, jsonStr: String, json: Dom.Element)
+case class TagPass(gitoid: Gitoid, jsonStr: String, json: Dom.Element)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala
@@ -37,7 +37,11 @@ object IndexFile {
         )
       }
 
-      val indexEnv: IndexFileEnvelope = Helpers.readLenAndCBOR(ipf)
+      // Envelope length is written as a 2-byte short by `writeABlock`, so
+      // we must read it the same way here. (Helpers.readLenAndCBOR reads
+      // a 4-byte int, which doesn't match the wire format.)
+      val envLen = Helpers.readShort(ipf)
+      val indexEnv: IndexFileEnvelope = Helpers.readCBOR(ipf, envLen)
       val indexPos = ipf.position()
       IndexFile(indexEnv, file, indexPos)
     }
@@ -79,7 +83,8 @@ object DataFile {
         )
       }
 
-      val dataEnv: DataFileEnvelope = Helpers.readLenAndCBOR(ipf)
+      val envLen = Helpers.readShort(ipf)
+      val dataEnv: DataFileEnvelope = Helpers.readCBOR(ipf, envLen)
       val indexPos = ipf.position()
       DataFile(dataEnv, FileInputStream(file).getChannel(), indexPos)
     }
@@ -92,7 +97,99 @@ case class GoatRodeoCluster(
     path: File,
     dataFiles: Map[Long, DataFile],
     indexFiles: Map[Long, IndexFile]
-)
+) {
+
+  /** Combined alias map across every DataFile in the cluster, inverted to
+    * `alternateIdentifier → canonicalIdentifier`. Built lazily on first
+    * access. Today each DataFile holds an identical copy of the
+    * cluster-wide map, so the merge is idempotent. */
+  lazy val aliasInverseMap: Map[String, String] = {
+    val b = scala.collection.mutable.Map.empty[String, String]
+    for {
+      df <- dataFiles.values
+      (canon, aliases) <- df.envelope.aliasMap
+      alias <- aliases
+    } b.update(alias, canon)
+    b.toMap
+  }
+
+  /** Resolve any alternate identifier to its canonical form. Returns the
+    * input unchanged if it's already canonical (or not known to the
+    * cluster). */
+  def canonicalise(id: String): String = aliasInverseMap.getOrElse(id, id)
+
+  /** Forward-edge index — `(edgeType, target) → set of source identifiers`.
+    *
+    * Built lazily by streaming every Item in every DataFile via
+    * `GRDWalker`. Because v3 GRDWalker synthesises the dropped
+    * `alias:from` edges back from `DataFileEnvelope.aliasMap`, this index
+    * also captures alias relationships, not just content edges.
+    *
+    * Cost: one full sequential scan of the cluster on first use, plus
+    * O(total-edges) memory for the index. */
+  private lazy val forwardEdgeIndex: Map[(String, String), Set[String]] = {
+    val b =
+      scala.collection.mutable.Map
+        .empty[(String, String), scala.collection.mutable.Set[String]]
+    for ((hash, _) <- dataFiles) {
+      val dataFileFile = GoatRodeoCluster.findFile(path, hash, "grd")
+      val fc = new FileInputStream(dataFileFile).getChannel()
+      try {
+        val walker = new GRDWalker(fc)
+        walker.open()
+        var next = walker.readNext()
+        while (next.isDefined) {
+          val item = next.get
+          val src = item.identifierString
+          for ((et, target) <- item.connections.iterator) {
+            b.getOrElseUpdate((et, target), scala.collection.mutable.Set.empty) += src
+          }
+          next = walker.readNext()
+        }
+      } finally fc.close()
+    }
+    b.iterator.map { case (k, v) => k -> v.toSet }.toMap
+  }
+
+  /** Answer "what items point at me via `edgeType`?"
+    *
+    * The on-disk format drops the inverse half of every content-edge
+    * pair (`contains` and `buildsTo`) and folds alias edges into the
+    * envelope's `aliasMap`. This helper synthesises the answer to the
+    * inverse-direction question by inverting the surviving forward
+    * edges, plus consulting the alias map for the alias direction.
+    *
+    * Examples:
+    *   - `cluster.reverseEdges(X, EdgeType.contains)` — items whose
+    *     `containedBy` points at X (X's children, in the legacy
+    *     "X contains Y" sense).
+    *   - `cluster.reverseEdges(X, EdgeType.buildsTo)` — items that X was
+    *     built from.
+    *   - `cluster.reverseEdges(X, EdgeType.aliasTo)` — the canonical id
+    *     of X if X is an alias, otherwise empty.
+    *
+    * The `id` argument is canonicalised first, so callers may pass any
+    * alias and get the same answer. */
+  def reverseEdges(id: String, edgeType: String): Set[String] = {
+    val canon = canonicalise(id)
+    edgeType match {
+      case EdgeType.aliasTo =>
+        // X.aliasTo points at canonical. If we're asked "what points at me
+        // via aliasTo", the answer is: nothing if I'm canonical (aliases
+        // don't exist as items post-Slice-2); my own canonical otherwise.
+        if (canon != id) Set(canon) else Set.empty
+      case other =>
+        // Map inverse-of-content/tag/alias to its forward counterpart.
+        val forwardEt = other match {
+          case EdgeType.contains => EdgeType.containedBy
+          case EdgeType.buildsTo => EdgeType.builtFrom
+          case EdgeType.tagTo    => EdgeType.tagFrom
+          case x                 => x
+        }
+        forwardEdgeIndex.getOrElse((forwardEt, canon), Set.empty)
+    }
+  }
+}
 
 object GoatRodeoCluster {
   def findFile(dir: File, hash: Long, suffix: String): File = {
@@ -125,7 +222,8 @@ object GoatRodeoCluster {
         )
       }
 
-      val env: ClusterFileEnvelope = Helpers.readLenAndCBOR(dfp)
+      val envLen = Helpers.readShort(dfp)
+      val env: ClusterFileEnvelope = Helpers.readCBOR(dfp, envLen)
 
       if (env.magic != GraphManager.Consts.ClusterFileMagicNumber) {
         throw Exception(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala
@@ -96,18 +96,27 @@ case class GoatRodeoCluster(
     envelope: ClusterFileEnvelope,
     path: File,
     dataFiles: Map[Long, DataFile],
-    indexFiles: Map[Long, IndexFile]
+    indexFiles: Map[Long, IndexFile],
+    /** Cluster-wide alias map, loaded from the `<hash>.gra` sidecar
+      * file referenced by `envelope.aliasMapFile`. Empty when the
+      * cluster has no aliases (e.g. v1 clusters, or v4 clusters with
+      * `aliasMapFile = None`). */
+    aliasMap: scala.collection.immutable.TreeMap[String, scala.collection.immutable.TreeSet[String]] =
+      scala.collection.immutable.TreeMap.empty
 ) {
 
-  /** Combined alias map across every DataFile in the cluster, inverted to
-    * `alternateIdentifier → canonicalIdentifier`. Built lazily on first
-    * access. Today each DataFile holds an identical copy of the
-    * cluster-wide map, so the merge is idempotent. */
+  /** Look up the alternates registered for a canonical identifier, if
+    * any. Useful for v4 readers that want to surface the `alias:from`
+    * edges that were stripped at write time. */
+  def aliasesFor(canonical: String): scala.collection.immutable.TreeSet[String] =
+    aliasMap.getOrElse(canonical, scala.collection.immutable.TreeSet.empty)
+
+  /** Inverse of [[aliasMap]] — `alternateIdentifier → canonicalIdentifier`.
+    * Built lazily on first access. */
   lazy val aliasInverseMap: Map[String, String] = {
     val b = scala.collection.mutable.Map.empty[String, String]
     for {
-      df <- dataFiles.values
-      (canon, aliases) <- df.envelope.aliasMap
+      (canon, aliases) <- aliasMap
       alias <- aliases
     } b.update(alias, canon)
     b.toMap
@@ -195,6 +204,53 @@ object GoatRodeoCluster {
   def findFile(dir: File, hash: Long, suffix: String): File = {
     File(dir, f"${String.format("%016x", hash)}.${suffix}")
   }
+
+  /** Read and decode a `<hash>.gra` alias-map sidecar file.
+    *
+    * The file's layout matches [[GraphManager.writeAliasMapFile]]:
+    *
+    *   - 4 bytes — [[GraphManager.Consts.AliasMapFileMagicNumber]].
+    *   - Rest of the file — a single CBOR-encoded
+    *     `TreeMap[String, TreeSet[String]]` (no length prefix; the map
+    *     is self-delimiting and consumes the remainder of the file).
+    *
+    * This is the read companion to the sidecar emission that replaces
+    * the v3 embedded-alias-map design (which silently truncated for
+    * any cluster whose alias map exceeded ~64 KiB).
+    */
+  private def loadAliasMapFile(
+      dir: File,
+      hash: Long
+  ): scala.collection.immutable.TreeMap[String, scala.collection.immutable.TreeSet[String]] = {
+    val file = findFile(dir, hash, "gra")
+    Using.resource(FileInputStream(file)) { fis =>
+      val fc = fis.getChannel()
+      val magic = Helpers.readInt(fc)
+      if (magic != GraphManager.Consts.AliasMapFileMagicNumber) {
+        throw Exception(
+          f"Unexpected magic number ${magic} expecting ${GraphManager.Consts.AliasMapFileMagicNumber} for alias-map file ${file.getName()}"
+        )
+      }
+      // Read the remainder of the file as a single CBOR-encoded map.
+      val remaining = (fc.size() - fc.position()).toInt
+      val buf = java.nio.ByteBuffer.allocate(remaining)
+      while (buf.hasRemaining()) {
+        if (fc.read(buf) < 0) {
+          throw Exception(
+            f"Unexpected EOF while reading alias-map file ${file.getName()}"
+          )
+        }
+      }
+      buf.position(0)
+      import io.bullet.borer.Cbor
+      Cbor
+        .decode(buf)
+        .to[
+          scala.collection.immutable.TreeMap[String, scala.collection.immutable.TreeSet[String]]
+        ]
+        .value
+    }
+  }
   def open(path: File): GoatRodeoCluster = {
 
     val fileName = path.getName()
@@ -244,11 +300,19 @@ object GoatRodeoCluster {
         dataFileHash <- dataFileHashes.toSeq
       } yield (dataFileHash -> DataFile.open(theDir, dataFileHash)))*)
 
+      val aliasMap = env.aliasMapFile match {
+        case Some(hash) => loadAliasMapFile(theDir, hash)
+        case None       =>
+          scala.collection.immutable.TreeMap
+            .empty[String, scala.collection.immutable.TreeSet[String]]
+      }
+
       GoatRodeoCluster(
         envelope = env,
         path = theDir,
         dataFiles = dataFiles,
-        indexFiles = indexFiles
+        indexFiles = indexFiles,
+        aliasMap = aliasMap
       )
     }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
@@ -189,7 +189,25 @@ object GraphManager {
     indexWriter.write(ByteBuffer.wrap(indexEnvBytes))
     val indexBB = ByteBuffer.allocate(pairs.length * 32)
 
-    for { v <- pairs } {
+    // Sort by MD5 byte array (unsigned, lex order). The collection is in
+    // *write* order (topological from `Storage.prepareForWrite`), but the
+    // .gri reader (both goatrodeo's own GRDWalker and BigTent's binary
+    // search) requires entries sorted by raw MD5 bytes for lookups to
+    // succeed.
+    val sortedPairs = pairs.sortWith { (a, b) =>
+      val ab = a._2
+      val bb = b._2
+      val n = math.min(ab.length, bb.length)
+      var i = 0
+      var result = 0
+      while (i < n && result == 0) {
+        result = (ab(i) & 0xff) - (bb(i) & 0xff)
+        i += 1
+      }
+      if (result != 0) result < 0 else ab.length < bb.length
+    }
+
+    for { v <- sortedPairs } {
       indexBB.put(v._2)
       indexBB.putLong(sha256Long)
       indexBB.putLong(v._3)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
@@ -106,25 +106,60 @@ object GraphManager {
 
     var pairs: Vector[(String, Array[Byte], Position)] = Vector()
 
+    // Batched write buffer: a single reusable 4 MiB heap ByteBuffer that
+    // accumulates length-prefixed item frames and is flushed to the
+    // channel only when full (or when an oversized item arrives, or at
+    // end-of-stream). Replaces the previous per-item
+    // `ByteBuffer.allocate(256 + entryBytes.length)` + `writer.write` —
+    // ~300k Items on the ADGTests corpus → ~300k allocations and
+    // ~300k syscalls otherwise.
+    //
+    // `logicalPosition` is what the channel position *will be* once the
+    // buffer is flushed, i.e. `writer.position() + buffer.position()`.
+    // It is the offset recorded into `pairs` and into
+    // `writeCtx.record(...)` for back-references, and it is also what
+    // the `TargetMaxFileSize` check uses (writer.position() lags the
+    // true byte stream by up to BUFFER_CAPACITY here).
+    val BufferCapacity = 4 * 1024 * 1024
+    val batch = ByteBuffer.allocate(BufferCapacity)
+    var logicalPosition: Long = writer.position()
+
+    def flushBatch(): Unit = {
+      if (batch.position() > 0) {
+        batch.flip()
+        while (batch.hasRemaining()) writer.write(batch)
+        batch.clear()
+      }
+    }
+
     // loop writing entries until empty or the file is >= 16GB in size
-    while (items.hasNext && writer.position() < Consts.TargetMaxFileSize) {
+    while (items.hasNext && logicalPosition < Consts.TargetMaxFileSize) {
       val orgEntry = items.next()
-      val currentPosition = writer.position()
+      val currentPosition = logicalPosition
       val entry = orgEntry
       val md5 = entry.identifierMD5()
       val entryBytes = Item.encodeStreamed(entry, writeCtx)
 
       pairs = pairs.appended((Helpers.toHex(md5), md5, currentPosition))
 
-      val toAlloc = 256 + (entryBytes.length)
-      val bb = ByteBuffer.allocate(toAlloc)
-
-      bb.putInt(entryBytes.length)
-      bb.put(entryBytes)
-
-      bb.flip()
-
-      writer.write(bb)
+      val frameLen = 4 + entryBytes.length
+      if (frameLen <= BufferCapacity) {
+        if (frameLen > batch.remaining()) flushBatch()
+        batch.putInt(entryBytes.length)
+        batch.put(entryBytes)
+      } else {
+        // Item larger than BufferCapacity: flush whatever is queued,
+        // then write the frame directly to the channel. Rare in
+        // practice (per-item CBOR is typically < a few KB).
+        flushBatch()
+        val header = ByteBuffer.allocate(4)
+        header.putInt(entryBytes.length)
+        header.flip()
+        while (header.hasRemaining()) writer.write(header)
+        val body = ByteBuffer.wrap(entryBytes)
+        while (body.hasRemaining()) writer.write(body)
+      }
+      logicalPosition += frameLen
 
       // Record this item's location for backref encoding of items later in
       // the stream. The recorded offset is the start of the length-prefixed
@@ -143,6 +178,9 @@ object GraphManager {
         )
       }
     }
+
+    // Final flush before writing the EOF trailer.
+    flushBatch()
 
     // 4-byte -1 sentinel — matches the 4-byte length prefix `readNext`
     // expects for each item frame, so the reader can detect end-of-file

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
@@ -137,7 +137,11 @@ object GraphManager {
       }
     }
 
-    Helpers.writeShort(writer, -1) // a marker that says end of file
+    // 4-byte -1 sentinel — matches the 4-byte length prefix `readNext`
+    // expects for each item frame, so the reader can detect end-of-file
+    // by reading -1 here. (Older revisions of this file wrote a 2-byte
+    // short, which `readNext`'s `Helpers.readInt` could not recognise.)
+    Helpers.writeInt(writer, -1)
 
     // write final back-pointer (to the last entry record)
     Helpers.writeLong(writer, previousPosition)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
@@ -1,6 +1,7 @@
 package io.spicelabs.goatrodeo.omnibor
 
 import com.typesafe.scalalogging.Logger
+import io.bullet.borer.Cbor
 import io.spicelabs.goatrodeo.envelopes.ClusterFileEnvelope
 import io.spicelabs.goatrodeo.envelopes.DataFileEnvelope
 import io.spicelabs.goatrodeo.envelopes.IndexFileEnvelope
@@ -54,6 +55,14 @@ object GraphManager {
       */
     val ClusterFileMagicNumber: Int = 0xba4a4a // Banana
 
+    /** Magic number at the start of GRA (alias-map sidecar) files:
+      * 0x0A11A5ED ("Aliased"). Written by the cluster's writeEntries
+      * pass when the alias collapse produces a non-empty map. The
+      * `.gra` file is referenced by hash from
+      * [[io.spicelabs.goatrodeo.envelopes.ClusterFileEnvelope.aliasMapFile]].
+      */
+    val AliasMapFileMagicNumber: Int = 0x0a11a5ed // Aliased
+
     /** Target maximum file size (15 GB) before starting a new data file. */
     val TargetMaxFileSize: Long = 15L * 1024L * 1024L * 1024L // 15G
   }
@@ -71,8 +80,7 @@ object GraphManager {
       items: Iterator[Item],
       previous: Long,
       afterWrite: Item => Unit,
-      writeCtx: WriteContext,
-      aliasMap: TreeMap[String, TreeSet[String]]
+      writeCtx: WriteContext
   ): DataAndIndexFiles = {
     val start = Instant.now()
     // create temporary file
@@ -86,8 +94,7 @@ object GraphManager {
     val dataFileEnvelope =
       DataFileEnvelope.build(
         previous = previous,
-        builtFromMerge = false,
-        aliasMap = aliasMap
+        builtFromMerge = false
       )
     val envelopeBytes = dataFileEnvelope.encode()
     // write the DataFileEnvelope length
@@ -256,8 +263,7 @@ object GraphManager {
         entries,
         previous = previousInChain,
         updateBiggest,
-        writeCtx,
-        aliasMap
+        writeCtx
       )
       previousInChain = dataAndIndex.dataFile
       fileSet = dataAndIndex :: fileSet
@@ -270,6 +276,15 @@ object GraphManager {
         writeCtx.currentFileOrdinal =
           (writeCtx.currentFileOrdinal + 1).toByte
     }
+
+    // If alias collapse produced a non-empty map, write it out to a
+    // sidecar `.gra` file and capture the hash for the cluster envelope.
+    // We do this here (after data/index files and before the cluster
+    // envelope) so the cluster envelope can reference the sidecar by
+    // hash and stay small itself.
+    val aliasMapFileHash: Option[Long] =
+      if (aliasMap.isEmpty) None
+      else Some(writeAliasMapFile(targetDirectory, aliasMap))
 
     val tempFile =
       Files.createTempFile(
@@ -284,7 +299,8 @@ object GraphManager {
     val clusterEnvelope =
       ClusterFileEnvelope.build(
         indexFiles = fileSet.map(_.indexFile).toVector,
-        dataFiles = fileSet.map(_.dataFile).toVector
+        dataFiles = fileSet.map(_.dataFile).toVector,
+        aliasMapFile = aliasMapFileHash
       )
     val envelopeBytes = clusterEnvelope.encode()
     Helpers.writeShort(writer, envelopeBytes.length)
@@ -335,6 +351,50 @@ object GraphManager {
     (fileSet, targetFile)
   }
 
+  /** Write the cluster-wide alias map to a `<sha256_low_63>.gra`
+    * sidecar file in `targetDirectory` and return the hash that names
+    * the file (and is referenced from
+    * [[io.spicelabs.goatrodeo.envelopes.ClusterFileEnvelope.aliasMapFile]]).
+    *
+    * File layout:
+    *
+    *   - 4 bytes — [[Consts.AliasMapFileMagicNumber]] (big-endian).
+    *   - Rest of the file — a single CBOR-encoded
+    *     `TreeMap[String, TreeSet[String]]` mapping canonical
+    *     identifiers to their alternates.
+    *
+    * No length prefix on the CBOR payload: the map is self-delimiting,
+    * and the file is consumed by reading to EOF. This avoids the 16-bit
+    * length-prefix overflow that previously corrupted large embedded
+    * alias maps inside `DataFileEnvelope` (v3).
+    */
+  private def writeAliasMapFile(
+      targetDirectory: File,
+      aliasMap: TreeMap[String, TreeSet[String]]
+  ): Long = {
+    val tempFile =
+      Files.createTempFile(
+        targetDirectory.toPath(),
+        "goat_rodeo_alias_",
+        ".gra"
+      )
+    val fileWriter = new FileOutputStream(tempFile.toFile())
+    val writer = fileWriter.getChannel()
+    try {
+      Helpers.writeInt(writer, Consts.AliasMapFileMagicNumber)
+      val cborBytes = Cbor.encode(aliasMap).toByteArray
+      writer.write(ByteBuffer.wrap(cborBytes))
+    } finally {
+      writer.close()
+    }
+    val sha256Long = Helpers.byteArrayToLong63Bits(
+      Helpers.computeSHA256(new FileInputStream(tempFile.toFile()))
+    )
+    val finalFile =
+      new File(targetDirectory, f"${Helpers.toHex(sha256Long)}.gra")
+    tempFile.toFile().renameTo(finalFile)
+    sha256Long
+  }
 }
 
 /** A walker for reading Items from a GRD (Goat Rodeo Data) file.
@@ -417,25 +477,14 @@ class GRDWalker(source: FileChannel) {
         // write side, which records `currentPosition` before writing.
         readCtx.record(frameStart, rawItem.identifierString)
 
-        // v3: reconstruct alias edges from the envelope's aliasMap. Items
-        // that were a canonical of a collapsed equivalence class have
-        // their `alias:from` edges synthesised back, so consumers see
-        // `connections` exactly as it would have been before the
-        // collapse.
-        val entry = envelopeOpt match {
-          case Some(env) if env.version >= 3 && env.aliasMap.nonEmpty =>
-            env.aliasMap.get(rawItem.identifierString) match {
-              case Some(aliases) if aliases.nonEmpty =>
-                val added = aliases.iterator
-                  .map(a => (EdgeType.aliasFrom, a))
-                rawItem.copy(
-                  connections = rawItem.connections ++ added
-                )
-              case _ => rawItem
-            }
-          case _ => rawItem
-        }
-        Some(entry)
+        // Alias-edge synthesis for v3+ canonicals is no longer the
+        // walker's responsibility. The cluster-wide alias map lives in
+        // a separate `.gra` sidecar referenced from `ClusterFileEnvelope`
+        // and `GoatRodeoCluster.open` loads it; callers reading items via
+        // the cluster get alias synthesis at that layer. Standalone
+        // GRDWalker callers (e.g. `forwardEdgeIndex`'s internal scan)
+        // operate on the raw item set.
+        Some(rawItem)
       }
     }
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala
@@ -9,6 +9,9 @@ import io.spicelabs.goatrodeo.util.Helpers
 import org.json4s.JsonDSL
 import org.json4s.JsonDSL.*
 
+import scala.collection.immutable.TreeMap
+import scala.collection.immutable.TreeSet
+
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -67,7 +70,9 @@ object GraphManager {
       targetDirectory: File,
       items: Iterator[Item],
       previous: Long,
-      afterWrite: Item => Unit
+      afterWrite: Item => Unit,
+      writeCtx: WriteContext,
+      aliasMap: TreeMap[String, TreeSet[String]]
   ): DataAndIndexFiles = {
     val start = Instant.now()
     // create temporary file
@@ -81,7 +86,8 @@ object GraphManager {
     val dataFileEnvelope =
       DataFileEnvelope.build(
         previous = previous,
-        builtFromMerge = false
+        builtFromMerge = false,
+        aliasMap = aliasMap
       )
     val envelopeBytes = dataFileEnvelope.encode()
     // write the DataFileEnvelope length
@@ -99,7 +105,7 @@ object GraphManager {
       val currentPosition = writer.position()
       val entry = orgEntry
       val md5 = entry.identifierMD5()
-      val entryBytes = entry.encodeCBOR()
+      val entryBytes = Item.encodeStreamed(entry, writeCtx)
 
       pairs = pairs.appended((Helpers.toHex(md5), md5, currentPosition))
 
@@ -112,6 +118,13 @@ object GraphManager {
       bb.flip()
 
       writer.write(bb)
+
+      // Record this item's location for backref encoding of items later in
+      // the stream. The recorded offset is the start of the length-prefixed
+      // frame (currentPosition), so the read path's `ReadContext.record`
+      // can match positions exactly without having to skip the frame
+      // header.
+      writeCtx.record(entry.identifierString, currentPosition)
 
       previousPosition = currentPosition; // itemEnvelope.position;
 
@@ -214,7 +227,8 @@ object GraphManager {
     */
   def writeEntries(
       targetDirectory: File,
-      entries: Iterator[Item]
+      entries: Iterator[Item],
+      aliasMap: TreeMap[String, TreeSet[String]] = TreeMap.empty
   ): (Seq[DataAndIndexFiles], File) = {
     var previousInChain: Long = 0L
     var biggest: Vector[(Item, Int)] = Vector()
@@ -231,16 +245,26 @@ object GraphManager {
     }
 
     var fileSet: List[DataAndIndexFiles] = Nil
+    val writeCtx = new WriteContext()
     while (entries.hasNext) {
       val dataAndIndex = writeABlock(
         targetDirectory,
         entries,
         previous = previousInChain,
-        updateBiggest
+        updateBiggest,
+        writeCtx,
+        aliasMap
       )
       previousInChain = dataAndIndex.dataFile
       fileSet = dataAndIndex :: fileSet
-
+      // Next DataFile in this cluster gets a fresh ordinal so cross-file
+      // backrefs are unambiguous. We cap at Byte.MaxValue; a cluster with
+      // more than 127 DataFiles (each up to 15 GB → ~2 TB cluster) is
+      // beyond the design target, but rather than truncate we fall back
+      // to External edges past the cap.
+      if (writeCtx.currentFileOrdinal < Byte.MaxValue)
+        writeCtx.currentFileOrdinal =
+          (writeCtx.currentFileOrdinal + 1).toByte
     }
 
     val tempFile =
@@ -315,10 +339,18 @@ object GraphManager {
   * validate the file and read the envelope, then `readNext()` or `items()` to
   * iterate through Items.
   *
+  * For v2 GRD files, the walker maintains an internal `ReadContext` so that
+  * `WireEdge.SameFile` / `CrossFile` backrefs can be resolved as items are
+  * streamed in. Callers that need cross-DataFile resolution should supply a
+  * shared `ReadContext` via `open(sharedCtx)`.
+  *
   * @param source
   *   the FileChannel to read from
   */
 class GRDWalker(source: FileChannel) {
+
+  private var envelopeOpt: Option[DataFileEnvelope] = None
+  private var readCtx: ReadContext = new ReadContext()
 
   /** Open the GRD file and read its envelope.
     *
@@ -327,7 +359,14 @@ class GRDWalker(source: FileChannel) {
     * @return
     *   a Try containing the envelope on success, or an error on failure
     */
-  def open(): Try[DataFileEnvelope] = {
+  def open(): Try[DataFileEnvelope] = open(new ReadContext())
+
+  /** Open the GRD file with an externally-managed `ReadContext`. Useful when
+    * reading multiple DataFiles of a cluster sequentially: pass the same
+    * context to each walker so cross-file backrefs resolve correctly. Caller
+    * is responsible for bumping `ctx.currentFileOrdinal` between files. */
+  def open(ctx: ReadContext): Try[DataFileEnvelope] = {
+    readCtx = ctx
     val magic_? = Helpers.readInt(source)
     if (magic_? != GraphManager.Consts.DataFileMagicNumber) {
       // FIXME log the error
@@ -340,7 +379,9 @@ class GRDWalker(source: FileChannel) {
     if (len != readLen) {
       throw new Exception(f"Wanted ${len} bytes got ${readLen}")
     }
-    DataFileEnvelope.decode(ba.position(0).array())
+    val env = DataFileEnvelope.decode(ba.position(0).array())
+    env.foreach(e => envelopeOpt = Some(e))
+    env
   }
 
   /** Read the next Item from the file.
@@ -352,6 +393,7 @@ class GRDWalker(source: FileChannel) {
     if (source.position() == source.size()) {
       None
     } else {
+      val frameStart = source.position()
       val entryLen = Helpers.readInt(source)
       if (entryLen == -1) {
         None
@@ -360,7 +402,35 @@ class GRDWalker(source: FileChannel) {
         source.read(entryByteBuffer)
 
         val entryBytes = entryByteBuffer.array()
-        val entry = Item.decode(entryBytes).get
+        val rawItem: Item = envelopeOpt match {
+          case Some(env) if env.version >= 2 =>
+            Item.decodeStreamed(entryBytes, readCtx).get
+          case _ =>
+            Item.decode(entryBytes).get
+        }
+        // Record this item's identifier against the frame-start offset so
+        // any later backref edges pointing here can resolve. Mirrors the
+        // write side, which records `currentPosition` before writing.
+        readCtx.record(frameStart, rawItem.identifierString)
+
+        // v3: reconstruct alias edges from the envelope's aliasMap. Items
+        // that were a canonical of a collapsed equivalence class have
+        // their `alias:from` edges synthesised back, so consumers see
+        // `connections` exactly as it would have been before the
+        // collapse.
+        val entry = envelopeOpt match {
+          case Some(env) if env.version >= 3 && env.aliasMap.nonEmpty =>
+            env.aliasMap.get(rawItem.identifierString) match {
+              case Some(aliases) if aliases.nonEmpty =>
+                val added = aliases.iterator
+                  .map(a => (EdgeType.aliasFrom, a))
+                rawItem.copy(
+                  connections = rawItem.connections ++ added
+                )
+              case _ => rawItem
+            }
+          case _ => rawItem
+        }
         Some(entry)
       }
     }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -9,7 +9,7 @@ import io.bullet.borer.Reader
 import io.bullet.borer.Writer
 import io.bullet.borer.derivation.key
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
 
@@ -34,7 +34,7 @@ import scala.util.Try
   *   optional metadata about this Item (either ItemMetaData or ItemTagData)
   */
 case class Item(
-    identifier: String,
+    identifier: Gitoid,
     // reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
@@ -70,7 +70,7 @@ case class Item(
   def withConnection(edgeType: String, id: String): Item =
     this.copy(connections = this.connections + (edgeType -> id))
 
-  private lazy val md5 = Helpers.computeMD5(identifier)
+  private lazy val md5 = Helpers.computeMD5(identifier())
 
   /** Lazily cached CBOR-encoded representation of this Item. */
   lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
@@ -90,8 +90,8 @@ case class Item(
     *   true if this Item's hash is lexicographically less than the other's
     */
   def cmpMd5(that: Item): Boolean = {
-    val myHash = Helpers.md5hashHex(identifier)
-    val thatHash = Helpers.md5hashHex(that.identifier)
+    val myHash = Helpers.md5hashHex(identifier())
+    val thatHash = Helpers.md5hashHex(that.identifier())
     myHash < thatHash
   }
 
@@ -102,7 +102,7 @@ case class Item(
   def isRoot(): Boolean = {
     if (this.bodyMimeType != Some(ItemMetaData.mimeType)) {
       false
-    } else if (this.identifier == "tags") {
+    } else if (this.identifier() == "tags") {
       false
     } else if (
       this.connections
@@ -169,7 +169,7 @@ case class Item(
   def createOrUpdateInStore(store: Storage, context: Item => String): Item = {
     store
       .write(
-        identifier,
+        identifier(),
         {
           case None        => Some(this)
           case Some(other) => Some(this.merge(other))
@@ -189,15 +189,15 @@ case class Item(
             case Some(item) =>
               Some(
                 item.copy(connections =
-                  item.connections + (aliasType -> this.identifier)
+                  item.connections + (aliasType -> this.identifier())
                 )
               )
             case None =>
               Some(
                 Item(
-                  itemNeedingAlias,
+                  Gitoid(itemNeedingAlias),
                   // noopLocationReference,
-                  TreeSet(aliasType -> this.identifier),
+                  TreeSet(aliasType -> this.identifier()),
                   None,
                   None
                 )
@@ -311,7 +311,7 @@ case class Item(
     *   the enhanced `Item`
     */
   def enhanceWithMetadata(
-      maybeParent: Option[GitOID] = None,
+      maybeParent: Option[Gitoid] = None,
       extra: TreeMap[String, TreeSet[StringOrPair]] = TreeMap(),
       filenames: Seq[String] = Vector(),
       mimeTypes: Seq[String] = Vector()
@@ -359,7 +359,7 @@ case class Item(
   }
 
   def getMd5(): Array[Byte] = this.md5
-  def getIdentifier(): String = identifier
+  def getIdentifier(): String = identifier()
   def isRootWorkItem(): Boolean = isRoot()
 }
 
@@ -380,14 +380,14 @@ object Item {
     * @return
     *   the created item
     */
-  def itemFrom(artifact: ArtifactWrapper, container: Option[GitOID]): Item = {
+  def itemFrom(artifact: ArtifactWrapper, container: Option[Gitoid]): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
       id,
       // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
-      ) ++ container.toSeq.map(c => EdgeType.containedBy -> c),
+      ) ++ container.toSeq.map(c => EdgeType.containedBy -> c()),
       Some(ItemMetaData.mimeType),
       Some(
         ItemMetaData(
@@ -418,7 +418,7 @@ object Item {
       items: Seq[Item],
       nameFilter: String => Boolean = s => true,
       mimeFilter: Set[String] => Boolean = s => true
-  ): Map[String, GitOID] = {
+  ): Map[String, Gitoid] = {
     val mapping = for {
       item <- items
       metadata <- item.body match {
@@ -505,7 +505,7 @@ object Item {
         assert(r.readString() == "connections")
         val connections: TreeSet[Edge] = r.read[TreeSet[Edge]]()
         assert(r.readString() == "identifier")
-        val identifier = r.readString()
+        val identifier = Gitoid(r.readString())
 
         val ret = Item(
           identifier,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -34,7 +34,7 @@ import scala.util.Try
   *   optional metadata about this Item (either ItemMetaData or ItemTagData)
   */
 case class Item(
-    identifier: Gitoid,
+    identifier: String,
     // reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
@@ -70,7 +70,7 @@ case class Item(
   def withConnection(edgeType: String, id: String): Item =
     this.copy(connections = this.connections + (edgeType -> id))
 
-  private lazy val md5 = Helpers.computeMD5(identifier())
+  private lazy val md5 = Helpers.computeMD5(identifier)
 
   /** Lazily cached CBOR-encoded representation of this Item. */
   lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
@@ -90,8 +90,8 @@ case class Item(
     *   true if this Item's hash is lexicographically less than the other's
     */
   def cmpMd5(that: Item): Boolean = {
-    val myHash = Helpers.md5hashHex(identifier())
-    val thatHash = Helpers.md5hashHex(that.identifier())
+    val myHash = Helpers.md5hashHex(identifier)
+    val thatHash = Helpers.md5hashHex(that.identifier)
     myHash < thatHash
   }
 
@@ -102,7 +102,7 @@ case class Item(
   def isRoot(): Boolean = {
     if (this.bodyMimeType != Some(ItemMetaData.mimeType)) {
       false
-    } else if (this.identifier() == "tags") {
+    } else if (this.identifier == Item.tagsRootIdentifier) {
       false
     } else if (
       this.connections
@@ -169,7 +169,7 @@ case class Item(
   def createOrUpdateInStore(store: Storage, context: Item => String): Item = {
     store
       .write(
-        identifier(),
+        identifier,
         {
           case None        => Some(this)
           case Some(other) => Some(this.merge(other))
@@ -189,15 +189,15 @@ case class Item(
             case Some(item) =>
               Some(
                 item.copy(connections =
-                  item.connections + (aliasType -> this.identifier())
+                  item.connections + (aliasType -> this.identifier)
                 )
               )
             case None =>
               Some(
                 Item(
-                  Gitoid(itemNeedingAlias),
+                  itemNeedingAlias,
                   // noopLocationReference,
-                  TreeSet(aliasType -> this.identifier()),
+                  TreeSet(aliasType -> this.identifier),
                   None,
                   None
                 )
@@ -343,7 +343,7 @@ case class Item(
             case Some(parent)
                 if baseFileNames.size > 1 || (baseFileNames.size == 1 && !baseFileNames
                   .contains(name)) =>
-              Vector(name, f"${parent}/${name}")
+              Vector(name, f"${parent()}/${name}")
             case _ => Vector(name)
           }
         )
@@ -359,7 +359,7 @@ case class Item(
   }
 
   def getMd5(): Array[Byte] = this.md5
-  def getIdentifier(): String = identifier()
+  def getIdentifier(): String = identifier
   def isRootWorkItem(): Boolean = isRoot()
 }
 
@@ -367,6 +367,10 @@ case class Item(
   * utilities.
   */
 object Item {
+
+  /** The sentinel identifier used for the "tags" root Item — the Item under
+    * which per-package tag references are anchored. Not a real gitoid URL. */
+  val tagsRootIdentifier: String = "tags"
   protected val logger: Logger = Logger(getClass())
 
   /** Given an ArtifactWrapper, create an `Item` based on the hashes/gitoids for
@@ -383,7 +387,7 @@ object Item {
   def itemFrom(artifact: ArtifactWrapper, container: Option[Gitoid]): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
-      id,
+      id(),
       // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
@@ -427,7 +431,7 @@ object Item {
         case _ => None.toSeq
       }
       filename <- metadata.fileNames.toSeq if nameFilter(filename)
-    } yield filename -> item.identifier
+    } yield filename -> Gitoid(item.identifier)
 
     Map(mapping*)
   }
@@ -505,7 +509,7 @@ object Item {
         assert(r.readString() == "connections")
         val connections: TreeSet[Edge] = r.read[TreeSet[Edge]]()
         assert(r.readString() == "identifier")
-        val identifier = Gitoid(r.readString())
+        val identifier = r.readString()
 
         val ret = Item(
           identifier,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -9,9 +9,11 @@ import io.bullet.borer.Reader
 import io.bullet.borer.Writer
 import io.bullet.borer.derivation.key
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
+import io.spicelabs.goatrodeo.util.EdgeTypeId
 import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.Identifier
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -34,7 +36,7 @@ import scala.util.Try
   *   optional metadata about this Item (either ItemMetaData or ItemTagData)
   */
 case class Item(
-    identifier: String,
+    identifier: Identifier,
     // reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
@@ -70,7 +72,22 @@ case class Item(
   def withConnection(edgeType: String, id: String): Item =
     this.copy(connections = this.connections + (edgeType -> id))
 
-  private lazy val md5 = Helpers.computeMD5(identifier)
+  /** Canonical String form of `identifier`. Materialised lazily on first
+    * access and cached, so the cost of decoding bytes back into a String is
+    * paid at most once per Item lifetime regardless of how many storage-key,
+    * edge, or logging consumers ask for it. */
+  lazy val identifierString: String = identifier.apply()
+
+  /** MD5 of the identifier's raw bytes — no UTF-8 round-trip through the
+    * canonical String form. */
+  private lazy val md5: Array[Byte] = identifier.md5
+
+  /** Cache the auto-derived hashCode. Without this, `Item.hashCode` recomputes
+    * the identifier's byte-array hash on every call (because `ArraySeq.ofByte`
+    * doesn't cache its hashCode the way `String` does). Items frequently
+    * appear as `HashMap` / `HashSet` elements, where each `put` / `get` /
+    * `contains` invokes hashCode at least once. */
+  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 
   /** Lazily cached CBOR-encoded representation of this Item. */
   lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
@@ -90,8 +107,8 @@ case class Item(
     *   true if this Item's hash is lexicographically less than the other's
     */
   def cmpMd5(that: Item): Boolean = {
-    val myHash = Helpers.md5hashHex(identifier)
-    val thatHash = Helpers.md5hashHex(that.identifier)
+    val myHash = Helpers.toHex(this.md5)
+    val thatHash = Helpers.toHex(that.md5)
     myHash < thatHash
   }
 
@@ -169,7 +186,7 @@ case class Item(
   def createOrUpdateInStore(store: Storage, context: Item => String): Item = {
     store
       .write(
-        identifier,
+        identifierString,
         {
           case None        => Some(this)
           case Some(other) => Some(this.merge(other))
@@ -189,15 +206,15 @@ case class Item(
             case Some(item) =>
               Some(
                 item.copy(connections =
-                  item.connections + (aliasType -> this.identifier)
+                  item.connections + (aliasType -> this.identifierString)
                 )
               )
             case None =>
               Some(
                 Item(
-                  itemNeedingAlias,
+                  Identifier(itemNeedingAlias),
                   // noopLocationReference,
-                  TreeSet(aliasType -> this.identifier),
+                  TreeSet(aliasType -> this.identifierString),
                   None,
                   None
                 )
@@ -207,7 +224,7 @@ case class Item(
             f"Updating alias reference ${itemNeedingAlias} ${item.bodyAsItemMetaData match {
                 case None       => ""
                 case Some(body) => f"files ${body.fileNames}"
-              }} alias name ${aliasType} for item ${this.identifier}${this.bodyAsItemMetaData match {
+              }} alias name ${aliasType} for item ${this.identifierString}${this.bodyAsItemMetaData match {
                 case None       => ""
                 case Some(body) => f" files ${body.fileNames}"
               }}, parent scope ${parentScope.parentScopeInformation()}"
@@ -359,7 +376,7 @@ case class Item(
   }
 
   def getMd5(): Array[Byte] = this.md5
-  def getIdentifier(): String = identifier
+  def getIdentifier(): String = identifierString
   def isRootWorkItem(): Boolean = isRoot()
 }
 
@@ -370,7 +387,11 @@ object Item {
 
   /** The sentinel identifier used for the "tags" root Item — the Item under
     * which per-package tag references are anchored. Not a real gitoid URL. */
-  val tagsRootIdentifier: String = "tags"
+  val tagsRootIdentifier: Identifier = Identifier.sentinel("tags")
+
+  /** Canonical String form of `tagsRootIdentifier` for use where a String
+    * storage key is required. */
+  val tagsRootIdentifierString: String = tagsRootIdentifier.apply()
   protected val logger: Logger = Logger(getClass())
 
   /** Given an ArtifactWrapper, create an `Item` based on the hashes/gitoids for
@@ -387,7 +408,7 @@ object Item {
   def itemFrom(artifact: ArtifactWrapper, container: Option[Gitoid]): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
-      id(),
+      Identifier.fromGitoid(id),
       // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
@@ -431,7 +452,9 @@ object Item {
         case _ => None.toSeq
       }
       filename <- metadata.fileNames.toSeq if nameFilter(filename)
-    } yield filename -> Gitoid(item.identifier)
+    } yield filename -> item.identifier.asGitoid.getOrElse(
+      Gitoid(item.identifierString)
+    )
 
     Map(mapping*)
   }
@@ -461,7 +484,9 @@ object Item {
   /** A no-op location reference (0, 0) used as a placeholder. */
   val noopLocationReference: LocationReference = (0L, 0L)
 
-  /** CBOR encoder for Item. */
+  /** CBOR encoder for Item. The `identifier` is written as a CBOR byte string
+    * for CBOR output (compact, no String materialisation) and as the canonical
+    * text form for JSON output (which can't represent byte strings). */
   given Encoder[Item] = {
 
     import io.bullet.borer.Dom
@@ -481,7 +506,15 @@ object Item {
         }
 
         w.writeMapMember("connections", item.connections)
-        w.writeMapMember("identifier", item.identifier)
+        // Default: write the identifier as the canonical text form. The
+        // decoder (below) still accepts CBOR byte-string input, so a future
+        // encoder can be switched to binary by replacing this line with
+        //   if (w.writingCbor) w.writeMapMember("identifier", item.identifier)
+        //   else                w.writeMapMember("identifier", item.identifierString)
+        // The focused `GraphBenchmark` shows binary saves ~8% on-disk and is
+        // 11-28% faster on decode/read but ~14% slower on disk write; the
+        // full sbt test wall-clock is too noisy to distinguish the two.
+        w.writeMapMember("identifier", item.identifierString)
         w.writeMapClose()
 
       }
@@ -509,7 +542,12 @@ object Item {
         assert(r.readString() == "connections")
         val connections: TreeSet[Edge] = r.read[TreeSet[Edge]]()
         assert(r.readString() == "identifier")
-        val identifier = r.readString()
+        // Identifier may arrive as a CBOR byte string (current wire format) or
+        // — for legacy data / JSON input — as a text string. Dispatch on the
+        // data-item type.
+        val identifier: Identifier =
+          if (r.hasByteArray) r.read[Identifier]()
+          else Identifier(r.readString())
 
         val ret = Item(
           identifier,
@@ -542,6 +580,187 @@ object Item {
     */
   def decode(bytes: Array[Byte]): Try[Item] = {
     Cbor.decode(bytes).to[Item].valueTry
+  }
+
+  /** Encode an Item using the v2 streamed CBOR format.
+    *
+    * The on-disk shape is the same map as the legacy encoder (`body`,
+    * `body_mime_type`, `connections`, `identifier`), but each entry of
+    * `connections` is a `WireEdge` rather than a `Tuple2[String, String]`.
+    *
+    * For each edge `(edgeTypeStr, targetGitoidStr)`:
+    *   - if the target is already recorded in `ctx.gitoidToLoc`, the edge
+    *     becomes a `WireEdge.SameFile` or `WireEdge.CrossFile` backref
+    *   - if the edge-type string is one of the known constants in
+    *     `EdgeTypeId`, the edge becomes `WireEdge.External`
+    *   - otherwise the edge becomes `WireEdge.UnknownType` and round-trips
+    *     verbatim.
+    *
+    * The encoder does **not** mutate `ctx`; the caller is responsible for
+    * calling `ctx.record(identifierString, offset)` after the bytes are
+    * actually appended to the DataFile.
+    */
+  def encodeStreamed(item: Item, ctx: WriteContext): Array[Byte] = {
+    import io.bullet.borer.Dom
+    // Custom one-off encoder so we stream directly through the writer
+    // (no intermediate Vector[WireEdge]). Mirrors the legacy `given Encoder`
+    // exactly except for the `connections` field.
+    val encoder: Encoder[Item] = new Encoder[Item] {
+      def write(w: Writer, it: Item): w.type = {
+        w.writeMapOpen(4)
+        it.body match {
+          case None                  => w.writeMapMember("body", Dom.NullElem)
+          case Some(v: ItemMetaData) => w.writeMapMember("body", v)
+          case Some(v: ItemTagData)  => w.writeMapMember("body", v.tag)
+        }
+        it.bodyMimeType match {
+          case None           => w.writeMapMember("body_mime_type", Dom.NullElem)
+          case Some(mimeType) => w.writeMapMember("body_mime_type", mimeType)
+        }
+        // connections: write directly as a sized CBOR array of WireEdges
+        // without materialising the intermediate Vector.
+        w.writeString("connections")
+        val size = it.connections.size
+        w.writeArrayOpen(size)
+        val cur = ctx.currentFileOrdinal
+        it.connections.foreach { case (edgeTypeStr, targetGitoid) =>
+          val etId = EdgeTypeId.fromString(edgeTypeStr)
+          val we: WireEdge =
+            if (etId == EdgeTypeId.Unknown) {
+              WireEdge.UnknownType(edgeTypeStr, targetGitoid)
+            } else {
+              ctx.gitoidToLoc.get(targetGitoid) match {
+                case Some((fo, off)) =>
+                  if (fo == cur) WireEdge.SameFile(etId, off)
+                  else WireEdge.CrossFile(etId, fo, off)
+                case None => WireEdge.External(etId, targetGitoid)
+              }
+            }
+          w.write(we)
+        }
+        w.writeArrayClose()
+        w.writeMapMember("identifier", it.identifierString)
+        w.writeMapClose()
+        w
+      }
+    }
+    Cbor.encode(item)(using encoder).toByteArray
+  }
+
+  /** Decode an Item from v2 streamed CBOR bytes.
+    *
+    * `WireEdge.SameFile` and `WireEdge.CrossFile` backref edges are resolved
+    * against `ctx.locToGitoid`; if a backref points at an unknown offset,
+    * decoding fails with an `IllegalStateException`. */
+  def decodeStreamed(bytes: Array[Byte], ctx: ReadContext): Try[Item] = {
+    val decoder: Decoder[Item] = new Decoder[Item] {
+      import io.bullet.borer.Dom
+      def read(r: Reader): Item = {
+        val unbounded = r.readMapOpen(4)
+        assert(r.readString() == "body")
+        val bodyOpt: Option[Dom.Element] = if (r.hasNull) {
+          r.readNull()
+          None
+        } else {
+          Some(r.read[Dom.Element]())
+        }
+        assert(r.readString() == "body_mime_type")
+        val bodyMimeType: Option[String] = if (r.hasNull) {
+          r.readNull()
+          None
+        } else { Some(r.readString()) }
+        assert(r.readString() == "connections")
+        // Connections are written as a sized CBOR array of WireEdges. Let
+        // Borer's collection decoder pull them in one go, then resolve each
+        // to a legacy `Edge` against the per-DataFile context.
+        val cur = ctx.currentFileOrdinal
+        val wireEdges = r.read[Vector[WireEdge]]()
+        val connectionsBuilder = TreeSet.newBuilder[Edge]
+        wireEdges.foreach { we =>
+          connectionsBuilder += resolveWireEdge(we, ctx, cur)
+        }
+        val connections: TreeSet[Edge] = connectionsBuilder.result()
+
+        assert(r.readString() == "identifier")
+        val identifier: Identifier =
+          if (r.hasByteArray) r.read[Identifier]()
+          else Identifier(r.readString())
+
+        val ret = Item(
+          identifier,
+          connections,
+          bodyMimeType,
+          (bodyMimeType, bodyOpt) match {
+            case (None, _) => None
+            case (Some(ItemMetaData.mimeType), Some(body)) =>
+              Some(Cbor.transEncode(body).transDecode.to[ItemMetaData].value)
+            case (Some(ItemTagData.mimeType), Some(body)) =>
+              Some(ItemTagData(body))
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Unexpected bodyMimeType/bodyOpt combination: bodyMimeType=$bodyMimeType, bodyOpt=$bodyOpt"
+              )
+          }
+        )
+        r.readMapClose(unbounded = unbounded, ret)
+      }
+    }
+    Cbor.decode(bytes).to[Item](using decoder).valueTry
+  }
+
+  /** Resolve a `WireEdge` to the in-memory `Edge` `(String, String)` form
+    * using the supplied `ReadContext`. */
+  private def resolveWireEdge(
+      we: WireEdge,
+      ctx: ReadContext,
+      currentFileOrdinal: Byte
+  ): Edge = {
+    we match {
+      case WireEdge.SameFile(et, off) =>
+        val target = ctx.resolve(currentFileOrdinal, off).getOrElse(
+          throw new IllegalStateException(
+            s"v2 SameFile edge points at unknown offset $off in file $currentFileOrdinal"
+          )
+        )
+        (
+          EdgeTypeId
+            .toStringOpt(et)
+            .getOrElse(
+              throw new IllegalStateException(
+                s"Unknown EdgeTypeId $et in SameFile backref"
+              )
+            ),
+          target
+        )
+      case WireEdge.CrossFile(et, fo, off) =>
+        val target = ctx.resolve(fo, off).getOrElse(
+          throw new IllegalStateException(
+            s"v2 CrossFile edge points at unknown offset $off in file $fo"
+          )
+        )
+        (
+          EdgeTypeId
+            .toStringOpt(et)
+            .getOrElse(
+              throw new IllegalStateException(
+                s"Unknown EdgeTypeId $et in CrossFile backref"
+              )
+            ),
+          target
+        )
+      case WireEdge.External(et, gid) =>
+        (
+          EdgeTypeId
+            .toStringOpt(et)
+            .getOrElse(
+              throw new IllegalStateException(
+                s"Unknown EdgeTypeId $et in External edge"
+              )
+            ),
+          gid
+        )
+      case WireEdge.UnknownType(et, gid) => (et, gid)
+    }
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -26,11 +26,13 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import java.util.function.BiFunction
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
 import scala.collection.parallel.CollectionConverters.VectorIsParallelizable
+import scala.jdk.CollectionConverters._
 
 /** An abstract definition of a GitOID Corpus storage backend
   */
@@ -442,26 +444,25 @@ class MemStorage(val targetDir: Option[File])
 
   private val logger = Logger(getClass())
 
+  // The item store. `ConcurrentHashMap.compute` gives us atomic
+  // read-modify-write per key under a bucket-level lock — replacing the
+  // old `AtomicReference[Map[String, Item]]` + global `dbSync` +
+  // per-path `locks: HashMap[String, AtomicInteger]` setup. Each write
+  // touches a single bucket instead of allocating a fresh immutable
+  // Map on every update, and contention is naturally striped across
+  // the table's internal segments.
+  private val db: ConcurrentHashMap[String, Item] =
+    new ConcurrentHashMap[String, Item]()
+
+  private val thePurls: AtomicReference[TreeSet[PackageUrl]] =
+    AtomicReference(TreeSet())
+
   override def contains(identifier: String): Boolean =
-    db.get().contains(identifier)
+    db.containsKey(identifier)
 
   override def destDirectory(): Option[File] = targetDir
 
-  // synchronize access to the locks map
-  private val sync = new Object()
-
-  // synchronize access to the database
-  private val dbSync = new Object()
-  private var db: AtomicReference[Map[String, Item]] = AtomicReference(Map())
-  private var thePurls: AtomicReference[TreeSet[PackageUrl]] =
-    AtomicReference(TreeSet())
-  private val locks: java.util.HashMap[String, AtomicInteger] =
-    java.util.HashMap()
-  def keys(): Set[String] = {
-
-    db.get().keySet
-
-  }
+  def keys(): Set[String] = db.keySet().asScala.toSet
 
   override def pathsSortedWithMD5(): Vector[(String, String)] = {
     keys().toVector.par
@@ -484,78 +485,47 @@ class MemStorage(val targetDir: Option[File])
 
   def purls(): TreeSet[PackageUrl] = thePurls.get()
 
-  override def size(): Int = db.get().size
+  override def size(): Int = db.size()
 
   override def target(): Option[File] = targetDir
 
-  override def exists(path: String): Boolean =
-    db.get().contains(path)
+  override def exists(path: String): Boolean = db.containsKey(path)
 
-  override def read(path: String): Option[Item] = {
-    val ret = db.get().get(path)
-    ret
-  }
+  override def read(path: String): Option[Item] = Option(db.get(path))
 
   override def write(
       path: String,
       opr: Option[Item] => Option[Item],
       context: Item => String
   ): Option[Item] = {
-    val (lock, waiters) = sync.synchronized {
-      val theLock = Option(locks.get(path)) match {
-        case Some(lock) => lock
-        case None => {
-          val lock = AtomicInteger(0)
-          locks.put(path, lock)
-          lock
-        }
-      }
-
-      // how many threads are waiting on this row?
-      val waiters = theLock.incrementAndGet()
-
-      theLock -> waiters
-    }
-
-    val contentionThreshold = 8
-
-    try {
-      lock.synchronized {
-        val current = read(path)
-        val updated = opr(current)
-        // if it's contentionThreshold or more, log the message and if it's a multiple of contentionThreshold, log again
-        if (
-          waiters >= contentionThreshold && waiters % contentionThreshold == 0
-        ) {
-          for { updatedItem <- updated } {
-            logger.debug(
-              f"Lock contention for ${path} waiting ${waiters} context ${context(updatedItem)}"
-            )
-          }
-        }
-
-        dbSync.synchronized {
-
-          for { updatedItem <- updated } {
-            val newVal = db.get() + (path -> updatedItem)
-            db.set(newVal)
-          }
-          updated
-        }
-      }
-    } finally {
-      sync.synchronized {
-        val cnt = lock.decrementAndGet()
-        if (cnt == 0) {
-          locks.remove(path)
-        }
+    // `compute` holds the bucket lock for `path` for the duration of
+    // the remapping function; calls for the same path serialise here
+    // exactly as the old per-path AtomicInteger lock did, but without
+    // the global sync. Calls for different paths run in parallel
+    // (striped across the table's internal segments).
+    //
+    // The `context` callback is kept in the signature for source
+    // compatibility — the old contention-logging machinery it fed
+    // (waiter counts on `locks: HashMap[String, AtomicInteger]`) no
+    // longer exists.
+    val _ = context
+    val ref = new AtomicReference[Option[Item]](None)
+    // CHM permits a null return from the BiFunction to mean "remove
+    // the entry" (it explicitly forbids null values otherwise). With
+    // `-Yexplicit-nulls` we have to cast the deletion case manually.
+    val remap: BiFunction[String, Item, Item] = (_, current) => {
+      val updated = opr(Option(current))
+      ref.set(updated)
+      updated match {
+        case Some(item) => item
+        case None       => null.asInstanceOf[Item]
       }
     }
+    db.compute(path, remap)
+    ref.get()
   }
 
-  def release(): Unit = sync.synchronized {
-    db.set(Map()); locks.clear()
-  }
+  def release(): Unit = db.clear()
 
   def getPurls(): Set[PackageUrl] = {
     thePurls.synchronized {
@@ -563,13 +533,9 @@ class MemStorage(val targetDir: Option[File])
     }
   }
 
-  def getKeys(): Set[String] = {
-    keys()
-  }
+  def getKeys(): Set[String] = keys()
 
-  def containsID(identifier: String): Boolean = {
-    contains(identifier)
-  }
+  def containsID(identifier: String): Boolean = contains(identifier)
 }
 
 /** Deal with in-memory storage

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -17,7 +17,7 @@ package io.spicelabs.goatrodeo.omnibor
 import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.BufferedOutputStream
@@ -94,8 +94,10 @@ trait Storage {
     *
     * @return
     */
-  def gitoidKeys(): Set[GitOID] =
-    keys().filter(_.startsWith("gitoid:blob:sha256:"))
+  def gitoidKeys(): Set[Gitoid] =
+    keys().collect {
+      case k if k.startsWith("gitoid:blob:sha256:") => Gitoid(k)
+    }
 
   def destDirectory(): Option[File]
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -19,6 +19,7 @@ import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.PackageUrl
 
 import java.io.BufferedOutputStream
 import java.io.File
@@ -110,9 +111,9 @@ trait Storage {
   /** Get the purls
     *
     * @return
-    *   the purls
+    *   the purls (each a validated canonical pURL string)
     */
-  def purls(): TreeSet[String]
+  def purls(): TreeSet[PackageUrl]
 
   def emitRootsToDir(dir: File): Unit = {
     dir.mkdirs()
@@ -221,9 +222,8 @@ class MemStorage(val targetDir: Option[File])
   // synchronize access to the database
   private val dbSync = new Object()
   private var db: AtomicReference[Map[String, Item]] = AtomicReference(Map())
-  private var thePurls: AtomicReference[TreeSet[String]] = AtomicReference(
-    TreeSet()
-  )
+  private var thePurls: AtomicReference[TreeSet[PackageUrl]] =
+    AtomicReference(TreeSet())
   private val locks: java.util.HashMap[String, AtomicInteger] =
     java.util.HashMap()
   def keys(): Set[String] = {
@@ -246,12 +246,12 @@ class MemStorage(val targetDir: Option[File])
     */
   def addPurl(purl: PackageURL): Unit = {
     thePurls.synchronized {
-      val next = thePurls.get() + purl.canonicalize()
+      val next = thePurls.get() + PackageUrl(purl)
       thePurls.set(next)
     }
   }
 
-  def purls(): TreeSet[String] = thePurls.get()
+  def purls(): TreeSet[PackageUrl] = thePurls.get()
 
   override def size(): Int = db.get().size
 
@@ -326,7 +326,7 @@ class MemStorage(val targetDir: Option[File])
     db.set(Map()); locks.clear()
   }
 
-  def getPurls(): Set[String] = {
+  def getPurls(): Set[PackageUrl] = {
     thePurls.synchronized {
       thePurls.get()
     }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -299,11 +299,27 @@ trait ListFileNames extends Storage {
       }
     }
 
+    /** Strip the inverse half of every content-edge pair (`contained:down`
+      * = `contains`, and `build:up` = `buildsTo`). With items written in
+      * forward topological order, each `A contains B` edge is redundant
+      * with the `B containedBy A` edge already encoded on B; same for
+      * builds. A consumer that needs reverse lookups should use a
+      * cluster-level `reverseEdges` helper, which we can synthesise from
+      * the forward edges in one pass. */
+    def stripInverseContentEdges(it: Item): Item = {
+      val newConns = it.connections.filterNot { case (et, _) =>
+        et == EdgeType.contains || et == EdgeType.buildsTo
+      }
+      if (newConns.size == it.connections.size) it
+      else it.copy(connections = newConns)
+    }
+
     val workingItems: Vector[Item] = rawItems.flatMap { it =>
       val id = it.identifierString
       if (droppedIds.contains(id)) None
-      else if (collapsed.contains(id)) Some(stripIfCollapsed(collapsed(id)))
-      else Some(it)
+      else if (collapsed.contains(id))
+        Some(stripInverseContentEdges(stripIfCollapsed(collapsed(id))))
+      else Some(stripInverseContentEdges(it))
     }
 
     // --- 4. Topological sort along forward content edges ---

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -17,6 +17,7 @@ package io.spicelabs.goatrodeo.omnibor
 import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
+import io.spicelabs.goatrodeo.util.EdgeTypeId
 import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.PackageUrl
@@ -27,6 +28,7 @@ import java.io.FileOutputStream
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
 import scala.collection.parallel.CollectionConverters.VectorIsParallelizable
 
@@ -123,7 +125,7 @@ trait Storage {
     val rootItems = for {
       key <- keys().toVector
       item <- read(key) if item.isRoot()
-    } yield item.identifier
+    } yield item.identifierString
 
     Files.writeString(file.toPath(), Json.encode(rootItems).toUtf8String)
   }
@@ -171,6 +173,219 @@ trait ListFileNames extends Storage {
     *   sorted vector of Tuples (MD5 of the path, the path)
     */
   def pathsSortedWithMD5(): Vector[(String, String)]
+
+  /** Prepare the store's contents for a v3 streamed write.
+    *
+    * Performs three things:
+    *   1. **Alias-class detection.** Runs union-find across `alias:from` /
+    *      `alias:to` edges to group identifiers that refer to the same
+    *      content into equivalence classes.
+    *   2. **Item collapse.** For every class with two or more identifiers
+    *      backed by an Item in the store, the alternate-form Items are
+    *      merged into a single canonical Item via `Item.merge`, and the
+    *      alternate Items are dropped from the output. Singleton classes
+    *      and classes with only one Item-backed member are left alone (the
+    *      alias relationships still get recorded in the table, but no
+    *      Item-level merging happens). Choice of canonical prefers the
+    *      `gitoid:blob:sha256:` form, falling back to the lex-smallest
+    *      Item-backed identifier.
+    *   3. **Alias-edge stripping + alias map.** From every Item that
+    *      participates in a multi-member class, all `alias:from` /
+    *      `alias:to` edges are stripped — the equivalence information now
+    *      lives in `aliasMap` (`canonical → alternates`). On read,
+    *      `GRDWalker` reconstructs the `alias:from` edges from this map so
+    *      `Item.connections` round-trips byte-for-byte from the caller's
+    *      perspective.
+    *
+    * The returned `items` are then topologically sorted along forward
+    * content edges, identical to the v2 path. */
+  def prepareForWrite(): (Vector[Item], TreeMap[String, TreeSet[String]]) = {
+    val md5Sorted: Vector[String] = pathsSortedWithMD5().map(_._2)
+    val rawItems: Vector[Item] = md5Sorted.flatMap(read)
+    if (rawItems.isEmpty) return (Vector.empty, TreeMap.empty)
+
+    // --- 1. Union-find over alias edges ---
+    val parent = scala.collection.mutable.HashMap.empty[String, String]
+    def find(x: String): String = {
+      if (!parent.contains(x)) { parent.update(x, x); return x }
+      var cur = x
+      while (parent(cur) != cur) cur = parent(cur)
+      val root = cur
+      cur = x
+      while (parent(cur) != root) {
+        val nxt = parent(cur)
+        parent.update(cur, root)
+        cur = nxt
+      }
+      root
+    }
+    def union(a: String, b: String): Unit = {
+      val ra = find(a); val rb = find(b)
+      if (ra != rb) parent.update(ra, rb)
+    }
+
+    for (item <- rawItems) {
+      val id = item.identifierString
+      find(id)
+      for ((et, target) <- item.connections.iterator) {
+        if (et == EdgeType.aliasFrom || et == EdgeType.aliasTo) {
+          find(target); union(id, target)
+        }
+      }
+    }
+
+    // --- 2. Build equivalence classes ---
+    val classes =
+      scala.collection.mutable.HashMap
+        .empty[String, scala.collection.mutable.Set[String]]
+    for (k <- parent.keys) {
+      classes
+        .getOrElseUpdate(find(k), scala.collection.mutable.Set.empty) += k
+    }
+
+    val itemById: Map[String, Item] =
+      rawItems.iterator.map(it => it.identifierString -> it).toMap
+
+    def pickCanonical(members: Set[String], itemBacked: Set[String]): String =
+      if (itemBacked.isEmpty) {
+        // shouldn't happen for classes encountered via items, but defensive
+        members.min
+      } else {
+        // Prefer item-backed gitoid:blob:sha256:... form; else lex-smallest item-backed.
+        val gitoidBacked = itemBacked.filter(_.startsWith("gitoid:blob:sha256:"))
+        if (gitoidBacked.nonEmpty) gitoidBacked.min else itemBacked.min
+      }
+
+    // --- 3. Collapse + alias-edge stripping ---
+    val aliasMapBuilder = TreeMap.newBuilder[String, TreeSet[String]]
+    val collapsed = scala.collection.mutable.HashMap.empty[String, Item]
+    val droppedIds = scala.collection.mutable.Set.empty[String]
+    val canonicalOf = scala.collection.mutable.HashMap.empty[String, String]
+
+    for ((_, membersMut) <- classes) {
+      val members = membersMut.toSet
+      val itemBacked = members.filter(itemById.contains)
+      if (members.size <= 1 || itemBacked.size <= 1) {
+        // Singleton class, or only one Item-backed identifier: no collapse,
+        // no alias map entry. Keep the existing Item(s) untouched.
+        ()
+      } else {
+        val canon = pickCanonical(members, itemBacked)
+        val baseItem = itemById(canon)
+        val others = (itemBacked - canon).iterator.map(itemById)
+        val merged =
+          others.foldLeft(baseItem)((acc, o) => acc.merge(o))
+        collapsed.update(canon, merged)
+        for (id <- itemBacked if id != canon) droppedIds += id
+        for (m <- members) canonicalOf.update(m, canon)
+        val aliases = members - canon
+        if (aliases.nonEmpty)
+          aliasMapBuilder += (canon -> TreeSet.from(aliases))
+      }
+    }
+
+    val aliasMap: TreeMap[String, TreeSet[String]] = aliasMapBuilder.result()
+    val collapsedCanonicals: Set[String] = collapsed.keySet.toSet
+
+    def stripIfCollapsed(it: Item): Item = {
+      val id = it.identifierString
+      if (!collapsedCanonicals.contains(id)) it
+      else {
+        val newConns = it.connections.filterNot { case (et, _) =>
+          et == EdgeType.aliasFrom || et == EdgeType.aliasTo
+        }
+        if (newConns.size == it.connections.size) it
+        else it.copy(connections = newConns)
+      }
+    }
+
+    val workingItems: Vector[Item] = rawItems.flatMap { it =>
+      val id = it.identifierString
+      if (droppedIds.contains(id)) None
+      else if (collapsed.contains(id)) Some(stripIfCollapsed(collapsed(id)))
+      else Some(it)
+    }
+
+    // --- 4. Topological sort along forward content edges ---
+    val items = workingItems
+    val n = items.size
+    val indexOf: scala.collection.mutable.HashMap[String, Int] =
+      scala.collection.mutable.HashMap.empty
+    indexOf.sizeHint(n)
+    for (i <- 0 until n) indexOf.update(items(i).identifierString, i)
+
+    val successors: Array[scala.collection.mutable.ArrayBuffer[Int]] =
+      Array.fill(n)(scala.collection.mutable.ArrayBuffer.empty[Int])
+    val inDegree: Array[Int] = Array.fill(n)(0)
+
+    for (i <- 0 until n) {
+      val item = items(i)
+      for ((edgeType, target) <- item.connections.iterator) {
+        if (EdgeTypeId.isForwardContentEdge(edgeType)) {
+          indexOf.get(target) match {
+            case Some(j) if j != i =>
+              successors(j) += i
+              inDegree(i) += 1
+            case _ => ()
+          }
+        }
+      }
+    }
+
+    val ready = scala.collection.mutable.TreeSet.empty[Int]
+    for (i <- 0 until n) if (inDegree(i) == 0) ready += i
+
+    val out = scala.collection.mutable.ArrayBuffer.empty[Int]
+    out.sizeHint(n)
+    def drain(): Unit = {
+      while (ready.nonEmpty) {
+        val pick = ready.head
+        ready.remove(pick)
+        out += pick
+        for (s <- successors(pick)) {
+          val nd = inDegree(s) - 1
+          inDegree(s) = nd
+          if (nd == 0) ready += s
+        }
+      }
+    }
+    drain()
+    while (out.size < n) {
+      var pick = -1
+      var i = 0
+      while (i < n && pick == -1) {
+        if (inDegree(i) > 0) pick = i
+        i += 1
+      }
+      inDegree(pick) = 0
+      ready += pick
+      drain()
+    }
+
+    val resultBuilder = Vector.newBuilder[Item]
+    resultBuilder.sizeHint(n)
+    for (idx <- out) resultBuilder += items(idx)
+    (resultBuilder.result(), aliasMap)
+  }
+
+  /** Items in a deterministic order suitable for the v2 streamed write path.
+    *
+    * For every "forward content edge" (`contained:up` / `build:down` per
+    * `EdgeTypeId.isForwardContentEdge`) `A -> B`, item `B` appears strictly
+    * before item `A` in the result. Items not reachable via content edges are
+    * placed by their `pathsSortedWithMD5` order (the v1 tie-breaker), so the
+    * output is reproducible bit-for-bit across runs on the same input.
+    *
+    * Edges whose target identifier is not itself an Item in the store
+    * (synthetic alias targets, external references) are ignored for sort
+    * purposes — they'll be encoded as `WireEdge.External` at write time.
+    *
+    * Cycles (self-loops or genuine bidirectional content edges through
+    * pathological data) are broken by MD5 tie-break: when no item has zero
+    * outstanding dependencies, the next item is picked by lowest MD5 among
+    * those remaining.
+    */
+  def topologicallySortedForWrite(): Vector[Item] = prepareForWrite()._1
 
   /** The target output filename for the Storage
     *

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala
@@ -431,3 +431,126 @@ enum IndexLoc {
   *   the location where the Item data can be found
   */
 case class ItemOffset(hashHi: Long, hashLow: Long, loc: IndexLoc)
+
+/** Compact on-disk representation of an `Edge`, used by the v2 streamed
+  * encode/decode path in `GraphManager`.
+  *
+  * Edges are encoded as a CBOR array whose first element is a `uint8`
+  * discriminator:
+  *
+  *   - `[0, edgeTypeId: uint8, offset: uint]` — same-DataFile backref
+  *   - `[1, edgeTypeId: uint8, fileOrdinal: uint8, offset: uint]` — cross-file
+  *   - `[2, edgeTypeId: uint8, targetGitoid: string]` — full string fallback
+  *   - `[3, edgeTypeStr: string, targetGitoid: string]` — unrecognised edge
+  *     type, round-trips verbatim
+  *
+  * The in-memory `Edge` (`(String, String)`) API is unaffected; this type only
+  * exists at the wire boundary.
+  */
+sealed trait WireEdge
+object WireEdge {
+  case class SameFile(edgeType: Byte, offset: Long) extends WireEdge
+  case class CrossFile(edgeType: Byte, fileOrdinal: Byte, offset: Long)
+      extends WireEdge
+  case class External(edgeType: Byte, targetGitoid: String) extends WireEdge
+  case class UnknownType(edgeType: String, targetGitoid: String) extends WireEdge
+
+  given Encoder[WireEdge] = { (w, edge) =>
+    edge match {
+      case SameFile(et, off) =>
+        w.writeArrayOpen(3)
+          .writeInt(0)
+          .writeInt(et.toInt & 0xff)
+          .writeLong(off)
+          .writeArrayClose()
+      case CrossFile(et, fo, off) =>
+        w.writeArrayOpen(4)
+          .writeInt(1)
+          .writeInt(et.toInt & 0xff)
+          .writeInt(fo.toInt & 0xff)
+          .writeLong(off)
+          .writeArrayClose()
+      case External(et, gid) =>
+        w.writeArrayOpen(3)
+          .writeInt(2)
+          .writeInt(et.toInt & 0xff)
+          .writeString(gid)
+          .writeArrayClose()
+      case UnknownType(et, gid) =>
+        w.writeArrayOpen(3)
+          .writeInt(3)
+          .writeString(et)
+          .writeString(gid)
+          .writeArrayClose()
+    }
+  }
+
+  given Decoder[WireEdge] = { r =>
+    val unbounded = r.readArrayOpen(3)
+    val tag = r.readInt()
+    val ret: WireEdge = tag match {
+      case 0 =>
+        SameFile(r.readInt().toByte, r.readLong())
+      case 1 =>
+        CrossFile(r.readInt().toByte, r.readInt().toByte, r.readLong())
+      case 2 =>
+        External(r.readInt().toByte, r.readString())
+      case 3 =>
+        UnknownType(r.readString(), r.readString())
+      case other =>
+        r.unexpectedDataItem(
+          f"Unknown WireEdge discriminator ${other}"
+        )
+    }
+    r.readArrayClose(unbounded, ret)
+  }
+}
+
+/** Resolution context for **encoding** an Item's `connections` into `WireEdge`s
+  * during a streamed cluster write.
+  *
+  * As items are written sequentially within a DataFile, `gitoidToLoc` is
+  * populated with `(identifierString -> (fileOrdinal, byteOffset))`. When
+  * encoding an edge whose target is already in the map, the edge becomes a
+  * `SameFile` or `CrossFile` backref; otherwise it falls back to `External`.
+  *
+  * `currentFileOrdinal` is the ordinal of the DataFile being written right
+  * now within the cluster (0 for the first DataFile, etc.).
+  */
+class WriteContext(
+    val gitoidToLoc: scala.collection.mutable.HashMap[
+      String,
+      (Byte, Long)
+    ] = scala.collection.mutable.HashMap.empty,
+    var currentFileOrdinal: Byte = 0
+) {
+  def record(identifierString: String, offset: Long): Unit =
+    gitoidToLoc.update(identifierString, (currentFileOrdinal, offset))
+}
+
+/** Resolution context for **decoding** WireEdges back into legacy
+  * `(String, String)` `Edge`s during a streamed cluster read.
+  *
+  * Maintains the inverse table: `(fileOrdinal, byteOffset) -> targetGitoid`.
+  * Populated incrementally as items are read (the identifier of each Item is
+  * known the moment it's decoded), then consulted when resolving backref
+  * edges encountered later in the stream.
+  *
+  * For random-access reads via the IndexFile, the consumer is expected to
+  * populate the relevant per-DataFile portion of `locToGitoid` ahead of time
+  * (e.g. by streaming the DataFile once to gather identifiers) or to perform
+  * targeted seek-and-decode lookups.
+  */
+class ReadContext(
+    val locToGitoid: scala.collection.mutable.HashMap[
+      (Byte, Long),
+      String
+    ] = scala.collection.mutable.HashMap.empty,
+    var currentFileOrdinal: Byte = 0
+) {
+  def record(offset: Long, identifierString: String): Unit =
+    locToGitoid.update((currentFileOrdinal, offset), identifierString)
+
+  def resolve(fileOrdinal: Byte, offset: Long): Option[String] =
+    locToGitoid.get((fileOrdinal, offset))
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -152,7 +152,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       parent: Option[ParentScope],
       augmentationByHash: Map[String, Vector[Augmentation]]
   ): ParentScope =
-    ParentScope.forAndWith(item.identifier(), parent, augmentationByHash)
+    ParentScope.forAndWith(item.identifier, parent, augmentationByHash)
 }
 
 abstract class ParentScope(
@@ -317,6 +317,12 @@ trait ToProcess {
   ): Seq[Gitoid] = {
     if (keepRunning()) {
 
+      // `blockList` is `Set[Gitoid]` (validated gitoid URLs from the user). Item
+      // identifiers, however, are plain Strings — sometimes gitoid URLs,
+      // sometimes alias hashes ("md5:..." etc.) for back-reference stubs. We
+      // compare in String space.
+      val blockListAsStrings: Set[String] = blockList.map(_())
+
       val (elements, initialState) = getElementsToProcess()
       val (finalState, ret) =
         elements.foldLeft(initialState -> Vector[Gitoid]()) {
@@ -324,7 +330,7 @@ trait ToProcess {
             val itemRaw = Item.itemFrom(artifact, parentId)
 
             // in blocklist do nothing
-            if (blockList.contains(itemRaw.identifier)) {
+            if (blockListAsStrings.contains(itemRaw.identifier)) {
               orgState -> alreadyDone
             } else {
               val aliases = itemRaw.connections.toVector
@@ -422,7 +428,7 @@ trait ToProcess {
                       item =>
                         Some(
                           Item(
-                            tagGitoid,
+                            tagGitoid(),
                             TreeSet(EdgeType.tagFrom -> "tags"),
                             Some(ItemTagData.mimeType),
                             Some(ItemTagData(tagJson))
@@ -445,7 +451,7 @@ trait ToProcess {
                           case None =>
                             Some(
                               Item(
-                                Gitoid("tags"),
+                                Item.tagsRootIdentifier,
                                 TreeSet(EdgeType.tagTo -> tagGitoid()),
                                 None,
                                 None
@@ -477,7 +483,7 @@ trait ToProcess {
                 parentScope.finalAugmentation(store, artifact, item4)
 
               // if we've seen the gitoid before we write it
-              val hasBeenSeen = store.contains(itemScope4.identifier())
+              val hasBeenSeen = store.contains(itemScope4.identifier)
 
               // update back-references for this item
               // this is *only* for the the pre-merged `Item`
@@ -494,15 +500,15 @@ trait ToProcess {
                       case Some(item) =>
                         Some(
                           item.copy(connections =
-                            item.connections + (aliasType -> itemScope4.identifier())
+                            item.connections + (aliasType -> itemScope4.identifier)
                           )
                         )
                       case None =>
                         Some(
                           Item(
-                            Gitoid(itemNeedingAlias),
+                            itemNeedingAlias,
                             // noopLocationReference,
-                            TreeSet(aliasType -> itemScope4.identifier()),
+                            TreeSet(aliasType -> itemScope4.identifier),
                             None,
                             None
                           )
@@ -523,7 +529,7 @@ trait ToProcess {
               // write
               val answerItem = store
                 .write(
-                  itemScope4.identifier(),
+                  itemScope4.identifier,
                   {
                     case None            => Some(itemScope4)
                     case Some(otherItem) => Some(otherItem.merge(itemScope4))
@@ -569,7 +575,7 @@ trait ToProcess {
                       )
                       processSet.flatMap(tp =>
                         tp.process(
-                          Some(answerItem.identifier),
+                          Some(Gitoid(answerItem.identifier)),
                           store,
                           thisParentScope,
                           None,
@@ -585,7 +591,7 @@ trait ToProcess {
               val state5 =
                 state4.postChildProcessing(childGitoids, store, marker)
 
-              state5 -> (alreadyDone :+ answerItem.identifier)
+              state5 -> (alreadyDone :+ Gitoid(answerItem.identifier))
             }
         }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -9,6 +9,7 @@ import io.spicelabs.goatrodeo.util.FileWalker
 import io.spicelabs.goatrodeo.util.FileWrapper
 import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.Identifier
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.StaticMetadata
 
@@ -152,7 +153,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       parent: Option[ParentScope],
       augmentationByHash: Map[String, Vector[Augmentation]]
   ): ParentScope =
-    ParentScope.forAndWith(item.identifier, parent, augmentationByHash)
+    ParentScope.forAndWith(item.identifierString, parent, augmentationByHash)
 }
 
 abstract class ParentScope(
@@ -330,7 +331,7 @@ trait ToProcess {
             val itemRaw = Item.itemFrom(artifact, parentId)
 
             // in blocklist do nothing
-            if (blockListAsStrings.contains(itemRaw.identifier)) {
+            if (blockListAsStrings.contains(itemRaw.identifierString)) {
               orgState -> alreadyDone
             } else {
               val aliases = itemRaw.connections.toVector
@@ -428,7 +429,7 @@ trait ToProcess {
                       item =>
                         Some(
                           Item(
-                            tagGitoid(),
+                            Identifier.fromGitoid(tagGitoid),
                             TreeSet(EdgeType.tagFrom -> "tags"),
                             Some(ItemTagData.mimeType),
                             Some(ItemTagData(tagJson))
@@ -483,7 +484,7 @@ trait ToProcess {
                 parentScope.finalAugmentation(store, artifact, item4)
 
               // if we've seen the gitoid before we write it
-              val hasBeenSeen = store.contains(itemScope4.identifier)
+              val hasBeenSeen = store.contains(itemScope4.identifierString)
 
               // update back-references for this item
               // this is *only* for the the pre-merged `Item`
@@ -500,15 +501,15 @@ trait ToProcess {
                       case Some(item) =>
                         Some(
                           item.copy(connections =
-                            item.connections + (aliasType -> itemScope4.identifier)
+                            item.connections + (aliasType -> itemScope4.identifierString)
                           )
                         )
                       case None =>
                         Some(
                           Item(
-                            itemNeedingAlias,
+                            Identifier(itemNeedingAlias),
                             // noopLocationReference,
-                            TreeSet(aliasType -> itemScope4.identifier),
+                            TreeSet(aliasType -> itemScope4.identifierString),
                             None,
                             None
                           )
@@ -518,7 +519,7 @@ trait ToProcess {
                       f"Updating alias reference ${itemNeedingAlias} ${item.bodyAsItemMetaData match {
                           case None       => ""
                           case Some(body) => f"files ${body.fileNames}"
-                        }} alias name ${aliasType} for item ${itemScope4.identifier}${itemScope4.bodyAsItemMetaData match {
+                        }} alias name ${aliasType} for item ${itemScope4.identifierString}${itemScope4.bodyAsItemMetaData match {
                           case None       => ""
                           case Some(body) => f" files ${body.fileNames}"
                         }}, parent scope ${parentScope.parentScopeInformation()}"
@@ -529,13 +530,13 @@ trait ToProcess {
               // write
               val answerItem = store
                 .write(
-                  itemScope4.identifier,
+                  itemScope4.identifierString,
                   {
                     case None            => Some(itemScope4)
                     case Some(otherItem) => Some(otherItem.merge(itemScope4))
                   },
                   item =>
-                    f"Writing ${itemScope4.identifier}, ${item.body match {
+                    f"Writing ${itemScope4.identifierString}, ${item.body match {
                         case None => ""
                         case Some(body) =>
                           f"gitoid:sha1 ${item.connections.map(_._2).filter(_.startsWith("gitoid:blob:sha1"))}"
@@ -575,7 +576,7 @@ trait ToProcess {
                       )
                       processSet.flatMap(tp =>
                         tp.process(
-                          Some(Gitoid(answerItem.identifier)),
+                          Some(Gitoid(answerItem.identifierString)),
                           store,
                           thisParentScope,
                           None,
@@ -591,7 +592,7 @@ trait ToProcess {
               val state5 =
                 state4.postChildProcessing(childGitoids, store, marker)
 
-              state5 -> (alreadyDone :+ Gitoid(answerItem.identifier))
+              state5 -> (alreadyDone :+ Gitoid(answerItem.identifierString))
             }
         }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -7,7 +7,7 @@ import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWalker
 import io.spicelabs.goatrodeo.util.FileWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.StaticMetadata
@@ -127,7 +127,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
     *   an updated state
     */
   def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: PM
   ): ME
@@ -152,7 +152,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       parent: Option[ParentScope],
       augmentationByHash: Map[String, Vector[Augmentation]]
   ): ParentScope =
-    ParentScope.forAndWith(item.identifier, parent, augmentationByHash)
+    ParentScope.forAndWith(item.identifier(), parent, augmentationByHash)
 }
 
 abstract class ParentScope(
@@ -306,20 +306,20 @@ trait ToProcess {
     * @return
     */
   def process(
-      parentId: Option[GitOID],
+      parentId: Option[Gitoid],
       store: Storage,
       parentScope: ParentScope,
       tag: Option[TagPass],
       args: Config,
-      blockList: Set[GitOID] = Set(),
+      blockList: Set[Gitoid] = Set(),
       keepRunning: () => Boolean = () => true,
-      atEnd: (Option[GitOID], Item) => Unit = (_, _) => ()
-  ): Seq[GitOID] = {
+      atEnd: (Option[Gitoid], Item) => Unit = (_, _) => ()
+  ): Seq[Gitoid] = {
     if (keepRunning()) {
 
       val (elements, initialState) = getElementsToProcess()
       val (finalState, ret) =
-        elements.foldLeft(initialState -> Vector[GitOID]()) {
+        elements.foldLeft(initialState -> Vector[Gitoid]()) {
           case ((orgState, alreadyDone), (artifact, marker)) =>
             val itemRaw = Item.itemFrom(artifact, parentId)
 
@@ -372,7 +372,7 @@ trait ToProcess {
                 case None => itemScopePre3
                 case Some(tag) =>
                   itemScopePre3.copy(connections =
-                    itemScopePre3.connections + (EdgeType.tagFrom -> tag.gitoid)
+                    itemScopePre3.connections + (EdgeType.tagFrom -> tag.gitoid())
                   )
               }
 
@@ -418,7 +418,7 @@ trait ToProcess {
 
                     // Write tag item — unified with "tags" root
                     store.write(
-                      tagGitoid,
+                      tagGitoid(),
                       item =>
                         Some(
                           Item(
@@ -439,14 +439,14 @@ trait ToProcess {
                           case Some(item) =>
                             Some(
                               item.copy(connections =
-                                item.connections + (EdgeType.tagTo -> tagGitoid)
+                                item.connections + (EdgeType.tagTo -> tagGitoid())
                               )
                             )
                           case None =>
                             Some(
                               Item(
-                                "tags",
-                                TreeSet(EdgeType.tagTo -> tagGitoid),
+                                Gitoid("tags"),
+                                TreeSet(EdgeType.tagTo -> tagGitoid()),
                                 None,
                                 None
                               )
@@ -457,7 +457,7 @@ trait ToProcess {
 
                     // Add tagFrom to main artifact
                     itemScope3.copy(connections =
-                      itemScope3.connections + (EdgeType.tagFrom -> tagGitoid)
+                      itemScope3.connections + (EdgeType.tagFrom -> tagGitoid())
                     )
                   case None => itemScope3
                 }
@@ -477,7 +477,7 @@ trait ToProcess {
                 parentScope.finalAugmentation(store, artifact, item4)
 
               // if we've seen the gitoid before we write it
-              val hasBeenSeen = store.contains(itemScope4.identifier)
+              val hasBeenSeen = store.contains(itemScope4.identifier())
 
               // update back-references for this item
               // this is *only* for the the pre-merged `Item`
@@ -494,15 +494,15 @@ trait ToProcess {
                       case Some(item) =>
                         Some(
                           item.copy(connections =
-                            item.connections + (aliasType -> itemScope4.identifier)
+                            item.connections + (aliasType -> itemScope4.identifier())
                           )
                         )
                       case None =>
                         Some(
                           Item(
-                            itemNeedingAlias,
+                            Gitoid(itemNeedingAlias),
                             // noopLocationReference,
-                            TreeSet(aliasType -> itemScope4.identifier),
+                            TreeSet(aliasType -> itemScope4.identifier()),
                             None,
                             None
                           )
@@ -523,7 +523,7 @@ trait ToProcess {
               // write
               val answerItem = store
                 .write(
-                  itemScope4.identifier,
+                  itemScope4.identifier(),
                   {
                     case None            => Some(itemScope4)
                     case Some(otherItem) => Some(otherItem.merge(itemScope4))
@@ -544,7 +544,7 @@ trait ToProcess {
 
               atEnd(parentId, answerItem)
 
-              val childGitoids: Option[Vector[GitOID]] =
+              val childGitoids: Option[Vector[Gitoid]] =
                 // if the gitoid has already been seen, do not recurse into the potential child
                 if (hasBeenSeen) None
                 else {
@@ -854,7 +854,7 @@ object ToProcess {
       store: Storage = MemStorage(None),
       args: Config,
       purlOut: PackageURL => Unit = _ => (),
-      block: Set[GitOID] = Set()
+      block: Set[Gitoid] = Set()
   ): Storage = {
 
     for { individual <- toProcess } {
@@ -895,7 +895,7 @@ object ToProcess {
       args: Config,
       store: Storage = MemStorage(None),
       purlOut: PackageURL => Unit = _ => (),
-      block: Set[GitOID] = Set()
+      block: Set[Gitoid] = Set()
   ): Storage = {
 
     // generate the strategy

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -17,7 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 
 import scala.collection.immutable.TreeMap
@@ -130,7 +130,7 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
     item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): AnnattoState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -16,7 +16,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
@@ -233,7 +233,7 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
   ): (Item, BaharatState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): BaharatState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
@@ -25,7 +25,7 @@ import io.spicelabs.goatrodeo.omnibor.Storage
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.omnibor.strategies.Certificates.KVPair
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers.sha256Hex
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 
@@ -787,7 +787,7 @@ class CertificatesState(
 
   /** Certificates never recurses into child Items. */
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): CertificatesState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -163,7 +163,7 @@ case class DockerState(
 
       // Associate the item's hash with the item's gitoid/identifier
       updatedItem -> this.copy(layerToGitoidMapping =
-        this.layerToGitoidMapping + (hash -> updatedItem.identifier)
+        this.layerToGitoidMapping + (hash -> Gitoid(updatedItem.identifier))
       )
 
     case DockerMarkers.Config(info) =>
@@ -191,7 +191,7 @@ case class DockerState(
             )
           case None => None
         },
-        _.identifier()
+        _.identifier
       )
       val updatedItem = item.enhanceWithMetadata(mimeTypes =
         Vector(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -15,7 +15,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
 
@@ -56,7 +56,7 @@ enum DockerMarkers extends ProcessingMarker {
   *   map of layer SHA256 hashes to their GitOIDs
   */
 case class DockerState(
-    layerToGitoidMapping: Map[String, String],
+    layerToGitoidMapping: Map[String, Gitoid],
     configInfo: Option[ManifestInfo] = None
 ) extends ProcessingState[DockerMarkers, DockerState] {
 
@@ -191,7 +191,7 @@ case class DockerState(
             )
           case None => None
         },
-        _.identifier
+        _.identifier()
       )
       val updatedItem = item.enhanceWithMetadata(mimeTypes =
         Vector(
@@ -209,7 +209,7 @@ case class DockerState(
             case None => item
             case Some(gitoid) =>
               item.copy(connections =
-                item.connections + (EdgeType.contains -> gitoid)
+                item.connections + (EdgeType.contains -> gitoid())
               )
           }
       }
@@ -220,7 +220,7 @@ case class DockerState(
   }
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: DockerMarkers
   ): DockerState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -163,7 +163,7 @@ case class DockerState(
 
       // Associate the item's hash with the item's gitoid/identifier
       updatedItem -> this.copy(layerToGitoidMapping =
-        this.layerToGitoidMapping + (hash -> Gitoid(updatedItem.identifier))
+        this.layerToGitoidMapping + (hash -> Gitoid(updatedItem.identifierString))
       )
 
     case DockerMarkers.Config(info) =>
@@ -191,7 +191,7 @@ case class DockerState(
             )
           case None => None
         },
-        _.identifier
+        _.identifierString
       )
       val updatedItem = item.enhanceWithMetadata(mimeTypes =
         Vector(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -19,7 +19,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.DotnetDetector
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.Helpers.toHex
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
@@ -278,7 +278,7 @@ class DotnetState(
   ): (Item, DotnetState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): DotnetState = {

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
@@ -11,7 +11,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -66,7 +66,7 @@ class GenericFileState extends ProcessingState[SingleMarker, GenericFileState] {
   ): (Item, GenericFileState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): GenericFileState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -16,7 +16,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.FileWalker
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.PURLHelpers.Ecosystems
@@ -66,7 +66,7 @@ case class MavenState(
     pomFile: String = "",
     pomXml: NodeSeq = NodeSeq.Empty,
     sources: Map[String, Item] = Map(),
-    sourceGitoids: Map[String, GitOID] = Map(),
+    sourceGitoids: Map[String, Gitoid] = Map(),
     groupId: Option[String] = None,
     artifactId: Option[String] = None,
     version: Option[String] = None,
@@ -301,14 +301,14 @@ case class MavenState(
   ): (Item, MavenState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: MavenMarkers
   ): MavenState = (marker, kids) match {
     case (MavenMarkers.Sources, Some(kids)) =>
       val items = for {
         gitoid <- kids
-        item <- store.read(gitoid).toVector
+        item <- store.read(gitoid()).toVector
         metadata <- item.bodyAsItemMetaData.toVector
         filename <- metadata.fileNames.toVector
       } yield filename -> item
@@ -352,11 +352,11 @@ case class MavenState(
       // the code that associates source with class files
       new ParentScope(augmentationByHash) {
 
-        def scopeFor(): String = item.identifier
+        def scopeFor(): String = item.identifier()
         def parentOfParentScope(): Option[ParentScope] = parentScope
 
         def parentScopeInformation(): String =
-          f"Maven/JAR Scope for ${item.identifier}${parentScope match {
+          f"Maven/JAR Scope for ${item.identifier()}${parentScope match {
               case None     => ""
               case Some(ps) => f" Parent: ${ps.parentScopeInformation()}"
             }}"
@@ -371,11 +371,11 @@ case class MavenState(
             associatedFiles = sourceGitoids
           )
           sources.foldLeft(item) { case (item, source) =>
-            item.withConnection(EdgeType.builtFrom, source)
+            item.withConnection(EdgeType.builtFrom, source())
           }
         }
       }
-    case _ => ParentScope.forAndWith(item.identifier, parentScope, Map())
+    case _ => ParentScope.forAndWith(item.identifier(), parentScope, Map())
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -314,7 +314,7 @@ case class MavenState(
       } yield filename -> item
       val ret = this.copy(
         sources = Map(items*),
-        sourceGitoids = Map(items.map { case (k, v) => k -> v.identifier }*)
+        sourceGitoids = Map(items.map { case (k, v) => k -> Gitoid(v.identifier) }*)
       )
       ret
     case _ => this
@@ -352,11 +352,11 @@ case class MavenState(
       // the code that associates source with class files
       new ParentScope(augmentationByHash) {
 
-        def scopeFor(): String = item.identifier()
+        def scopeFor(): String = item.identifier
         def parentOfParentScope(): Option[ParentScope] = parentScope
 
         def parentScopeInformation(): String =
-          f"Maven/JAR Scope for ${item.identifier()}${parentScope match {
+          f"Maven/JAR Scope for ${item.identifier}${parentScope match {
               case None     => ""
               case Some(ps) => f" Parent: ${ps.parentScopeInformation()}"
             }}"
@@ -375,7 +375,7 @@ case class MavenState(
           }
         }
       }
-    case _ => ParentScope.forAndWith(item.identifier(), parentScope, Map())
+    case _ => ParentScope.forAndWith(item.identifier, parentScope, Map())
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -314,7 +314,7 @@ case class MavenState(
       } yield filename -> item
       val ret = this.copy(
         sources = Map(items*),
-        sourceGitoids = Map(items.map { case (k, v) => k -> Gitoid(v.identifier) }*)
+        sourceGitoids = Map(items.map { case (k, v) => k -> Gitoid(v.identifierString) }*)
       )
       ret
     case _ => this
@@ -352,11 +352,11 @@ case class MavenState(
       // the code that associates source with class files
       new ParentScope(augmentationByHash) {
 
-        def scopeFor(): String = item.identifier
+        def scopeFor(): String = item.identifierString
         def parentOfParentScope(): Option[ParentScope] = parentScope
 
         def parentScopeInformation(): String =
-          f"Maven/JAR Scope for ${item.identifier}${parentScope match {
+          f"Maven/JAR Scope for ${item.identifierString}${parentScope match {
               case None     => ""
               case Some(ps) => f" Parent: ${ps.parentScopeInformation()}"
             }}"
@@ -375,7 +375,7 @@ case class MavenState(
           }
         }
       }
-    case _ => ParentScope.forAndWith(item.identifier, parentScope, Map())
+    case _ => ParentScope.forAndWith(item.identifierString, parentScope, Map())
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/EdgeTypeId.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/EdgeTypeId.scala
@@ -1,0 +1,84 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import io.spicelabs.goatrodeo.omnibor.EdgeType
+
+/** Compact `uint8` IDs for each `EdgeType` string, used in the v2 on-disk edge
+  * encoding.
+  *
+  * Reserved IDs are stable and append-only. Never renumber an existing ID —
+  * doing so would silently corrupt previously-written clusters. Unknown IDs at
+  * decode time are an error.
+  */
+object EdgeTypeId {
+  val ContainedBy: Byte = 0 // EdgeType.containedBy ("contained:up")
+  val Contains: Byte = 1 // EdgeType.contains    ("contained:down")
+  val AliasFrom: Byte = 2 // EdgeType.aliasFrom   ("alias:from")
+  val AliasTo: Byte = 3 // EdgeType.aliasTo     ("alias:to")
+  val BuildsTo: Byte = 4 // EdgeType.buildsTo    ("build:up")
+  val BuiltFrom: Byte = 5 // EdgeType.builtFrom   ("build:down")
+  val TagFrom: Byte = 6 // EdgeType.tagFrom     ("tag:from")
+  val TagTo: Byte = 7 // EdgeType.tagTo       ("tag:to")
+
+  /** Sentinel for edge-type strings the codec doesn't recognise. They round-trip
+    * via `unknownTypes` in the `WriteContext` / `ReadContext`. */
+  val Unknown: Byte = -1
+
+  def fromString(edgeType: String): Byte = edgeType match {
+    case EdgeType.containedBy => ContainedBy
+    case EdgeType.contains    => Contains
+    case EdgeType.aliasFrom   => AliasFrom
+    case EdgeType.aliasTo     => AliasTo
+    case EdgeType.buildsTo    => BuildsTo
+    case EdgeType.builtFrom   => BuiltFrom
+    case EdgeType.tagFrom     => TagFrom
+    case EdgeType.tagTo       => TagTo
+    case _                    => Unknown
+  }
+
+  def toStringOpt(id: Byte): Option[String] = id match {
+    case ContainedBy => Some(EdgeType.containedBy)
+    case Contains    => Some(EdgeType.contains)
+    case AliasFrom   => Some(EdgeType.aliasFrom)
+    case AliasTo     => Some(EdgeType.aliasTo)
+    case BuildsTo    => Some(EdgeType.buildsTo)
+    case BuiltFrom   => Some(EdgeType.builtFrom)
+    case TagFrom     => Some(EdgeType.tagFrom)
+    case TagTo       => Some(EdgeType.tagTo)
+    case _           => None
+  }
+
+  /** Predicate: does the edge form a content-DAG relationship (`contained:*` or
+    * `build:*`)? Those are the edges the topological sort follows to decide
+    * write order. Inverse direction is included on purpose — we need to know
+    * about both halves to choose the canonical projection. */
+  def isContentEdge(edgeType: String): Boolean =
+    edgeType == EdgeType.contains ||
+      edgeType == EdgeType.containedBy ||
+      edgeType == EdgeType.builtFrom ||
+      edgeType == EdgeType.buildsTo
+
+  /** The "forward" half of a content-edge pair — the direction we orient the
+    * topological sort along. An Item that has a `forwardContentEdge` to X
+    * means X should be written **before** this Item (X is a child/dependency).
+    *
+    * The convention chosen: `contained:up` (containedBy) and `build:down`
+    * (builtFrom) are the forward edges. Their inverses (`contained:down` /
+    * `build:up`) are written first via the items they point at. */
+  def isForwardContentEdge(edgeType: String): Boolean =
+    edgeType == EdgeType.containedBy ||
+      edgeType == EdgeType.builtFrom
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -1178,78 +1178,45 @@ object GitOIDUtils {
     (str.substring(0, 3), str.substring(3, 6), str.substring(6))
   }
 
-  /** The object type
-    */
-  enum ObjectType {
-    case Blob, Tree, Commit, Tag
+  // Aliases to the canonical Gitoid enums. The legacy `.gitoidName()` /
+  // `.hashTypeName()` methods are preserved via extension methods below so
+  // existing call sites keep working without source changes.
+  type ObjectType = Gitoid.ObjectType
+  val ObjectType: Gitoid.ObjectType.type = Gitoid.ObjectType
 
-    /** Get the canonical name for the Object Type
-      *
-      * @return
-      *   the canonical name for the object type
-      */
-    def gitoidName(): String = {
-      this match {
-        case Blob   => "blob"
-        case Tree   => "tree"
-        case Commit => "commit"
-        case Tag    => "tag"
-      }
+  type HashType = Gitoid.HashAlgorithm
+  val HashType: Gitoid.HashAlgorithm.type = Gitoid.HashAlgorithm
+  // Legacy enum-value names (SHA1 / SHA256) used at call sites.
+  val SHA1 = Gitoid.HashAlgorithm.Sha1
+  val SHA256 = Gitoid.HashAlgorithm.Sha256
+
+  extension (t: Gitoid.ObjectType) def gitoidName(): String = t.name
+  extension (a: Gitoid.HashAlgorithm) {
+    def hashTypeName(): String = a.name
+    def getDigest(): MessageDigest = a match {
+      case Gitoid.HashAlgorithm.Sha1   => MessageDigest.getInstance("SHA-1")
+      case Gitoid.HashAlgorithm.Sha256 => MessageDigest.getInstance("SHA-256")
     }
   }
 
-  /** Takes a set of gitoids, sorts them, converts to binary, and generates the
-    * Gitoid tree
-    *
-    * @param gitoids
-    *   the gitoids to build the tree for
-    *
-    * @return
-    *   the computed tree
-    */
+  /** Takes a set of gitoids, sorts them, and generates the merkle Gitoid tree.
+    * Each gitoid contributes its raw hash bytes directly — no hex round-trip. */
   def merkleTreeFromGitoids(
       gitoids: Vector[Gitoid],
-      hashType: HashType = HashType.SHA256
+      hashType: HashType = HashType.Sha256
   ): Gitoid = {
     val sorted = gitoids.sorted
-    val out = new ByteArrayOutputStream()
+    val md = hashType.getDigest()
+    var totalLen = 0L
+    for (gitoid <- sorted) totalLen += gitoid.hash.length
+    val prefix =
+      String.format("%s %d ", ObjectType.Tree.name, totalLen).getBytes()
+    md.update(prefix)
     for (gitoid <- sorted) {
-      Helpers.convertHexToBinaryAndAppendToStream(gitoid(), out)
+      val h = gitoid.hash.asInstanceOf[Array[Byte]]
+      md.update(h, 0, h.length)
     }
-    out.flush()
-    val ba = out.toByteArray()
-    val in = new ByteArrayInputStream(ba)
-    url(in, ba.length, hashType, ObjectType.Tree)
-  }
-
-  /** The hash type
-    */
-  enum HashType {
-    case SHA1, SHA256
-
-    /** Based on the hash type, get the MessageDigest
-      *
-      * @return
-      *   the MessageDigest for the type
-      */
-    def getDigest(): MessageDigest = {
-      this match {
-        case SHA1   => MessageDigest.getInstance("SHA-1")
-        case SHA256 => MessageDigest.getInstance("SHA-256")
-      }
-    }
-
-    /** Get the canonical name for the hash type
-      *
-      * @return
-      *   the canonical name
-      */
-    def hashTypeName(): String = {
-      this match {
-        case SHA1   => "sha1"
-        case SHA256 => "sha256"
-      }
-    }
+    Gitoid(ObjectType.Tree, hashType, md.digest())
   }
 
   /** Given an object type, String, and a hash type, compute the GitOID
@@ -1265,7 +1232,7 @@ object GitOIDUtils {
     */
   def computeGitOIDForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): Array[Byte] = {
     val bytes = str.getBytes("UTF-8")
@@ -1287,7 +1254,7 @@ object GitOIDUtils {
   def computeGitOID(
       bytes: InputStream,
       len: Long,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): Array[Byte] = {
     // get the prefix bytes in local encoding... which should be okay given that
@@ -1327,7 +1294,7 @@ object GitOIDUtils {
   def hashAsHex(
       bytes: InputStream,
       len: Long,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): String = {
     Helpers.toHex(
@@ -1349,7 +1316,7 @@ object GitOIDUtils {
     */
   def hashAsHexForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): String = {
     Helpers.toHex(
@@ -1368,16 +1335,7 @@ object GitOIDUtils {
       len: Long,
       hashType: HashType,
       tpe: ObjectType = ObjectType.Blob
-  ): Gitoid = {
-    Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        tpe.gitoidName(),
-        hashType.hashTypeName(),
-        hashAsHex(inputStream, len, hashType, tpe)
-      )
-    )
-  }
+  ): Gitoid = Gitoid(tpe, hashType, computeGitOID(inputStream, len, hashType, tpe))
 
   /** A `gitoid` URL. See
     * https://www.iana.org/assignments/uri-schemes/prov/gitoid
@@ -1387,18 +1345,10 @@ object GitOIDUtils {
     */
   def urlForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
-  ): Gitoid = {
-    Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        tpe.gitoidName(),
-        hashType.hashTypeName(),
-        hashAsHexForString(str, hashType, tpe)
-      )
-    )
-  }
+  ): Gitoid =
+    Gitoid(tpe, hashType, computeGitOIDForString(str, hashType, tpe))
 
   def computeAllHashes(
       theFile: ArtifactWrapper
@@ -1431,22 +1381,16 @@ object GitOIDUtils {
       }
     }
 
-    val gitoidSha256Str = Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        ObjectType.Blob.gitoidName(),
-        HashType.SHA256.hashTypeName(),
-        Helpers.toHex(gitoidSha256.digest())
-      )
-    )
+    val gitoidSha256Result =
+      Gitoid(ObjectType.Blob, HashType.Sha256, gitoidSha256.digest())
 
     (
-      gitoidSha256Str,
+      gitoidSha256Result,
       Vector(
         String.format(
           "gitoid:%s:%s:%s",
           ObjectType.Blob.gitoidName(),
-          HashType.SHA1.hashTypeName(),
+          HashType.Sha1.hashTypeName(),
           Helpers.toHex(gitoidSha1.digest())
         ),
         String.format("sha1:%s", Helpers.toHex(sha1.digest())),

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -954,7 +954,9 @@ object Helpers {
     if (bytesRead != len) {
       throw Exception(f"Trying to read ${len} bytes but only got ${bytesRead}")
     }
-    Cbor.decode(dest).to[A].value
+    // Reset position to the start of what we just read so the CBOR decoder
+    // sees the bytes, not the empty tail of the buffer.
+    Cbor.decode(dest.position(0)).to[A].value
   }
 
   /** Slurp the contents of a File

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -50,11 +50,6 @@ import scala.collection.immutable.TreeSet
 import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.util.Try
 
-/** Type alias for Git Object Identifiers (GitOIDs). A GitOID is a
-  * content-addressable identifier based on Git's object hashing scheme.
-  */
-type GitOID = String
-
 /** A collection of utility functions for file I/O, hashing, byte manipulation,
   * and various helper operations used throughout the Goat Rodeo project.
   *
@@ -198,8 +193,8 @@ object Helpers {
     */
   def computeAssociatedSource(
       file: ArtifactWrapper,
-      associatedFiles: Map[String, GitOID]
-  ): TreeSet[GitOID] = {
+      associatedFiles: Map[String, Gitoid]
+  ): TreeSet[Gitoid] = {
     file.mimeType match {
       case maybeClass if javaClassMimeTypes.intersect(maybeClass).nonEmpty =>
         val sourceName: Option[String] =
@@ -1213,13 +1208,13 @@ object GitOIDUtils {
     *   the computed tree
     */
   def merkleTreeFromGitoids(
-      gitoids: Vector[String],
+      gitoids: Vector[Gitoid],
       hashType: HashType = HashType.SHA256
-  ): String = {
+  ): Gitoid = {
     val sorted = gitoids.sorted
     val out = new ByteArrayOutputStream()
     for (gitoid <- sorted) {
-      Helpers.convertHexToBinaryAndAppendToStream(gitoid, out)
+      Helpers.convertHexToBinaryAndAppendToStream(gitoid(), out)
     }
     out.flush()
     val ba = out.toByteArray()
@@ -1373,12 +1368,14 @@ object GitOIDUtils {
       len: Long,
       hashType: HashType,
       tpe: ObjectType = ObjectType.Blob
-  ): String = {
-    String.format(
-      "gitoid:%s:%s:%s",
-      tpe.gitoidName(),
-      hashType.hashTypeName(),
-      hashAsHex(inputStream, len, hashType, tpe)
+  ): Gitoid = {
+    Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        tpe.gitoidName(),
+        hashType.hashTypeName(),
+        hashAsHex(inputStream, len, hashType, tpe)
+      )
     )
   }
 
@@ -1392,46 +1389,70 @@ object GitOIDUtils {
       str: String,
       hashType: HashType = HashType.SHA256,
       tpe: ObjectType = ObjectType.Blob
-  ): String = {
-    String.format(
-      "gitoid:%s:%s:%s",
-      tpe.gitoidName(),
-      hashType.hashTypeName(),
-      hashAsHexForString(str, hashType, tpe)
+  ): Gitoid = {
+    Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        tpe.gitoidName(),
+        hashType.hashTypeName(),
+        hashAsHexForString(str, hashType, tpe)
+      )
     )
   }
 
   def computeAllHashes(
       theFile: ArtifactWrapper
-  ): (String, Vector[String]) = {
+  ): (Gitoid, Vector[String]) = {
+    val len = theFile.size()
+    val gitoidPrefix =
+      String.format("%s %d ", ObjectType.Blob.gitoidName(), len).getBytes()
 
-    val gitoidSha256 =
-      theFile.withStream(url(_, theFile.size(), HashType.SHA256))
+    val gitoidSha1 = MessageDigest.getInstance("SHA-1")
+    val gitoidSha256 = MessageDigest.getInstance("SHA-256")
+    val sha1 = MessageDigest.getInstance("SHA-1")
+    val sha256 = MessageDigest.getInstance("SHA-256")
+    val sha512 = MessageDigest.getInstance("SHA-512")
+    val md5 = MessageDigest.getInstance("MD5")
+
+    gitoidSha1.update(gitoidPrefix)
+    gitoidSha256.update(gitoidPrefix)
+
+    theFile.withStream { in =>
+      val buf = new Array[Byte](64 * 1024)
+      var read = in.read(buf)
+      while (read > 0) {
+        gitoidSha1.update(buf, 0, read)
+        gitoidSha256.update(buf, 0, read)
+        sha1.update(buf, 0, read)
+        sha256.update(buf, 0, read)
+        sha512.update(buf, 0, read)
+        md5.update(buf, 0, read)
+        read = in.read(buf)
+      }
+    }
+
+    val gitoidSha256Str = Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        ObjectType.Blob.gitoidName(),
+        HashType.SHA256.hashTypeName(),
+        Helpers.toHex(gitoidSha256.digest())
+      )
+    )
 
     (
-      gitoidSha256,
+      gitoidSha256Str,
       Vector(
-        theFile.withStream(url(_, theFile.size(), HashType.SHA1)),
-        String
-          .format(
-            "sha1:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA1(_)))
-          ),
-        String
-          .format(
-            "sha256:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA256(_)))
-          ),
-        String
-          .format(
-            "sha512:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA512(_)))
-          ),
-        String
-          .format(
-            "md5:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeMD5(_)))
-          )
+        String.format(
+          "gitoid:%s:%s:%s",
+          ObjectType.Blob.gitoidName(),
+          HashType.SHA1.hashTypeName(),
+          Helpers.toHex(gitoidSha1.digest())
+        ),
+        String.format("sha1:%s", Helpers.toHex(sha1.digest())),
+        String.format("sha256:%s", Helpers.toHex(sha256.digest())),
+        String.format("sha512:%s", Helpers.toHex(sha512.digest())),
+        String.format("md5:%s", Helpers.toHex(md5.digest()))
       )
     )
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -17,21 +17,49 @@ package io.spicelabs.goatrodeo.util
 import io.bullet.borer.Decoder
 import io.bullet.borer.Encoder
 
+import java.security.MessageDigest
 import scala.annotation.targetName
 import scala.collection.immutable.ArraySeq
 
 object Opaques {
 
-  /** A Gitoid — a content-addressable identifier with an object type and hash
-    * algorithm.
+  /** Shared header-byte layout for both `Gitoid` and `Identifier`.
     *
-    * Internally a single `ArraySeq.ofByte` of length `1 + algorithm.byteLength`:
-    *   - byte 0: header — high nibble = `ObjectType.ordinal`, low nibble = `HashAlgorithm.ordinal`
+    * byte 0:
+    *   high nibble (bits 7..4) — IdentifierKind ordinal
+    *     0 = Gitoid
+    *     1 = RawHash
+    *     2 = PackageUrl
+    *     3 = Sentinel
+    *   low nibble (bits 3..0) — kind-specific sub-encoding
+    *     Gitoid:     (ObjectType.ordinal << 2) | HashAlgorithm.ordinal
+    *     RawHash:    RawHashAlgorithm.ordinal
+    *     PackageUrl: 0 (reserved)
+    *     Sentinel:   0 (reserved)
+    *
+    * bytes 1..n:
+    *   Gitoid / RawHash: raw hash bytes (length determined by algorithm)
+    *   PackageUrl / Sentinel: UTF-8 bytes of the canonical text form
+    */
+  private inline val KindGitoid = 0
+  private inline val KindRawHash = 1
+  private inline val KindPackageUrl = 2
+  private inline val KindSentinel = 3
+
+  // ============================================================================
+  // Gitoid
+  // ============================================================================
+
+  /** A Gitoid — a content-addressable git-style identifier with an object type
+    * and hash algorithm.
+    *
+    * Internally `ArraySeq.ofByte` of length `1 + algorithm.byteLength`:
+    *   - byte 0: high nibble = 0 (Identifier.Kind.Gitoid), low nibble =
+    *     `(ObjectType.ordinal << 2) | HashAlgorithm.ordinal`
     *   - bytes 1..n: raw hash bytes
     *
-    * `ArraySeq.ofByte` is backed by a single `Array[Byte]` (no per-element
-    * boxing) and provides structural equality / hashCode, which is required
-    * for `Set[Gitoid]` and `Map[Gitoid, _]` semantics.
+    * Identical wire layout to an `Identifier` whose `kind == Kind.Gitoid`, so
+    * conversion to/from `Identifier` is zero-copy.
     */
   opaque type Gitoid = ArraySeq.ofByte
 
@@ -63,53 +91,10 @@ object Opaques {
     }
 
     private inline def headerByte(t: ObjectType, a: HashAlgorithm): Byte =
-      (((t.ordinal & 0xf) << 4) | (a.ordinal & 0xf)).toByte
+      ((KindGitoid << 4) | ((t.ordinal & 0x3) << 2) | (a.ordinal & 0x3)).toByte
 
-    /** Internal byte accessor — returns the backing array directly (zero-copy).
-      * Do not mutate. */
     private[Opaques] inline def bytes(g: Gitoid): Array[Byte] = g.unsafeArray
 
-    private inline def hexNibble(c: Char): Int = c match {
-      case '0'       => 0
-      case '1'       => 1
-      case '2'       => 2
-      case '3'       => 3
-      case '4'       => 4
-      case '5'       => 5
-      case '6'       => 6
-      case '7'       => 7
-      case '8'       => 8
-      case '9'       => 9
-      case 'a' | 'A' => 10
-      case 'b' | 'B' => 11
-      case 'c' | 'C' => 12
-      case 'd' | 'D' => 13
-      case 'e' | 'E' => 14
-      case 'f' | 'F' => 15
-      case _ =>
-        throw new IllegalArgumentException(s"Invalid hex character: '$c'")
-    }
-
-    private inline def hexChar(b: Int): Char = (b & 0xf) match {
-      case 0  => '0'
-      case 1  => '1'
-      case 2  => '2'
-      case 3  => '3'
-      case 4  => '4'
-      case 5  => '5'
-      case 6  => '6'
-      case 7  => '7'
-      case 8  => '8'
-      case 9  => '9'
-      case 10 => 'a'
-      case 11 => 'b'
-      case 12 => 'c'
-      case 13 => 'd'
-      case 14 => 'e'
-      case 15 => 'f'
-    }
-
-    /** Build a Gitoid directly from binary hash bytes — no String materialised. */
     @targetName("fromIArray")
     def apply(
         objectType: ObjectType,
@@ -118,8 +103,6 @@ object Opaques {
     ): Gitoid =
       apply(objectType, algorithm, hash.asInstanceOf[Array[Byte]])
 
-    /** Build a Gitoid from a mutable `Array[Byte]` (e.g. straight from
-      * `MessageDigest.digest()`). Defensive copy. */
     @targetName("fromArray")
     def apply(
         objectType: ObjectType,
@@ -137,9 +120,7 @@ object Opaques {
       new ArraySeq.ofByte(out)
     }
 
-    /** Parse a `gitoid:<type>:<algo>:<hex>` URL into a Gitoid. Walks the input
-      * character by character; one final `Array[Byte]` allocation. Throws
-      * `IllegalArgumentException` on malformed input. */
+    /** Parse a `gitoid:<type>:<algo>:<hex>` URL into a Gitoid. */
     def apply(s: String): Gitoid = {
       val len = s.length
       val prefix = "gitoid:"
@@ -170,8 +151,8 @@ object Opaques {
       out(0) = headerByte(objectType, algorithm)
       var j = 0
       while (j < algorithm.byteLength) {
-        val hi = hexNibble(s.charAt(i + j * 2))
-        val lo = hexNibble(s.charAt(i + j * 2 + 1))
+        val hi = HexUtil.nibble(s.charAt(i + j * 2))
+        val lo = HexUtil.nibble(s.charAt(i + j * 2 + 1))
         out(1 + j) = ((hi << 4) | lo).toByte
         j += 1
       }
@@ -222,35 +203,29 @@ object Opaques {
       } else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
     }
 
-    /** Pattern-match accessor. Returns `(objectType, algorithm, hash)`. */
     def unapply(g: Gitoid): Some[(ObjectType, HashAlgorithm, IArray[Byte])] = {
       val gb = bytes(g)
-      val header = gb(0) & 0xff
-      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
-      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val sub = gb(0) & 0xf
+      val objectType = ObjectType.fromOrdinal((sub >>> 2) & 0x3)
+      val algorithm = HashAlgorithm.fromOrdinal(sub & 0x3)
       val n = algorithm.byteLength
       val hashCopy = new Array[Byte](n)
-      var i = 0
-      while (i < n) {
-        hashCopy(i) = gb(1 + i)
-        i += 1
-      }
+      System.arraycopy(gb, 1, hashCopy, 0, n)
       Some((objectType, algorithm, IArray.unsafeFromArray(hashCopy)))
     }
 
-    /** URL-form-equivalent ordering: by type name, then algo name, then hash
-      * bytes (unsigned). Matches the prior `Ordering.String` over URL strings
-      * for any two well-formed gitoids, keeping merkle outputs stable. */
     given Ordering[Gitoid] = (a: Gitoid, b: Gitoid) => {
       val ab = bytes(a)
       val bb = bytes(b)
-      val aType = ObjectType.fromOrdinal((ab(0) & 0xff) >>> 4 & 0xf)
-      val bType = ObjectType.fromOrdinal((bb(0) & 0xff) >>> 4 & 0xf)
+      val aSub = ab(0) & 0xf
+      val bSub = bb(0) & 0xf
+      val aType = ObjectType.fromOrdinal((aSub >>> 2) & 0x3)
+      val bType = ObjectType.fromOrdinal((bSub >>> 2) & 0x3)
       val typeCmp = aType.name.compareTo(bType.name)
       if (typeCmp != 0) typeCmp
       else {
-        val aAlgo = HashAlgorithm.fromOrdinal(ab(0) & 0xf)
-        val bAlgo = HashAlgorithm.fromOrdinal(bb(0) & 0xf)
+        val aAlgo = HashAlgorithm.fromOrdinal(aSub & 0x3)
+        val bAlgo = HashAlgorithm.fromOrdinal(bSub & 0x3)
         val algoCmp = aAlgo.name.compareTo(bAlgo.name)
         if (algoCmp != 0) algoCmp
         else {
@@ -266,20 +241,33 @@ object Opaques {
       }
     }
 
-    /** Borer wire format: encode/decode as the URL string. Preserves on-disk
-      * compatibility with existing ADGs. */
-    given Encoder[Gitoid] =
-      Encoder.forString.contramap[Gitoid](toUrlString)
-    given Decoder[Gitoid] =
-      Decoder.forString.map(Gitoid(_))
+    given Encoder[Gitoid] = new Encoder[Gitoid] {
+      def write(w: io.bullet.borer.Writer, g: Gitoid): w.type =
+        w.writeBytes(bytes(g))
+    }
+    given Decoder[Gitoid] = new Decoder[Gitoid] {
+      def read(r: io.bullet.borer.Reader): Gitoid = {
+        val raw = r.readByteArray()
+        if (raw.length < 1) throw new IllegalArgumentException("Empty gitoid bytes")
+        val kind = (raw(0) & 0xff) >>> 4
+        if (kind != KindGitoid)
+          throw new IllegalArgumentException(s"Bytes are not a Gitoid (kind=$kind)")
+        val sub = raw(0) & 0xf
+        val algo = HashAlgorithm.fromOrdinal(sub & 0x3)
+        if (raw.length != 1 + algo.byteLength)
+          throw new IllegalArgumentException(
+            s"Gitoid bytes length ${raw.length} does not match header (expects ${1 + algo.byteLength})"
+          )
+        new ArraySeq.ofByte(raw)
+      }
+    }
 
-    /** Reconstruct the `gitoid:<type>:<algo>:<hex>` URL. One `StringBuilder`
-      * allocation sized exactly. */
+    /** Reconstruct the `gitoid:<type>:<algo>:<hex>` URL. */
     private[Opaques] def toUrlString(g: Gitoid): String = {
       val gb = bytes(g)
-      val header = gb(0) & 0xff
-      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
-      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val sub = gb(0) & 0xf
+      val objectType = ObjectType.fromOrdinal((sub >>> 2) & 0x3)
+      val algorithm = HashAlgorithm.fromOrdinal(sub & 0x3)
       val typeName = objectType.name
       val algoName = algorithm.name
       val n = algorithm.byteLength
@@ -290,8 +278,8 @@ object Opaques {
       var i = 0
       while (i < n) {
         val b = gb(1 + i) & 0xff
-        sb.append(hexChar(b >>> 4))
-        sb.append(hexChar(b & 0xf))
+        sb.append(HexUtil.char(b >>> 4))
+        sb.append(HexUtil.char(b & 0xf))
         i += 1
       }
       sb.toString
@@ -299,53 +287,261 @@ object Opaques {
   }
 
   extension (g: Gitoid) {
-    /** Reconstruct the URL form. Allocates a fresh String. */
     def apply(): String = Gitoid.toUrlString(g)
 
     def objectType: Gitoid.ObjectType =
-      Gitoid.ObjectType.fromOrdinal((Gitoid.bytes(g)(0) & 0xff) >>> 4 & 0xf)
+      Gitoid.ObjectType.fromOrdinal(((Gitoid.bytes(g)(0) & 0xf) >>> 2) & 0x3)
 
     def hashAlgorithm: Gitoid.HashAlgorithm =
-      Gitoid.HashAlgorithm.fromOrdinal(Gitoid.bytes(g)(0) & 0xf)
+      Gitoid.HashAlgorithm.fromOrdinal(Gitoid.bytes(g)(0) & 0x3)
 
-    /** A copy of the hash bytes (without the header). */
     def hash: IArray[Byte] = {
       val gb = Gitoid.bytes(g)
       val n = gb.length - 1
       val out = new Array[Byte](n)
-      var i = 0
-      while (i < n) {
-        out(i) = gb(1 + i)
-        i += 1
-      }
+      System.arraycopy(gb, 1, out, 0, n)
       IArray.unsafeFromArray(out)
     }
 
-    def isBlobSha256: Boolean = Gitoid.bytes(g)(0) == ((0 << 4) | 1).toByte
+    /** A Gitoid is "blob+sha256" iff sub-encoding bits are `(Blob.ordinal << 2)
+      * | Sha256.ordinal` = `(0 << 2) | 1` = 1. */
+    def isBlobSha256: Boolean =
+      Gitoid.bytes(g)(0) == ((KindGitoid << 4) | 1).toByte
 
-    /** Does the URL form start with the given prefix? Materialises the URL
-      * string — callers in performance-sensitive paths should prefer
-      * `objectType` / `hashAlgorithm` checks. */
     def startsWith(prefix: String): Boolean =
       Gitoid.toUrlString(g).startsWith(prefix)
   }
 
-  /** A canonical Package URL (https://github.com/package-url/purl-spec).
+  // ============================================================================
+  // Identifier
+  // ============================================================================
+
+  /** A general-purpose `Item` identifier — Gitoid, raw hash alias, package URL,
+    * or sentinel string. Byte-encoded as a single `ArraySeq.ofByte` whose first
+    * byte tags the kind (see top-of-file layout comment); the remaining bytes
+    * are kind-dependent.
     *
-    * Internally just the canonical `String` — `PackageURL` objects are
-    * ephemeral and we never carry them around in long-lived state; the
-    * canonical form is the wire format and the in-memory representation alike.
-    * The opaque type adds compile-time type safety at API boundaries (so a
-    * stray non-pURL String can't end up in a pURL position) without changing
-    * any byte on disk or in memory. */
+    * Sharing the wire layout with `Gitoid` means converting between them is
+    * zero-copy when the underlying bytes are valid for both. */
+  opaque type Identifier = ArraySeq.ofByte
+
+  object Identifier {
+
+    enum Kind {
+      case Gitoid, RawHash, PackageUrl, Sentinel
+    }
+
+    enum RawHashAlgorithm {
+      case Md5, Sha1, Sha256, Sha512
+
+      def byteLength: Int = this match {
+        case Md5    => 16
+        case Sha1   => 20
+        case Sha256 => 32
+        case Sha512 => 64
+      }
+
+      def name: String = this match {
+        case Md5    => "md5"
+        case Sha1   => "sha1"
+        case Sha256 => "sha256"
+        case Sha512 => "sha512"
+      }
+    }
+
+    private[Opaques] inline def bytes(id: Identifier): Array[Byte] = id.unsafeArray
+
+    private inline def headerByte(kind: Int, sub: Int): Byte =
+      (((kind & 0xf) << 4) | (sub & 0xf)).toByte
+
+    // ---- Construction from typed sources (cheap, no parsing) ---------------
+
+    /** Zero-copy: the underlying `ArraySeq.ofByte` is already valid as both
+      * `Gitoid` and `Identifier` because they share the byte layout. */
+    def fromGitoid(g: Gitoid): Identifier = g.asInstanceOf[Identifier]
+
+    def fromPackageUrl(p: PackageUrl): Identifier = {
+      val utf8 = p.apply().getBytes("UTF-8")
+      val out = new Array[Byte](1 + utf8.length)
+      out(0) = headerByte(KindPackageUrl, 0)
+      System.arraycopy(utf8, 0, out, 1, utf8.length)
+      new ArraySeq.ofByte(out)
+    }
+
+    def sentinel(text: String): Identifier = {
+      val utf8 = text.getBytes("UTF-8")
+      val out = new Array[Byte](1 + utf8.length)
+      out(0) = headerByte(KindSentinel, 0)
+      System.arraycopy(utf8, 0, out, 1, utf8.length)
+      new ArraySeq.ofByte(out)
+    }
+
+    def rawHash(algo: RawHashAlgorithm, hash: Array[Byte]): Identifier = {
+      if (hash.length != algo.byteLength)
+        throw new IllegalArgumentException(
+          s"Hash length ${hash.length} does not match ${algo.name} byte length ${algo.byteLength}"
+        )
+      val out = new Array[Byte](1 + algo.byteLength)
+      out(0) = headerByte(KindRawHash, algo.ordinal & 0xf)
+      System.arraycopy(hash, 0, out, 1, algo.byteLength)
+      new ArraySeq.ofByte(out)
+    }
+
+    // ---- Construction from canonical String (dispatches on prefix) ---------
+
+    /** Parse a canonical identifier string into the appropriate kind:
+      *
+      *   "gitoid:…"   → Gitoid
+      *   "md5:…" / "sha1:…" / "sha256:…" / "sha512:…" → RawHash
+      *   "pkg:…"      → PackageUrl
+      *   otherwise    → Sentinel (free-form text, tolerates "tags" et al.)
+      */
+    def apply(canonical: String): Identifier = {
+      if (canonical.startsWith("gitoid:")) {
+        fromGitoid(Gitoid(canonical))
+      } else if (canonical.startsWith("pkg:")) {
+        fromPackageUrl(PackageUrl(canonical))
+      } else {
+        // Possible raw-hash prefixes.
+        val algoOpt: Option[RawHashAlgorithm] =
+          if (canonical.startsWith("md5:")) Some(RawHashAlgorithm.Md5)
+          else if (canonical.startsWith("sha1:")) Some(RawHashAlgorithm.Sha1)
+          else if (canonical.startsWith("sha256:")) Some(RawHashAlgorithm.Sha256)
+          else if (canonical.startsWith("sha512:")) Some(RawHashAlgorithm.Sha512)
+          else None
+        algoOpt match {
+          case Some(algo) =>
+            val colonAt = canonical.indexOf(':')
+            val hexStart = colonAt + 1
+            val expectedHex = algo.byteLength * 2
+            if (canonical.length - hexStart != expectedHex) {
+              // Wrong hex length — preserve as sentinel rather than reject.
+              // This keeps short test fixtures and unusual identifier strings
+              // working without burdening every caller with a try/catch.
+              sentinel(canonical)
+            } else {
+              val hash = new Array[Byte](algo.byteLength)
+              var j = 0
+              var fallToSentinel = false
+              while (j < algo.byteLength && !fallToSentinel) {
+                try {
+                  val hi = HexUtil.nibble(canonical.charAt(hexStart + j * 2))
+                  val lo = HexUtil.nibble(canonical.charAt(hexStart + j * 2 + 1))
+                  hash(j) = ((hi << 4) | lo).toByte
+                  j += 1
+                } catch {
+                  case _: IllegalArgumentException =>
+                    fallToSentinel = true
+                }
+              }
+              if (fallToSentinel) sentinel(canonical) else rawHash(algo, hash)
+            }
+          case None =>
+            sentinel(canonical)
+        }
+      }
+    }
+
+    given Ordering[Identifier] = (a: Identifier, b: Identifier) => {
+      val ab = bytes(a)
+      val bb = bytes(b)
+      val n = math.min(ab.length, bb.length)
+      var i = 0
+      var result = 0
+      while (i < n && result == 0) {
+        result = (ab(i) & 0xff) - (bb(i) & 0xff)
+        i += 1
+      }
+      if (result != 0) result else ab.length - bb.length
+    }
+
+    given Encoder[Identifier] = new Encoder[Identifier] {
+      def write(w: io.bullet.borer.Writer, id: Identifier): w.type =
+        w.writeBytes(bytes(id))
+    }
+    given Decoder[Identifier] = new Decoder[Identifier] {
+      def read(r: io.bullet.borer.Reader): Identifier =
+        new ArraySeq.ofByte(r.readByteArray())
+    }
+
+    /** Materialise the canonical String form. Used by the lazy cache on
+      * `Item` so each Item pays at most once. */
+    private[Opaques] def toCanonicalString(id: Identifier): String = {
+      val ib = bytes(id)
+      if (ib.length == 0)
+        throw new IllegalStateException("Identifier with no bytes")
+      val kind = (ib(0) & 0xff) >>> 4
+      kind match {
+        case KindGitoid     => Gitoid.toUrlString(id.asInstanceOf[Gitoid])
+        case KindRawHash    => rawHashString(ib)
+        case KindPackageUrl => new String(ib, 1, ib.length - 1, "UTF-8")
+        case KindSentinel   => new String(ib, 1, ib.length - 1, "UTF-8")
+        case other =>
+          throw new IllegalStateException(s"Unknown Identifier kind: $other")
+      }
+    }
+
+    private def rawHashString(ib: Array[Byte]): String = {
+      val algo = RawHashAlgorithm.fromOrdinal(ib(0) & 0xf)
+      val n = algo.byteLength
+      val name = algo.name
+      val totalLen = name.length + 1 + n * 2
+      val sb = new java.lang.StringBuilder(totalLen)
+      sb.append(name).append(':')
+      var i = 0
+      while (i < n) {
+        val b = ib(1 + i) & 0xff
+        sb.append(HexUtil.char(b >>> 4))
+        sb.append(HexUtil.char(b & 0xf))
+        i += 1
+      }
+      sb.toString
+    }
+  }
+
+  extension (id: Identifier) {
+    /** Canonical text form. */
+    @targetName("identifierApply")
+    def apply(): String = Identifier.toCanonicalString(id)
+
+    @targetName("identifierKind")
+    def kind: Identifier.Kind = {
+      val k = (Identifier.bytes(id)(0) & 0xff) >>> 4
+      Identifier.Kind.fromOrdinal(k)
+    }
+
+    @targetName("identifierIsGitoid")
+    def isGitoid: Boolean = ((Identifier.bytes(id)(0) & 0xff) >>> 4) == KindGitoid
+
+    /** Zero-copy conversion to `Gitoid` when this identifier IS a gitoid. */
+    @targetName("identifierAsGitoid")
+    def asGitoid: Option[Gitoid] =
+      if (id.isGitoid) Some(id.asInstanceOf[Gitoid]) else None
+
+    /** MD5 of the raw identifier bytes — no UTF-8 round-trip through a
+      * canonical String. */
+    @targetName("identifierMd5")
+    def md5: Array[Byte] = {
+      val md = MessageDigest.getInstance("MD5")
+      md.digest(Identifier.bytes(id))
+    }
+
+    @targetName("identifierMd5Hex")
+    def md5Hex: String = bytesToHex(id.md5)
+
+    @targetName("identifierStartsWith")
+    def startsWith(prefix: String): Boolean =
+      Identifier.toCanonicalString(id).startsWith(prefix)
+  }
+
+  // ============================================================================
+  // PackageUrl
+  // ============================================================================
+
   opaque type PackageUrl = String
 
   object PackageUrl {
 
-    /** Wrap a canonical `pkg:...` String. Validates by round-tripping the
-      * input through `com.github.packageurl.PackageURL` and re-canonicalising;
-      * throws `IllegalArgumentException` if the input is malformed or not
-      * already in canonical form. */
     def apply(canonical: String): PackageUrl = {
       val parsed = new com.github.packageurl.PackageURL(canonical)
       val again = parsed.canonicalize()
@@ -356,13 +552,10 @@ object Opaques {
       canonical
     }
 
-    /** Wrap a `PackageURL` directly — the common case in production where
-      * we build pURLs via `PackageURLBuilder`. */
     def apply(purl: com.github.packageurl.PackageURL): PackageUrl =
       purl.canonicalize()
 
     given Ordering[PackageUrl] = Ordering.String
-
     given Encoder[PackageUrl] =
       Encoder.forString.asInstanceOf[Encoder[PackageUrl]]
     given Decoder[PackageUrl] =
@@ -370,17 +563,75 @@ object Opaques {
   }
 
   extension (p: PackageUrl) {
-    /** The canonical `pkg:...` String form. */
     def apply(): String = p
 
-    /** Parse the canonical form back into a mutable `PackageURL` object for
-      * field access (`getType`, `getNamespace`, `getQualifiers`, etc.). */
     def parsed: com.github.packageurl.PackageURL =
       new com.github.packageurl.PackageURL(p)
 
     def startsWith(prefix: String): Boolean = (p: String).startsWith(prefix)
   }
+
+  // ============================================================================
+  // Shared hex utilities (also used by Helpers but kept private to Opaques
+  // so the encoders/decoders here have no external dependencies). The public
+  // hex helpers in Helpers.scala are unchanged.
+  // ============================================================================
+
+  private object HexUtil {
+    inline def nibble(c: Char): Int = c match {
+      case '0'       => 0
+      case '1'       => 1
+      case '2'       => 2
+      case '3'       => 3
+      case '4'       => 4
+      case '5'       => 5
+      case '6'       => 6
+      case '7'       => 7
+      case '8'       => 8
+      case '9'       => 9
+      case 'a' | 'A' => 10
+      case 'b' | 'B' => 11
+      case 'c' | 'C' => 12
+      case 'd' | 'D' => 13
+      case 'e' | 'E' => 14
+      case 'f' | 'F' => 15
+      case _ =>
+        throw new IllegalArgumentException(s"Invalid hex character: '$c'")
+    }
+
+    inline def char(b: Int): Char = (b & 0xf) match {
+      case 0  => '0'
+      case 1  => '1'
+      case 2  => '2'
+      case 3  => '3'
+      case 4  => '4'
+      case 5  => '5'
+      case 6  => '6'
+      case 7  => '7'
+      case 8  => '8'
+      case 9  => '9'
+      case 10 => 'a'
+      case 11 => 'b'
+      case 12 => 'c'
+      case 13 => 'd'
+      case 14 => 'e'
+      case 15 => 'f'
+    }
+  }
+
+  private def bytesToHex(arr: Array[Byte]): String = {
+    val sb = new java.lang.StringBuilder(arr.length * 2)
+    var i = 0
+    while (i < arr.length) {
+      val b = arr(i) & 0xff
+      sb.append(HexUtil.char(b >>> 4))
+      sb.append(HexUtil.char(b & 0xf))
+      i += 1
+    }
+    sb.toString
+  }
 }
 
 export Opaques.Gitoid
+export Opaques.Identifier
 export Opaques.PackageUrl

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -14,25 +14,320 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.util
 
-import io.bullet.borer.Encoder
 import io.bullet.borer.Decoder
+import io.bullet.borer.Encoder
+
+import scala.annotation.targetName
+import scala.collection.immutable.ArraySeq
 
 object Opaques {
-  opaque type Gitoid = String
+
+  /** A Gitoid — a content-addressable identifier with an object type and hash
+    * algorithm.
+    *
+    * Internally a single `ArraySeq.ofByte` of length `1 + algorithm.byteLength`:
+    *   - byte 0: header — high nibble = `ObjectType.ordinal`, low nibble = `HashAlgorithm.ordinal`
+    *   - bytes 1..n: raw hash bytes
+    *
+    * `ArraySeq.ofByte` is backed by a single `Array[Byte]` (no per-element
+    * boxing) and provides structural equality / hashCode, which is required
+    * for `Set[Gitoid]` and `Map[Gitoid, _]` semantics.
+    */
+  opaque type Gitoid = ArraySeq.ofByte
 
   object Gitoid {
-    def apply(string: String): Gitoid = string
 
-    given Ordering[Gitoid] = Ordering.String
-    given Encoder[Gitoid] = Encoder.forString.write(_, _)
-    given Decoder[Gitoid] = Decoder.forString.read(_)
+    enum ObjectType {
+      case Blob, Tree, Commit, Tag
+
+      def name: String = this match {
+        case Blob   => "blob"
+        case Tree   => "tree"
+        case Commit => "commit"
+        case Tag    => "tag"
+      }
+    }
+
+    enum HashAlgorithm {
+      case Sha1, Sha256
+
+      def name: String = this match {
+        case Sha1   => "sha1"
+        case Sha256 => "sha256"
+      }
+
+      def byteLength: Int = this match {
+        case Sha1   => 20
+        case Sha256 => 32
+      }
+    }
+
+    private inline def headerByte(t: ObjectType, a: HashAlgorithm): Byte =
+      (((t.ordinal & 0xf) << 4) | (a.ordinal & 0xf)).toByte
+
+    /** Internal byte accessor — returns the backing array directly (zero-copy).
+      * Do not mutate. */
+    private[Opaques] inline def bytes(g: Gitoid): Array[Byte] = g.unsafeArray
+
+    private inline def hexNibble(c: Char): Int = c match {
+      case '0'       => 0
+      case '1'       => 1
+      case '2'       => 2
+      case '3'       => 3
+      case '4'       => 4
+      case '5'       => 5
+      case '6'       => 6
+      case '7'       => 7
+      case '8'       => 8
+      case '9'       => 9
+      case 'a' | 'A' => 10
+      case 'b' | 'B' => 11
+      case 'c' | 'C' => 12
+      case 'd' | 'D' => 13
+      case 'e' | 'E' => 14
+      case 'f' | 'F' => 15
+      case _ =>
+        throw new IllegalArgumentException(s"Invalid hex character: '$c'")
+    }
+
+    private inline def hexChar(b: Int): Char = (b & 0xf) match {
+      case 0  => '0'
+      case 1  => '1'
+      case 2  => '2'
+      case 3  => '3'
+      case 4  => '4'
+      case 5  => '5'
+      case 6  => '6'
+      case 7  => '7'
+      case 8  => '8'
+      case 9  => '9'
+      case 10 => 'a'
+      case 11 => 'b'
+      case 12 => 'c'
+      case 13 => 'd'
+      case 14 => 'e'
+      case 15 => 'f'
+    }
+
+    /** Build a Gitoid directly from binary hash bytes — no String materialised. */
+    @targetName("fromIArray")
+    def apply(
+        objectType: ObjectType,
+        algorithm: HashAlgorithm,
+        hash: IArray[Byte]
+    ): Gitoid =
+      apply(objectType, algorithm, hash.asInstanceOf[Array[Byte]])
+
+    /** Build a Gitoid from a mutable `Array[Byte]` (e.g. straight from
+      * `MessageDigest.digest()`). Defensive copy. */
+    @targetName("fromArray")
+    def apply(
+        objectType: ObjectType,
+        algorithm: HashAlgorithm,
+        hash: Array[Byte]
+    ): Gitoid = {
+      val expected = algorithm.byteLength
+      if (hash.length != expected)
+        throw new IllegalArgumentException(
+          s"Hash length ${hash.length} does not match ${algorithm.name} byte length $expected"
+        )
+      val out = new Array[Byte](1 + expected)
+      out(0) = headerByte(objectType, algorithm)
+      System.arraycopy(hash, 0, out, 1, expected)
+      new ArraySeq.ofByte(out)
+    }
+
+    /** Parse a `gitoid:<type>:<algo>:<hex>` URL into a Gitoid. Walks the input
+      * character by character; one final `Array[Byte]` allocation. Throws
+      * `IllegalArgumentException` on malformed input. */
+    def apply(s: String): Gitoid = {
+      val len = s.length
+      val prefix = "gitoid:"
+      if (len < prefix.length || !s.startsWith(prefix))
+        throw new IllegalArgumentException(s"Not a gitoid URL: '$s'")
+      var i = prefix.length
+
+      val tStart = i
+      while (i < len && s.charAt(i) != ':') i += 1
+      if (i >= len)
+        throw new IllegalArgumentException(s"Missing object type separator in: '$s'")
+      val objectType = parseObjectType(s, tStart, i)
+      i += 1
+
+      val aStart = i
+      while (i < len && s.charAt(i) != ':') i += 1
+      if (i >= len)
+        throw new IllegalArgumentException(s"Missing hash algorithm separator in: '$s'")
+      val algorithm = parseHashAlgorithm(s, aStart, i)
+      i += 1
+
+      val expectedHexLen = algorithm.byteLength * 2
+      if (len - i != expectedHexLen)
+        throw new IllegalArgumentException(
+          s"Expected $expectedHexLen hex characters for ${algorithm.name}, got ${len - i} in: '$s'"
+        )
+      val out = new Array[Byte](1 + algorithm.byteLength)
+      out(0) = headerByte(objectType, algorithm)
+      var j = 0
+      while (j < algorithm.byteLength) {
+        val hi = hexNibble(s.charAt(i + j * 2))
+        val lo = hexNibble(s.charAt(i + j * 2 + 1))
+        out(1 + j) = ((hi << 4) | lo).toByte
+        j += 1
+      }
+      new ArraySeq.ofByte(out)
+    }
+
+    private def parseObjectType(s: String, from: Int, until: Int): ObjectType = {
+      val tokenLen = until - from
+      if (tokenLen == 4) {
+        if (s.charAt(from) == 'b' && s.charAt(from + 1) == 'l' &&
+          s.charAt(from + 2) == 'o' && s.charAt(from + 3) == 'b')
+          ObjectType.Blob
+        else if (s.charAt(from) == 't' && s.charAt(from + 1) == 'r' &&
+          s.charAt(from + 2) == 'e' && s.charAt(from + 3) == 'e')
+          ObjectType.Tree
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else if (tokenLen == 6) {
+        if (s.charAt(from) == 'c' && s.charAt(from + 1) == 'o' &&
+          s.charAt(from + 2) == 'm' && s.charAt(from + 3) == 'm' &&
+          s.charAt(from + 4) == 'i' && s.charAt(from + 5) == 't')
+          ObjectType.Commit
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else if (tokenLen == 3) {
+        if (s.charAt(from) == 't' && s.charAt(from + 1) == 'a' &&
+          s.charAt(from + 2) == 'g')
+          ObjectType.Tag
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+    }
+
+    private def parseHashAlgorithm(
+        s: String,
+        from: Int,
+        until: Int
+    ): HashAlgorithm = {
+      val tokenLen = until - from
+      if (tokenLen == 4) {
+        if (s.charAt(from) == 's' && s.charAt(from + 1) == 'h' &&
+          s.charAt(from + 2) == 'a' && s.charAt(from + 3) == '1')
+          HashAlgorithm.Sha1
+        else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+      } else if (tokenLen == 6) {
+        if (s.charAt(from) == 's' && s.charAt(from + 1) == 'h' &&
+          s.charAt(from + 2) == 'a' && s.charAt(from + 3) == '2' &&
+          s.charAt(from + 4) == '5' && s.charAt(from + 5) == '6')
+          HashAlgorithm.Sha256
+        else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+      } else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+    }
+
+    /** Pattern-match accessor. Returns `(objectType, algorithm, hash)`. */
+    def unapply(g: Gitoid): Some[(ObjectType, HashAlgorithm, IArray[Byte])] = {
+      val gb = bytes(g)
+      val header = gb(0) & 0xff
+      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
+      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val n = algorithm.byteLength
+      val hashCopy = new Array[Byte](n)
+      var i = 0
+      while (i < n) {
+        hashCopy(i) = gb(1 + i)
+        i += 1
+      }
+      Some((objectType, algorithm, IArray.unsafeFromArray(hashCopy)))
+    }
+
+    /** URL-form-equivalent ordering: by type name, then algo name, then hash
+      * bytes (unsigned). Matches the prior `Ordering.String` over URL strings
+      * for any two well-formed gitoids, keeping merkle outputs stable. */
+    given Ordering[Gitoid] = (a: Gitoid, b: Gitoid) => {
+      val ab = bytes(a)
+      val bb = bytes(b)
+      val aType = ObjectType.fromOrdinal((ab(0) & 0xff) >>> 4 & 0xf)
+      val bType = ObjectType.fromOrdinal((bb(0) & 0xff) >>> 4 & 0xf)
+      val typeCmp = aType.name.compareTo(bType.name)
+      if (typeCmp != 0) typeCmp
+      else {
+        val aAlgo = HashAlgorithm.fromOrdinal(ab(0) & 0xf)
+        val bAlgo = HashAlgorithm.fromOrdinal(bb(0) & 0xf)
+        val algoCmp = aAlgo.name.compareTo(bAlgo.name)
+        if (algoCmp != 0) algoCmp
+        else {
+          val n = math.min(ab.length, bb.length)
+          var i = 1
+          var result = 0
+          while (i < n && result == 0) {
+            result = (ab(i) & 0xff) - (bb(i) & 0xff)
+            i += 1
+          }
+          if (result != 0) result else ab.length - bb.length
+        }
+      }
+    }
+
+    /** Borer wire format: encode/decode as the URL string. Preserves on-disk
+      * compatibility with existing ADGs. */
+    given Encoder[Gitoid] =
+      Encoder.forString.contramap[Gitoid](toUrlString)
+    given Decoder[Gitoid] =
+      Decoder.forString.map(Gitoid(_))
+
+    /** Reconstruct the `gitoid:<type>:<algo>:<hex>` URL. One `StringBuilder`
+      * allocation sized exactly. */
+    private[Opaques] def toUrlString(g: Gitoid): String = {
+      val gb = bytes(g)
+      val header = gb(0) & 0xff
+      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
+      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val typeName = objectType.name
+      val algoName = algorithm.name
+      val n = algorithm.byteLength
+      val totalLen =
+        "gitoid:".length + typeName.length + 1 + algoName.length + 1 + n * 2
+      val sb = new java.lang.StringBuilder(totalLen)
+      sb.append("gitoid:").append(typeName).append(':').append(algoName).append(':')
+      var i = 0
+      while (i < n) {
+        val b = gb(1 + i) & 0xff
+        sb.append(hexChar(b >>> 4))
+        sb.append(hexChar(b & 0xf))
+        i += 1
+      }
+      sb.toString
+    }
   }
 
-  extension (gitoid: Gitoid) {
-    def apply(): String = gitoid
-    def length: Int = (gitoid: String).length
-    def startsWith(prefix: String): Boolean = (gitoid: String).startsWith(prefix)
-    def isBlobSha256: Boolean = (gitoid: String).startsWith("gitoid:blob:sha256:")
+  extension (g: Gitoid) {
+    /** Reconstruct the URL form. Allocates a fresh String. */
+    def apply(): String = Gitoid.toUrlString(g)
+
+    def objectType: Gitoid.ObjectType =
+      Gitoid.ObjectType.fromOrdinal((Gitoid.bytes(g)(0) & 0xff) >>> 4 & 0xf)
+
+    def hashAlgorithm: Gitoid.HashAlgorithm =
+      Gitoid.HashAlgorithm.fromOrdinal(Gitoid.bytes(g)(0) & 0xf)
+
+    /** A copy of the hash bytes (without the header). */
+    def hash: IArray[Byte] = {
+      val gb = Gitoid.bytes(g)
+      val n = gb.length - 1
+      val out = new Array[Byte](n)
+      var i = 0
+      while (i < n) {
+        out(i) = gb(1 + i)
+        i += 1
+      }
+      IArray.unsafeFromArray(out)
+    }
+
+    def isBlobSha256: Boolean = Gitoid.bytes(g)(0) == ((0 << 4) | 1).toByte
+
+    /** Does the URL form start with the given prefix? Materialises the URL
+      * string — callers in performance-sensitive paths should prefer
+      * `objectType` / `hashAlgorithm` checks. */
+    def startsWith(prefix: String): Boolean =
+      Gitoid.toUrlString(g).startsWith(prefix)
   }
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -1,0 +1,39 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import io.bullet.borer.Encoder
+import io.bullet.borer.Decoder
+
+object Opaques {
+  opaque type Gitoid = String
+
+  object Gitoid {
+    def apply(string: String): Gitoid = string
+
+    given Ordering[Gitoid] = Ordering.String
+    given Encoder[Gitoid] = Encoder.forString.write(_, _)
+    given Decoder[Gitoid] = Decoder.forString.read(_)
+  }
+
+  extension (gitoid: Gitoid) {
+    def apply(): String = gitoid
+    def length: Int = (gitoid: String).length
+    def startsWith(prefix: String): Boolean = (gitoid: String).startsWith(prefix)
+    def isBlobSha256: Boolean = (gitoid: String).startsWith("gitoid:blob:sha256:")
+  }
+}
+
+export Opaques.Gitoid

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -329,6 +329,58 @@ object Opaques {
     def startsWith(prefix: String): Boolean =
       Gitoid.toUrlString(g).startsWith(prefix)
   }
+
+  /** A canonical Package URL (https://github.com/package-url/purl-spec).
+    *
+    * Internally just the canonical `String` — `PackageURL` objects are
+    * ephemeral and we never carry them around in long-lived state; the
+    * canonical form is the wire format and the in-memory representation alike.
+    * The opaque type adds compile-time type safety at API boundaries (so a
+    * stray non-pURL String can't end up in a pURL position) without changing
+    * any byte on disk or in memory. */
+  opaque type PackageUrl = String
+
+  object PackageUrl {
+
+    /** Wrap a canonical `pkg:...` String. Validates by round-tripping the
+      * input through `com.github.packageurl.PackageURL` and re-canonicalising;
+      * throws `IllegalArgumentException` if the input is malformed or not
+      * already in canonical form. */
+    def apply(canonical: String): PackageUrl = {
+      val parsed = new com.github.packageurl.PackageURL(canonical)
+      val again = parsed.canonicalize()
+      if (again != canonical)
+        throw new IllegalArgumentException(
+          s"Not a canonical PackageURL: '$canonical' canonicalises to '$again'"
+        )
+      canonical
+    }
+
+    /** Wrap a `PackageURL` directly — the common case in production where
+      * we build pURLs via `PackageURLBuilder`. */
+    def apply(purl: com.github.packageurl.PackageURL): PackageUrl =
+      purl.canonicalize()
+
+    given Ordering[PackageUrl] = Ordering.String
+
+    given Encoder[PackageUrl] =
+      Encoder.forString.asInstanceOf[Encoder[PackageUrl]]
+    given Decoder[PackageUrl] =
+      Decoder.forString.asInstanceOf[Decoder[PackageUrl]]
+  }
+
+  extension (p: PackageUrl) {
+    /** The canonical `pkg:...` String form. */
+    def apply(): String = p
+
+    /** Parse the canonical form back into a mutable `PackageURL` object for
+      * field access (`getType`, `getNamespace`, `getQualifiers`, etc.). */
+    def parsed: com.github.packageurl.PackageURL =
+      new com.github.packageurl.PackageURL(p)
+
+    def startsWith(prefix: String): Boolean = (p: String).startsWith(prefix)
+  }
 }
 
 export Opaques.Gitoid
+export Opaques.PackageUrl

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -12,6 +12,7 @@ import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
 import io.spicelabs.goatrodeo.util.Gitoid
+import io.spicelabs.goatrodeo.util.PackageUrl
 import org.json4s.*
 import org.json4s.JsonAST.*
 import org.json4s.native.*
@@ -49,7 +50,7 @@ class DockerSuite extends munit.FunSuite {
 
     assertEquals(
       result,
-      TreeSet("pkg:docker/bigtent@2025_03_22")
+      TreeSet(PackageUrl("pkg:docker/bigtent@2025_03_22"))
     )
 
     val item = store1.read("pkg:docker/bigtent@2025_03_22").get
@@ -94,12 +95,12 @@ class DockerSuite extends munit.FunSuite {
 
     val result = store1.purls().filter(_.startsWith("pkg:docker"))
     val expectedpurls = TreeSet(
-      "pkg:docker/postgres@16.6",
-      "pkg:docker/postgres@9.6.12",
-      "pkg:docker/spicelabs%2Fbigtent@0.8.3",
-      "pkg:docker/spicelabs%2Fbigtent@latest",
-      "pkg:docker/spicelabs%2Fgrinder@0.1.0",
-      "pkg:docker/spicelabs%2Fgrinder@latest"
+      PackageUrl("pkg:docker/postgres@16.6"),
+      PackageUrl("pkg:docker/postgres@9.6.12"),
+      PackageUrl("pkg:docker/spicelabs%2Fbigtent@0.8.3"),
+      PackageUrl("pkg:docker/spicelabs%2Fbigtent@latest"),
+      PackageUrl("pkg:docker/spicelabs%2Fgrinder@0.1.0"),
+      PackageUrl("pkg:docker/spicelabs%2Fgrinder@latest")
     )
 
     assertEquals(result, expectedpurls)
@@ -107,7 +108,7 @@ class DockerSuite extends munit.FunSuite {
     for {
       purl <- expectedpurls
     } {
-      val item = store1.read(purl).get
+      val item = store1.read(purl()).get
       val aliasTo = item.connections
         .collect { case (t, v) if EdgeType.isAliasTo(t) => v }
         .headOption

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -11,6 +11,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.DockerToProcess
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import org.json4s.*
 import org.json4s.JsonAST.*
 import org.json4s.native.*
@@ -23,7 +24,7 @@ class DockerSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -24,7 +24,7 @@ class DockerSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -245,6 +245,6 @@ class DotNetTesting extends munit.FunSuite {
 
     val result = store1.purls()
     assertEquals(result.size, 1)
-    result.foreach(s => assertEquals(s, "pkg:nuget/BDInfo@0.8.0"))
+    result.foreach(s => assertEquals(s(), "pkg:nuget/BDInfo@0.8.0"))
   }
 }

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -8,6 +8,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.DotnetState
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import java.io.File
 import scala.collection.immutable.TreeMap
@@ -20,7 +21,7 @@ class DotNetTesting extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -21,7 +21,7 @@ class DotNetTesting extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/GitOIDUtilsTestSuite.scala
+++ b/src/test/scala/GitOIDUtilsTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.GitOIDUtils.HashType
 import io.spicelabs.goatrodeo.util.GitOIDUtils.ObjectType
+import io.spicelabs.goatrodeo.util.GitOIDUtils.{getDigest, hashTypeName, gitoidName}
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.ByteArrayInputStream
@@ -87,20 +88,20 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   // ==================== HashType Tests ====================
 
   test("HashType.hashTypeName - returns sha1 for SHA1") {
-    assertEquals(HashType.SHA1.hashTypeName(), "sha1")
+    assertEquals(HashType.Sha1.hashTypeName(), "sha1")
   }
 
   test("HashType.hashTypeName - returns sha256 for SHA256") {
-    assertEquals(HashType.SHA256.hashTypeName(), "sha256")
+    assertEquals(HashType.Sha256.hashTypeName(), "sha256")
   }
 
   test("HashType.getDigest - returns SHA1 digest") {
-    val digest = HashType.SHA1.getDigest()
+    val digest = HashType.Sha1.getDigest()
     assertEquals(digest.getAlgorithm(), "SHA-1")
   }
 
   test("HashType.getDigest - returns SHA256 digest") {
-    val digest = HashType.SHA256.getDigest()
+    val digest = HashType.Sha256.getDigest()
     assertEquals(digest.getAlgorithm(), "SHA-256")
   }
 
@@ -118,7 +119,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val input = "hello"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.computeGitOID(stream, bytes.length, HashType.SHA1)
+    val result = GitOIDUtils.computeGitOID(stream, bytes.length, HashType.Sha1)
     assertEquals(result.length, 20, "SHA1 should produce 20 bytes")
   }
 
@@ -162,18 +163,18 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val input = "test"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.url(stream, bytes.length, HashType.SHA256)
+    val result = GitOIDUtils.url(stream, bytes.length, HashType.Sha256)
     assert(result.startsWith("gitoid:blob:sha256:"))
-    assertEquals(result.length, "gitoid:blob:sha256:".length + 64)
+    assertEquals(result().length, "gitoid:blob:sha256:".length + 64)
   }
 
   test("url - generates SHA1 URL") {
     val input = "test"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.url(stream, bytes.length, HashType.SHA1)
+    val result = GitOIDUtils.url(stream, bytes.length, HashType.Sha1)
     assert(result.startsWith("gitoid:blob:sha1:"))
-    assertEquals(result.length, "gitoid:blob:sha1:".length + 40)
+    assertEquals(result().length, "gitoid:blob:sha1:".length + 40)
   }
 
   test("url - generates tree object URL") {
@@ -181,7 +182,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
     val result =
-      GitOIDUtils.url(stream, bytes.length, HashType.SHA256, ObjectType.Tree)
+      GitOIDUtils.url(stream, bytes.length, HashType.Sha256, ObjectType.Tree)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
@@ -191,7 +192,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   }
 
   test("urlForString - generates SHA1 URL") {
-    val result = GitOIDUtils.urlForString("test", HashType.SHA1)
+    val result = GitOIDUtils.urlForString("test", HashType.Sha1)
     assert(result.startsWith("gitoid:blob:sha1:"))
   }
 
@@ -243,15 +244,15 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   test("merkleTreeFromGitoids - computes tree hash from gitoids") {
     val gitoids: Vector[Gitoid] = Vector(
       Gitoid("gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
-      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
+      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
     )
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - sorts gitoids before hashing") {
-    val gitoids1: Vector[Gitoid] = Vector(Gitoid("aaaa"), Gitoid("bbbb"))
-    val gitoids2: Vector[Gitoid] = Vector(Gitoid("bbbb"), Gitoid("aaaa"))
+    val gitoids1: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aaaa"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("bbbb"))
+    val gitoids2: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("bbbb"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aaaa"))
     val result1 = GitOIDUtils.merkleTreeFromGitoids(gitoids1)
     val result2 = GitOIDUtils.merkleTreeFromGitoids(gitoids2)
     assertEquals(result1, result2, "Order should not matter")
@@ -264,14 +265,14 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   }
 
   test("merkleTreeFromGitoids - handles single gitoid") {
-    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"))
+    val gitoids: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aabbccdd"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - can use SHA1") {
-    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"), Gitoid("eeff0011"))
-    val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.SHA1)
+    val gitoids: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aabbccdd"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("eeff0011"))
+    val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.Sha1)
     assert(result.startsWith("gitoid:tree:sha1:"))
   }
 
@@ -293,8 +294,8 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
 
   test("url - empty content produces valid URL") {
     val stream = new ByteArrayInputStream(Array[Byte]())
-    val result = GitOIDUtils.url(stream, 0, HashType.SHA256)
+    val result = GitOIDUtils.url(stream, 0, HashType.Sha256)
     assert(result.startsWith("gitoid:blob:sha256:"))
-    assertEquals(result.length, "gitoid:blob:sha256:".length + 64)
+    assertEquals(result().length, "gitoid:blob:sha256:".length + 64)
   }
 }

--- a/src/test/scala/GitOIDUtilsTestSuite.scala
+++ b/src/test/scala/GitOIDUtilsTestSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.GitOIDUtils.HashType
 import io.spicelabs.goatrodeo.util.GitOIDUtils.ObjectType
@@ -240,36 +241,36 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   // ==================== merkleTreeFromGitoids Tests ====================
 
   test("merkleTreeFromGitoids - computes tree hash from gitoids") {
-    val gitoids = Vector(
-      "gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-      "gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2"
+    val gitoids: Vector[Gitoid] = Vector(
+      Gitoid("gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
+      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
     )
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - sorts gitoids before hashing") {
-    val gitoids1 = Vector("aaaa", "bbbb")
-    val gitoids2 = Vector("bbbb", "aaaa")
+    val gitoids1: Vector[Gitoid] = Vector(Gitoid("aaaa"), Gitoid("bbbb"))
+    val gitoids2: Vector[Gitoid] = Vector(Gitoid("bbbb"), Gitoid("aaaa"))
     val result1 = GitOIDUtils.merkleTreeFromGitoids(gitoids1)
     val result2 = GitOIDUtils.merkleTreeFromGitoids(gitoids2)
     assertEquals(result1, result2, "Order should not matter")
   }
 
   test("merkleTreeFromGitoids - handles empty vector") {
-    val gitoids = Vector[String]()
+    val gitoids = Vector[Gitoid]()
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - handles single gitoid") {
-    val gitoids = Vector("aabbccdd")
+    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - can use SHA1") {
-    val gitoids = Vector("aabbccdd", "eeff0011")
+    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"), Gitoid("eeff0011"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.SHA1)
     assert(result.startsWith("gitoid:tree:sha1:"))
   }

--- a/src/test/scala/GitoidFixtures.scala
+++ b/src/test/scala/GitoidFixtures.scala
@@ -1,0 +1,50 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.test
+
+import io.spicelabs.goatrodeo.util.Gitoid
+
+import java.security.MessageDigest
+
+/** Test helpers for constructing valid Gitoid values from arbitrary labels.
+  *
+  * The strict Gitoid parser only accepts well-formed `gitoid:<type>:<algo>:<hex>`
+  * URLs with the correct hash length. Many existing tests use short or
+  * non-hex placeholder strings as identifiers; this helper hashes the label
+  * deterministically so the test fixture is always a valid Gitoid while
+  * preserving distinctness between different labels.
+  */
+object GitoidFixtures {
+
+  /** Produce a deterministic valid blob/sha256 Gitoid URL string from any
+    * label.
+    *
+    * If `label` already parses as a Gitoid URL, returns it verbatim; otherwise
+    * synthesises a Gitoid by hashing the UTF-8 bytes of the label and returns
+    * its URL form. */
+  def gitoidFor(label: String): String = {
+    if (label.startsWith("gitoid:")) {
+      val _ = Gitoid(label) // validate
+      label
+    } else {
+      val md = MessageDigest.getInstance("SHA-256")
+      val hash = md.digest(label.getBytes("UTF-8"))
+      Gitoid(Gitoid.ObjectType.Blob, Gitoid.HashAlgorithm.Sha256, hash).apply()
+    }
+  }
+
+  /** Convenience: Gitoid form for use as a value in `Map[String, Gitoid]` etc. */
+  def gitoidForAsGitoid(label: String): Gitoid = Gitoid(gitoidFor(label))
+}

--- a/src/test/scala/GitoidFixtures.scala
+++ b/src/test/scala/GitoidFixtures.scala
@@ -15,36 +15,49 @@ limitations under the License. */
 package io.spicelabs.goatrodeo.test
 
 import io.spicelabs.goatrodeo.util.Gitoid
+import io.spicelabs.goatrodeo.util.Identifier
 
 import java.security.MessageDigest
 
-/** Test helpers for constructing valid Gitoid values from arbitrary labels.
+/** Test helpers for constructing valid identifier values from arbitrary
+  * labels.
   *
-  * The strict Gitoid parser only accepts well-formed `gitoid:<type>:<algo>:<hex>`
-  * URLs with the correct hash length. Many existing tests use short or
-  * non-hex placeholder strings as identifiers; this helper hashes the label
-  * deterministically so the test fixture is always a valid Gitoid while
-  * preserving distinctness between different labels.
+  * If `label` is already a canonical identifier (`gitoid:`, `pkg:`, `md5:`,
+  * etc.), it is parsed directly. Otherwise we synthesise a blob+SHA-256
+  * gitoid by hashing the label so the result is always a valid `Identifier`
+  * while preserving distinctness between different labels.
   */
 object GitoidFixtures {
 
-  /** Produce a deterministic valid blob/sha256 Gitoid URL string from any
-    * label.
+  /** Deterministic `Identifier` derived from any label.
     *
-    * If `label` already parses as a Gitoid URL, returns it verbatim; otherwise
-    * synthesises a Gitoid by hashing the UTF-8 bytes of the label and returns
-    * its URL form. */
-  def gitoidFor(label: String): String = {
-    if (label.startsWith("gitoid:")) {
-      val _ = Gitoid(label) // validate
-      label
+    * Used as `Item.identifier` and as a String-comparable key (via
+    * `identifier()` materialisation) in test assertions. */
+  def gitoidFor(label: String): Identifier = {
+    if (
+      label.startsWith("gitoid:") || label.startsWith("pkg:") ||
+      label.startsWith("md5:") || label.startsWith("sha1:") ||
+      label.startsWith("sha256:") || label.startsWith("sha512:")
+    ) {
+      Identifier(label)
     } else {
       val md = MessageDigest.getInstance("SHA-256")
       val hash = md.digest(label.getBytes("UTF-8"))
-      Gitoid(Gitoid.ObjectType.Blob, Gitoid.HashAlgorithm.Sha256, hash).apply()
+      Identifier.fromGitoid(
+        Gitoid(Gitoid.ObjectType.Blob, Gitoid.HashAlgorithm.Sha256, hash)
+      )
     }
   }
 
-  /** Convenience: Gitoid form for use as a value in `Map[String, Gitoid]` etc. */
-  def gitoidForAsGitoid(label: String): Gitoid = Gitoid(gitoidFor(label))
+  /** Canonical String form of the synthesised identifier — used where a
+    * test asserts on a String identifier value. */
+  def gitoidForString(label: String): String = gitoidFor(label).apply()
+
+  /** Convenience: returns a `Gitoid` for use as a value in
+    * `Map[String, Gitoid]` etc. The label must be a gitoid URL or hashable
+    * to one. */
+  def gitoidForAsGitoid(label: String): Gitoid =
+    gitoidFor(label).asGitoid.getOrElse(
+      throw new IllegalArgumentException(s"Label '$label' is not a Gitoid")
+    )
 }

--- a/src/test/scala/GraphManagerTestSuite.scala
+++ b/src/test/scala/GraphManagerTestSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.GRDWalker
+import io.spicelabs.goatrodeo.omnibor.GoatRodeoCluster
 import io.spicelabs.goatrodeo.omnibor.GraphManager
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
@@ -180,9 +181,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
         EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"
       )
       val items = Vector(
-        createTestItem(
-          "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
-          connections
+        createTestItem("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111", connections
         )
       )
       val (dataAndIndex, clusterFile) =
@@ -254,7 +253,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -274,7 +273,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -296,7 +295,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Simple test with minimal items - complex items have encoding issues
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -318,9 +317,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
         EdgeType.aliasFrom -> "sha256:hash1",
         EdgeType.containedBy -> "gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"
       )
-      val item = createTestItem(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
-        connections
+      val item = createTestItem("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111", connections
       )
       val (dataAndIndex, _) =
         GraphManager.writeEntries(tempDir, Vector(item).iterator)
@@ -385,6 +382,65 @@ class GraphManagerTestSuite extends munit.FunSuite {
       } finally {
         channel.close()
       }
+    } finally {
+      Helpers.deleteDirectory(tempDir.toPath())
+    }
+  }
+
+  // ==================== Cluster helper tests ====================
+
+  test("GoatRodeoCluster.reverseEdges - inverts containedBy across cluster") {
+    val tempDir = Files.createTempDirectory("revedges").toFile()
+    try {
+      val containerId =
+        "gitoid:blob:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      val child1Id =
+        "gitoid:blob:sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      val child2Id =
+        "gitoid:blob:sha256:3333333333333333333333333333333333333333333333333333333333333333"
+
+      val container = createTestItem(containerId)
+      val child1 = createTestItem(
+        child1Id,
+        TreeSet(EdgeType.containedBy -> containerId)
+      )
+      val child2 = createTestItem(
+        child2Id,
+        TreeSet(EdgeType.containedBy -> containerId)
+      )
+
+      val (_, clusterFile) = GraphManager.writeEntries(
+        tempDir,
+        Vector(container, child1, child2).iterator
+      )
+
+      val cluster = GoatRodeoCluster.open(clusterFile)
+      // "what does containerId contain?" — both children, synthesised from
+      // their forward `containedBy` edges.
+      assertEquals(
+        cluster.reverseEdges(containerId, EdgeType.contains),
+        Set(child1Id, child2Id)
+      )
+      // Leaf items have no children.
+      assertEquals(cluster.reverseEdges(child1Id, EdgeType.contains), Set.empty[String])
+    } finally {
+      Helpers.deleteDirectory(tempDir.toPath())
+    }
+  }
+
+  test("GoatRodeoCluster.canonicalise - returns input when no aliases") {
+    val tempDir = Files.createTempDirectory("canon-noop").toFile()
+    try {
+      val id =
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"
+      val (_, clusterFile) =
+        GraphManager.writeEntries(tempDir, Vector(createTestItem(id)).iterator)
+      val cluster = GoatRodeoCluster.open(clusterFile)
+      assertEquals(cluster.canonicalise(id), id)
+      assertEquals(
+        cluster.canonicalise("gitoid:blob:sha256:00"),
+        "gitoid:blob:sha256:00"
+      )
     } finally {
       Helpers.deleteDirectory(tempDir.toPath())
     }

--- a/src/test/scala/GraphManagerTestSuite.scala
+++ b/src/test/scala/GraphManagerTestSuite.scala
@@ -32,7 +32,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)] = TreeSet()
   ): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -177,7 +177,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       val connections = TreeSet(
         EdgeType.aliasFrom -> "sha256:alias1",
-        EdgeType.containedBy -> "gitoid:blob:sha256:parent"
+        EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"
       )
       val items = Vector(
         createTestItem(
@@ -254,7 +254,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -274,7 +274,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -296,7 +296,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Simple test with minimal items - complex items have encoding issues
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -316,7 +316,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       val connections = TreeSet(
         EdgeType.aliasFrom -> "sha256:hash1",
-        EdgeType.containedBy -> "gitoid:blob:sha256:parent123"
+        EdgeType.containedBy -> "gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"
       )
       val item = createTestItem(
         "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",

--- a/src/test/scala/GraphManagerTestSuite.scala
+++ b/src/test/scala/GraphManagerTestSuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.GRDWalker
 import io.spicelabs.goatrodeo.omnibor.GraphManager
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.FileInputStream
@@ -31,7 +32,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)] = TreeSet()
   ): Item = {
     Item(
-      id,
+      Gitoid(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -253,7 +254,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -273,7 +274,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -295,7 +296,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Simple test with minimal items - complex items have encoding issues
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.util.ByteWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -26,7 +27,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   def createBasicItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -45,7 +46,7 @@ class ItemTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)]
   ): Item = {
     Item(
-      id,
+      Gitoid(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -72,7 +73,7 @@ class ItemTestSuite extends munit.FunSuite {
     val bytes = item.encodeCBOR()
     val decoded = Item.decode(bytes)
     assert(decoded.isSuccess)
-    assertEquals(decoded.get.identifier, "test-id")
+    assertEquals(decoded.get.identifier(), "test-id")
   }
 
   test("Item - round-trip CBOR preserves identifier") {
@@ -122,12 +123,12 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item.itemFrom - includes container if provided") {
     val data = "test content".getBytes("UTF-8")
     val wrapper = ByteWrapper(data, "test.txt", None)
-    val container = Some("gitoid:blob:sha256:parent123")
+    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
     val item = Item.itemFrom(wrapper, container)
 
     assert(
       item.connections.exists(e =>
-        e._1 == EdgeType.containedBy && e._2 == container.get
+        e._1 == EdgeType.containedBy && e._2 == container.get()
       )
     )
   }
@@ -186,7 +187,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.isRoot - returns false for tags identifier") {
     val item = Item(
-      "tags",
+      Gitoid("tags"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet(), TreeSet(), 0, TreeMap()))
@@ -195,7 +196,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.isRoot - returns false for non-metadata body type") {
-    val item = Item("test-id", TreeSet(), None, None)
+    val item = Item(Gitoid("test-id"), TreeSet(), None, None)
     assert(!item.isRoot())
   }
 
@@ -261,13 +262,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.merge - merges metadata bodies") {
     val item1 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1"), TreeSet("mime1"), 100, TreeMap()))
     )
     val item2 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2"), TreeSet("mime2"), 100, TreeMap()))
@@ -284,12 +285,12 @@ class ItemTestSuite extends munit.FunSuite {
     val item2 = createBasicItem("id-2")
 
     val merged = item1.merge(item2)
-    assertEquals(merged.identifier, "id-1")
+    assertEquals(merged.identifier(), "id-1")
   }
 
   test("Item.merge - handles None body") {
     val item1 = createBasicItem("id")
-    val item2 = Item("id", TreeSet(), None, None)
+    val item2 = Item(Gitoid("id"), TreeSet(), None, None)
 
     val merged = item1.merge(item2)
     assert(merged.bodyAsItemMetaData.isDefined)
@@ -300,13 +301,13 @@ class ItemTestSuite extends munit.FunSuite {
     val extra2 = TreeMap("key2" -> TreeSet(StringOrPair("val2")))
     // ItemMetaData.merge requires non-empty fileNames
     val item1 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra1))
     )
     val item2 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra2))
@@ -378,7 +379,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - creates body if none exists") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -416,7 +417,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceWithMetadata - creates body if none exists") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("file.txt"))
     assert(enhanced.bodyAsItemMetaData.isDefined)
@@ -425,13 +426,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceWithMetadata - includes parent gitoid for duplicate filenames") {
     val item = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("existing.txt"), TreeSet(), 100, TreeMap()))
     )
 
-    val parent = Some("gitoid:blob:sha256:parent123")
+    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
     val enhanced = item.enhanceWithMetadata(
       maybeParent = parent,
       filenames = Seq("newfile.txt")
@@ -445,26 +446,26 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - creates filename to gitoid map") {
     val item1 = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1.txt"), TreeSet(), 100, TreeMap()))
     )
     val item2 = Item(
-      "gitoid:blob:sha256:def456",
+      Gitoid("gitoid:blob:sha256:def456"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2.txt"), TreeSet(), 100, TreeMap()))
     )
 
     val map = Item.itemsToFilenameGitOIDMap(Seq(item1, item2))
-    assertEquals(map.get("file1.txt"), Some("gitoid:blob:sha256:abc123"))
-    assertEquals(map.get("file2.txt"), Some("gitoid:blob:sha256:def456"))
+    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:abc123")))
+    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:def456")))
   }
 
   test("itemsToFilenameGitOIDMap - applies name filter") {
     val item = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -484,7 +485,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies mime filter") {
     val item1 = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -497,7 +498,7 @@ class ItemTestSuite extends munit.FunSuite {
       )
     )
     val item2 = Item(
-      "gitoid:blob:sha256:def456",
+      Gitoid("gitoid:blob:sha256:def456"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -514,7 +515,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("itemsToFilenameGitOIDMap - handles items without body") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     val map = Item.itemsToFilenameGitOIDMap(Seq(item))
     assert(map.isEmpty)
   }
@@ -527,7 +528,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.bodyAsItemMetaData - returns None for no body") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     assertEquals(item.bodyAsItemMetaData, None)
   }
 

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -27,7 +27,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   def createBasicItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -46,7 +46,7 @@ class ItemTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)]
   ): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -73,7 +73,7 @@ class ItemTestSuite extends munit.FunSuite {
     val bytes = item.encodeCBOR()
     val decoded = Item.decode(bytes)
     assert(decoded.isSuccess)
-    assertEquals(decoded.get.identifier(), "test-id")
+    assertEquals(decoded.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"))
   }
 
   test("Item - round-trip CBOR preserves identifier") {
@@ -86,7 +86,7 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item - round-trip CBOR preserves connections") {
     val connections = TreeSet(
       EdgeType.aliasFrom -> "sha256:abc123",
-      EdgeType.containedBy -> "gitoid:blob:sha256:parent"
+      EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"
     )
     val item = createItemWithConnections("test-id", connections)
     val bytes = item.encodeCBOR()
@@ -123,7 +123,7 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item.itemFrom - includes container if provided") {
     val data = "test content".getBytes("UTF-8")
     val wrapper = ByteWrapper(data, "test.txt", None)
-    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
+    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"))
     val item = Item.itemFrom(wrapper, container)
 
     assert(
@@ -167,27 +167,27 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== isRoot Tests ====================
 
   test("Item.isRoot - returns true for root item") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     assert(item.isRoot())
   }
 
   test("Item.isRoot - returns false for item with aliasTo") {
-    val connections = TreeSet(EdgeType.aliasTo -> "gitoid:blob:sha256:target")
+    val connections = TreeSet(EdgeType.aliasTo -> "gitoid:blob:sha256:34a04005bcaf206eec990bd9637d9fdb6725e0a0c0d4aebf003f17f4c956eb5c")
     val item = createItemWithConnections("sha256:abc123", connections)
     assert(!item.isRoot())
   }
 
   test("Item.isRoot - returns false for item with containedBy") {
     val connections =
-      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:parent")
+      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c")
     val item =
-      createItemWithConnections("gitoid:blob:sha256:abc123", connections)
+      createItemWithConnections("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090", connections)
     assert(!item.isRoot())
   }
 
   test("Item.isRoot - returns false for tags identifier") {
     val item = Item(
-      Gitoid("tags"),
+      Item.tagsRootIdentifier,
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet(), TreeSet(), 0, TreeMap()))
@@ -196,7 +196,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.isRoot - returns false for non-metadata body type") {
-    val item = Item(Gitoid("test-id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"), TreeSet(), None, None)
     assert(!item.isRoot())
   }
 
@@ -204,35 +204,35 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("buildListOfReferences - returns aliasTo for aliasFrom") {
     val connections = TreeSet(EdgeType.aliasFrom -> "sha256:abc123")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
     assert(refs.contains(EdgeType.aliasTo -> "sha256:abc123"))
   }
 
   test("buildListOfReferences - returns buildsTo for builtFrom") {
-    val connections = TreeSet(EdgeType.builtFrom -> "gitoid:blob:sha256:source")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val connections = TreeSet(EdgeType.builtFrom -> "gitoid:blob:sha256:41cf6794ba4200b839c53531555f0f3998df4cbb01a4d5cb0b94e3ca5e23947d")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.buildsTo -> "gitoid:blob:sha256:source"))
+    assert(refs.contains(EdgeType.buildsTo -> "gitoid:blob:sha256:41cf6794ba4200b839c53531555f0f3998df4cbb01a4d5cb0b94e3ca5e23947d"))
   }
 
   test("buildListOfReferences - returns contains for containedBy") {
     val connections =
-      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:parent")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.contains -> "gitoid:blob:sha256:parent"))
+    assert(refs.contains(EdgeType.contains -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"))
   }
 
   test("buildListOfReferences - returns tagTo for tagFrom") {
-    val connections = TreeSet(EdgeType.tagFrom -> "gitoid:blob:sha256:tag")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val connections = TreeSet(EdgeType.tagFrom -> "gitoid:blob:sha256:2a1073a6e67f0e5f09a5957c659503c690efe7272be8313df872556a9a684d8c")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.tagTo -> "gitoid:blob:sha256:tag"))
+    assert(refs.contains(EdgeType.tagTo -> "gitoid:blob:sha256:2a1073a6e67f0e5f09a5957c659503c690efe7272be8313df872556a9a684d8c"))
   }
 
   test("buildListOfReferences - handles multiple connections") {
@@ -241,7 +241,7 @@ class ItemTestSuite extends munit.FunSuite {
       EdgeType.aliasFrom -> "sha1:def",
       EdgeType.containedBy -> "parent"
     )
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
     assertEquals(refs.length, 3)
@@ -262,13 +262,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.merge - merges metadata bodies") {
     val item1 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1"), TreeSet("mime1"), 100, TreeMap()))
     )
     val item2 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2"), TreeSet("mime2"), 100, TreeMap()))
@@ -285,12 +285,12 @@ class ItemTestSuite extends munit.FunSuite {
     val item2 = createBasicItem("id-2")
 
     val merged = item1.merge(item2)
-    assertEquals(merged.identifier(), "id-1")
+    assertEquals(merged.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id-1"))
   }
 
   test("Item.merge - handles None body") {
     val item1 = createBasicItem("id")
-    val item2 = Item(Gitoid("id"), TreeSet(), None, None)
+    val item2 = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
 
     val merged = item1.merge(item2)
     assert(merged.bodyAsItemMetaData.isDefined)
@@ -301,13 +301,13 @@ class ItemTestSuite extends munit.FunSuite {
     val extra2 = TreeMap("key2" -> TreeSet(StringOrPair("val2")))
     // ItemMetaData.merge requires non-empty fileNames
     val item1 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra1))
     )
     val item2 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra2))
@@ -322,7 +322,7 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== enhanceItemWithPurls Tests ====================
 
   test("enhanceItemWithPurls - adds purl connections") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -337,7 +337,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - adds purl to filenames") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -352,13 +352,13 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - handles empty purls") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val enhanced = item.enhanceItemWithPurls(Seq())
     assertEquals(enhanced, item)
   }
 
   test("enhanceItemWithPurls - handles multiple purls") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl1 = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -379,7 +379,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - creates body if none exists") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -395,7 +395,7 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== enhanceWithMetadata Tests ====================
 
   test("enhanceWithMetadata - adds extra metadata") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val extra = TreeMap("key" -> TreeSet(StringOrPair("value")))
 
     val enhanced = item.enhanceWithMetadata(extra = extra)
@@ -403,21 +403,21 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceWithMetadata - adds filenames") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("newfile.txt"))
     assert(enhanced.bodyAsItemMetaData.get.fileNames.contains("newfile.txt"))
   }
 
   test("enhanceWithMetadata - adds mime types") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
 
     val enhanced = item.enhanceWithMetadata(mimeTypes = Seq("text/plain"))
     assert(enhanced.bodyAsItemMetaData.get.mimeType.contains("text/plain"))
   }
 
   test("enhanceWithMetadata - creates body if none exists") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("file.txt"))
     assert(enhanced.bodyAsItemMetaData.isDefined)
@@ -426,46 +426,46 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceWithMetadata - includes parent gitoid for duplicate filenames") {
     val item = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("existing.txt"), TreeSet(), 100, TreeMap()))
     )
 
-    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
+    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"))
     val enhanced = item.enhanceWithMetadata(
       maybeParent = parent,
       filenames = Seq("newfile.txt")
     )
     val fileNames = enhanced.bodyAsItemMetaData.get.fileNames
     // Should include parent-qualified filename
-    assert(fileNames.exists(_.contains("parent123")))
+    assert(fileNames.exists(_.contains("82e3edf5")))
   }
 
   // ==================== itemsToFilenameGitOIDMap Tests ====================
 
   test("itemsToFilenameGitOIDMap - creates filename to gitoid map") {
     val item1 = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1.txt"), TreeSet(), 100, TreeMap()))
     )
     val item2 = Item(
-      Gitoid("gitoid:blob:sha256:def456"),
+      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2.txt"), TreeSet(), 100, TreeMap()))
     )
 
     val map = Item.itemsToFilenameGitOIDMap(Seq(item1, item2))
-    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:abc123")))
-    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:def456")))
+    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")))
+    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587")))
   }
 
   test("itemsToFilenameGitOIDMap - applies name filter") {
     val item = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -485,7 +485,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies mime filter") {
     val item1 = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -498,7 +498,7 @@ class ItemTestSuite extends munit.FunSuite {
       )
     )
     val item2 = Item(
-      Gitoid("gitoid:blob:sha256:def456"),
+      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -515,7 +515,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("itemsToFilenameGitOIDMap - handles items without body") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     val map = Item.itemsToFilenameGitOIDMap(Seq(item))
     assert(map.isEmpty)
   }
@@ -528,7 +528,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.bodyAsItemMetaData - returns None for no body") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     assertEquals(item.bodyAsItemMetaData, None)
   }
 

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -446,13 +446,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - creates filename to gitoid map") {
     val item1 = Item(
-      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+      io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1.txt"), TreeSet(), 100, TreeMap()))
     )
     val item2 = Item(
-      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
+      io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2.txt"), TreeSet(), 100, TreeMap()))
@@ -465,7 +465,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies name filter") {
     val item = Item(
-      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+      io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -485,7 +485,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies mime filter") {
     val item1 = Item(
-      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+      io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -498,7 +498,7 @@ class ItemTestSuite extends munit.FunSuite {
       )
     )
     val item2 = Item(
-      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
+      io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -261,7 +261,7 @@ box but need special configuration, like udhcpc, the dhcp client."""
 
     var meta = gitoids
       .map(oid => {
-        store.read(oid)
+        store.read(oid())
       })
       .flatten
       .map(item => item.body)

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -525,7 +525,7 @@ the performance, all instances of the terminal are sharing a single process."""
       mainItemKey: String
   ): ItemMetaData = {
     val purls = store.purls()
-    assertEquals(TreeSet(expectedPurl), purls)
+    assertEquals(TreeSet(io.spicelabs.goatrodeo.util.PackageUrl(expectedPurl)), purls)
     val mainItemOpt = store.read(mainItemKey)
     assert(mainItemOpt.isDefined)
     val metadataOpt = mainItemOpt.get.bodyAsItemMetaData

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -321,7 +321,7 @@ class MySuite extends munit.FunSuite {
       nested,
       args = Config(),
       block = Set(
-        "gitoid:blob:sha256:e3f8d493cb200fd95c4881e248148836628e0f06ddb3c28cb3f95cf784e2f8e4"
+        Gitoid("gitoid:blob:sha256:e3f8d493cb200fd95c4881e248148836628e0f06ddb3c28cb3f95cf784e2f8e4")
       )
     )
 

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.util.*
+import io.spicelabs.goatrodeo.util.GitOIDUtils.{getDigest, hashTypeName, gitoidName}
 import io.spicelabs.goatrodeo.util.Config
 
 import java.io.ByteArrayInputStream
@@ -54,7 +55,7 @@ class MySuite extends munit.FunSuite {
 
   test("SHA256 hash produces correct hex output") {
     val txt = Array[Byte](49, 50, 51, 10)
-    val digest = GitOIDUtils.HashType.SHA256.getDigest()
+    val digest = GitOIDUtils.HashType.Sha256.getDigest()
     assertEquals(
       Helpers.toHex(digest.digest(txt)),
       "181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b"

--- a/src/test/scala/PropertyBasedTestSuite.scala
+++ b/src/test/scala/PropertyBasedTestSuite.scala
@@ -138,7 +138,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     metadata <-
       if (hasMetadata) genItemMetaData.map(Some(_)) else Gen.const(None)
   } yield Item(
-    identifier = Gitoid(identifier),
+    identifier = identifier,
     connections = connections,
     bodyMimeType = metadata.map(_ => ItemMetaData.mimeType),
     body = metadata
@@ -181,7 +181,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     forAll(genItemMetaData) { metadata =>
       val encoded = metadata.encodeCBOR()
       val item = Item(
-        identifier = Gitoid("gitoid:blob:sha256:" + "a" * 64),
+        identifier = "gitoid:blob:sha256:" + "a" * 64,
         connections = TreeSet(),
         bodyMimeType = Some(ItemMetaData.mimeType),
         body = Some(metadata)
@@ -465,8 +465,8 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
 
   property("Different identifiers produce different MD5s") {
     forAll(genItem, genGitOID) { (item, newId) =>
-      if (item.identifier() != newId) {
-        val item2 = item.copy(identifier = Gitoid(newId))
+      if (item.identifier != newId) {
+        val item2 = item.copy(identifier = newId)
         !item.identifierMD5().sameElements(item2.identifierMD5())
       } else {
         true

--- a/src/test/scala/PropertyBasedTestSuite.scala
+++ b/src/test/scala/PropertyBasedTestSuite.scala
@@ -44,14 +44,13 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
   // ==================== Generators ====================
   // Because ScalaCheck needs to know how to create random instances
 
-  /** Generate valid GitOID-like identifiers */
+  /** Generate valid GitOID-like identifiers. Limited to the algorithms our
+    * Gitoid type supports (sha1, sha256). */
   val genGitOID: Gen[String] = for {
-    hashType <- Gen.oneOf("sha256", "sha1", "sha512")
-    // Generate hex string of appropriate length
+    hashType <- Gen.oneOf("sha256", "sha1")
     hexLength = hashType match {
       case "sha256" => 64
       case "sha1"   => 40
-      case "sha512" => 128
       case _        => 64
     }
     hexChars <- Gen.listOfN(hexLength, Gen.hexChar)
@@ -138,7 +137,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     metadata <-
       if (hasMetadata) genItemMetaData.map(Some(_)) else Gen.const(None)
   } yield Item(
-    identifier = identifier,
+    identifier = io.spicelabs.goatrodeo.util.Identifier(identifier),
     connections = connections,
     bodyMimeType = metadata.map(_ => ItemMetaData.mimeType),
     body = metadata
@@ -181,7 +180,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     forAll(genItemMetaData) { metadata =>
       val encoded = metadata.encodeCBOR()
       val item = Item(
-        identifier = "gitoid:blob:sha256:" + "a" * 64,
+        identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:" + "a" * 64),
         connections = TreeSet(),
         bodyMimeType = Some(ItemMetaData.mimeType),
         body = Some(metadata)
@@ -465,8 +464,8 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
 
   property("Different identifiers produce different MD5s") {
     forAll(genItem, genGitOID) { (item, newId) =>
-      if (item.identifier != newId) {
-        val item2 = item.copy(identifier = newId)
+      if (item.identifierString != newId) {
+        val item2 = item.copy(identifier = io.spicelabs.goatrodeo.util.Identifier(newId))
         !item.identifierMD5().sameElements(item2.identifierMD5())
       } else {
         true

--- a/src/test/scala/PropertyBasedTestSuite.scala
+++ b/src/test/scala/PropertyBasedTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.PairOf
 import io.spicelabs.goatrodeo.omnibor.StringOf
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import munit.ScalaCheckSuite
@@ -137,7 +138,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     metadata <-
       if (hasMetadata) genItemMetaData.map(Some(_)) else Gen.const(None)
   } yield Item(
-    identifier = identifier,
+    identifier = Gitoid(identifier),
     connections = connections,
     bodyMimeType = metadata.map(_ => ItemMetaData.mimeType),
     body = metadata
@@ -180,7 +181,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     forAll(genItemMetaData) { metadata =>
       val encoded = metadata.encodeCBOR()
       val item = Item(
-        identifier = "gitoid:blob:sha256:" + "a" * 64,
+        identifier = Gitoid("gitoid:blob:sha256:" + "a" * 64),
         connections = TreeSet(),
         bodyMimeType = Some(ItemMetaData.mimeType),
         body = Some(metadata)
@@ -464,8 +465,8 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
 
   property("Different identifiers produce different MD5s") {
     forAll(genItem, genGitOID) { (item, newId) =>
-      if (item.identifier != newId) {
-        val item2 = item.copy(identifier = newId)
+      if (item.identifier() != newId) {
+        val item2 = item.copy(identifier = Gitoid(newId))
         !item.identifierMD5().sameElements(item2.identifierMD5())
       } else {
         true

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -205,7 +205,7 @@ class StorageTestSuite extends munit.FunSuite {
 
     val purls = storage.purls()
     assertEquals(purls.size, 1)
-    assert(purls.contains(purl.canonicalize()))
+    assert(purls.contains(io.spicelabs.goatrodeo.util.PackageUrl(purl)))
   }
 
   test("MemStorage - purls returns all added purls") {

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.MemStorage
 import io.spicelabs.goatrodeo.omnibor.Storage
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.nio.file.Files
@@ -27,7 +28,7 @@ class StorageTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String, fileNames: Set[String] = Set()): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -66,7 +67,7 @@ class StorageTestSuite extends munit.FunSuite {
     storage.write("test-id", _ => Some(item), _ => "")
     val result = storage.read("test-id")
     assert(result.isDefined)
-    assertEquals(result.get.identifier, "test-id")
+    assertEquals(result.get.identifier(), "test-id")
   }
 
   test("MemStorage - write creates new item") {
@@ -74,7 +75,7 @@ class StorageTestSuite extends munit.FunSuite {
     val item = createTestItem("new-id")
     val result = storage.write("new-id", _ => Some(item), _ => "")
     assert(result.isDefined)
-    assertEquals(result.get.identifier, "new-id")
+    assertEquals(result.get.identifier(), "new-id")
   }
 
   test("MemStorage - write updates existing item") {
@@ -173,9 +174,9 @@ class StorageTestSuite extends munit.FunSuite {
 
     val gitoids = storage.gitoidKeys()
     assertEquals(gitoids.size, 1)
-    assert(gitoids.contains("gitoid:blob:sha256:abc123"))
-    assert(!gitoids.contains("sha256:def456"))
-    assert(!gitoids.contains("pkg:maven/group/artifact@1.0"))
+    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:abc123")))
+    assert(!gitoids.contains(Gitoid("sha256:def456")))
+    assert(!gitoids.contains(Gitoid("pkg:maven/group/artifact@1.0")))
   }
 
   test("MemStorage - gitoidKeys returns empty for no gitoids") {
@@ -410,7 +411,7 @@ class StorageTestSuite extends munit.FunSuite {
       val storage = MemStorage(None)
       // Create a root item (no aliasTo or containedBy edges)
       val rootItem = Item(
-        "gitoid:blob:sha256:root123",
+        Gitoid("gitoid:blob:sha256:root123"),
         TreeSet(),
         Some(ItemMetaData.mimeType),
         Some(ItemMetaData(TreeSet(), TreeSet(), 100, TreeMap()))

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -174,8 +174,8 @@ class StorageTestSuite extends munit.FunSuite {
     val gitoids = storage.gitoidKeys()
     assertEquals(gitoids.size, 1)
     assert(gitoids.contains(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")))
-    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("sha256:def456")))
-    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("pkg:maven/group/artifact@1.0")))
+    // The `sha256:def456` and `pkg:maven/...` keys must NOT appear in gitoidKeys;
+    // size==1 above already covers that.
   }
 
   test("MemStorage - gitoidKeys returns empty for no gitoids") {
@@ -409,7 +409,7 @@ class StorageTestSuite extends munit.FunSuite {
     try {
       val storage = MemStorage(None)
       // Create a root item (no aliasTo or containedBy edges)
-      val rootItem = Item(        "gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8",
+      val rootItem = Item(io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8"),
         TreeSet(),
         Some(ItemMetaData.mimeType),
         Some(ItemMetaData(TreeSet(), TreeSet(), 100, TreeMap()))

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -27,8 +27,7 @@ import scala.collection.immutable.TreeSet
 class StorageTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String, fileNames: Set[String] = Set()): Item = {
-    Item(
-      Gitoid(id),
+    Item(      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -67,7 +66,7 @@ class StorageTestSuite extends munit.FunSuite {
     storage.write("test-id", _ => Some(item), _ => "")
     val result = storage.read("test-id")
     assert(result.isDefined)
-    assertEquals(result.get.identifier(), "test-id")
+    assertEquals(result.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"))
   }
 
   test("MemStorage - write creates new item") {
@@ -75,7 +74,7 @@ class StorageTestSuite extends munit.FunSuite {
     val item = createTestItem("new-id")
     val result = storage.write("new-id", _ => Some(item), _ => "")
     assert(result.isDefined)
-    assertEquals(result.get.identifier(), "new-id")
+    assertEquals(result.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("new-id"))
   }
 
   test("MemStorage - write updates existing item") {
@@ -157,8 +156,8 @@ class StorageTestSuite extends munit.FunSuite {
   test("MemStorage - gitoidKeys returns only gitoid keys") {
     val storage = MemStorage(None)
     storage.write(
-      "gitoid:blob:sha256:abc123",
-      _ => Some(createTestItem("gitoid:blob:sha256:abc123")),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+      _ => Some(createTestItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")),
       _ => ""
     )
     storage.write(
@@ -174,9 +173,9 @@ class StorageTestSuite extends munit.FunSuite {
 
     val gitoids = storage.gitoidKeys()
     assertEquals(gitoids.size, 1)
-    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:abc123")))
-    assert(!gitoids.contains(Gitoid("sha256:def456")))
-    assert(!gitoids.contains(Gitoid("pkg:maven/group/artifact@1.0")))
+    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")))
+    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("sha256:def456")))
+    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("pkg:maven/group/artifact@1.0")))
   }
 
   test("MemStorage - gitoidKeys returns empty for no gitoids") {
@@ -410,13 +409,12 @@ class StorageTestSuite extends munit.FunSuite {
     try {
       val storage = MemStorage(None)
       // Create a root item (no aliasTo or containedBy edges)
-      val rootItem = Item(
-        Gitoid("gitoid:blob:sha256:root123"),
+      val rootItem = Item(        "gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8",
         TreeSet(),
         Some(ItemMetaData.mimeType),
         Some(ItemMetaData(TreeSet(), TreeSet(), 100, TreeMap()))
       )
-      storage.write("gitoid:blob:sha256:root123", _ => Some(rootItem), _ => "")
+      storage.write("gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8", _ => Some(rootItem), _ => "")
 
       storage.emitRootsToDir(tempDir)
 

--- a/src/test/scala/ToProcessTestSuite.scala
+++ b/src/test/scala/ToProcessTestSuite.scala
@@ -33,7 +33,7 @@ class ToProcessTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -206,7 +206,7 @@ class ToProcessTestSuite extends munit.FunSuite {
     val store = ToProcess.buildGraphForToProcess(
       toProcess,
       args = Config(),
-      block = Set(Gitoid("gitoid:blob:sha256:abc123"))
+      block = Set(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"))
     )
 
     assert(store.size() > 0)

--- a/src/test/scala/ToProcessTestSuite.scala
+++ b/src/test/scala/ToProcessTestSuite.scala
@@ -21,6 +21,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.GenericFile
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.File
@@ -32,7 +33,7 @@ class ToProcessTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -205,7 +206,7 @@ class ToProcessTestSuite extends munit.FunSuite {
     val store = ToProcess.buildGraphForToProcess(
       toProcess,
       args = Config(),
-      block = Set("gitoid:blob:sha256:abc123")
+      block = Set(Gitoid("gitoid:blob:sha256:abc123"))
     )
 
     assert(store.size() > 0)

--- a/src/test/scala/benchmarks/GraphBenchmark.scala
+++ b/src/test/scala/benchmarks/GraphBenchmark.scala
@@ -1,0 +1,326 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.bench
+
+import io.spicelabs.goatrodeo.omnibor.*
+import io.spicelabs.goatrodeo.util.*
+
+import java.io.File
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.security.MessageDigest
+import scala.collection.immutable.TreeMap
+import scala.collection.immutable.TreeSet
+
+/** Standalone benchmark for the graph-write / graph-read path, isolated from
+  * the main test suite so it can be exercised in ~1 minute with low noise.
+  *
+  * Run with:
+  *
+  *   sbt 'Test/runMain io.spicelabs.goatrodeo.bench.GraphBenchmark'
+  *
+  * Optional CLI: a single integer arg overrides the default item count
+  * (10 000). Lower it for faster iteration; raise it to see the asymptotic
+  * behaviour.
+  *
+  * The benchmark reports wall-clock time for each phase. Each phase is run
+  * three times and the median is printed alongside min/max so transient noise
+  * is visible.
+  *
+  * To compare two encoder strategies (e.g. text identifier vs binary
+  * identifier in `Item.scala`'s `given Encoder[Item]`), swap the encoder body,
+  * `sbt 'Test/runMain io.spicelabs.goatrodeo.bench.GraphBenchmark'`, and
+  * compare the printed phase medians.
+  */
+object GraphBenchmark {
+
+  // ----- Synthetic graph generators -----------------------------------------
+
+  /** Deterministic synthetic SHA-256 gitoid for seed `i`. */
+  private def synthGitoid(seed: Int): Gitoid = {
+    val md = MessageDigest.getInstance("SHA-256")
+    md.update(s"item-$seed".getBytes("UTF-8"))
+    Gitoid(Gitoid.ObjectType.Blob, Gitoid.HashAlgorithm.Sha256, md.digest())
+  }
+
+  /** Synthesise a hash-alias string ("sha1:…", "md5:…", etc.) for seed `i`. */
+  private def synthHash(prefix: String, byteLen: Int, seed: Int): String = {
+    val md = MessageDigest.getInstance("SHA-256")
+    md.update(s"$prefix-$seed".getBytes("UTF-8"))
+    val bytes = md.digest().take(byteLen)
+    s"$prefix:${Helpers.toHex(bytes)}"
+  }
+
+  /** Build a synthetic Item with a realistic edge fan-out:
+    *  - 4 hash-alias edges (sha1, sha256, sha512, md5)
+    *  - 1 containedBy edge pointing at a "container" gitoid (every ~50
+    *    items share a container, simulating archives)
+    */
+  def makeItem(seed: Int): Item = {
+    val gitoid = synthGitoid(seed)
+    val containerGitoid = synthGitoid(seed % 50).apply()
+    val connections: TreeSet[Edge] = TreeSet(
+      EdgeType.aliasFrom -> synthHash("sha1", 20, seed),
+      EdgeType.aliasFrom -> synthHash("sha256", 32, seed),
+      EdgeType.aliasFrom -> synthHash("sha512", 64, seed),
+      EdgeType.aliasFrom -> synthHash("md5", 16, seed),
+      EdgeType.containedBy -> containerGitoid
+    )
+    Item(
+      Identifier.fromGitoid(gitoid),
+      connections,
+      Some(ItemMetaData.mimeType),
+      Some(
+        ItemMetaData(
+          fileNames = TreeSet(s"file-$seed.txt"),
+          mimeType = TreeSet("application/octet-stream"),
+          fileSize = 100L + seed,
+          extra = TreeMap()
+        )
+      )
+    )
+  }
+
+  // ----- Timing helpers -----------------------------------------------------
+
+  private def timeOnce(body: => Unit): Long = {
+    val start = System.nanoTime()
+    body
+    System.nanoTime() - start
+  }
+
+  /** Run `body` `repeats` times and report median / min / max in ms. */
+  private def report(label: String, repeats: Int)(body: => Unit): Unit = {
+    val nanos = (1 to repeats).map(_ => timeOnce(body)).toVector.sorted
+    val medianMs = nanos(repeats / 2) / 1e6
+    val minMs = nanos.head / 1e6
+    val maxMs = nanos.last / 1e6
+    println(
+      f"  $label%-38s median ${medianMs}%8.1f ms   min ${minMs}%8.1f ms   max ${maxMs}%8.1f ms"
+    )
+  }
+
+  private def warmup(items: Vector[Item]): Unit = {
+    val n = math.min(items.size, 1000)
+    var i = 0
+    while (i < n) {
+      val cbor = items(i).encodeCBOR()
+      Item.decode(cbor).get
+      i += 1
+    }
+  }
+
+  // ----- Phases -------------------------------------------------------------
+
+  def main(args: Array[String]): Unit = {
+    val itemCount = args.headOption.flatMap(_.toIntOption).getOrElse(50000)
+    val repeats = 5
+    println(s"# Graph benchmark — $itemCount items, $repeats repeats per phase")
+    println()
+
+    println("Building synthetic graph...")
+    val items = (1 to itemCount).map(makeItem).toVector
+    val totalEdges = items.map(_.connections.size).sum
+    println(s"  $itemCount items, $totalEdges total edges")
+    println()
+
+    println("Warming up JIT...")
+    warmup(items)
+    println()
+
+    println("Phase 1 — CBOR encode each Item:")
+    // Pre-clear the cached CBOR on each pass so the encoder runs every time.
+    // (Item.cachedCBOR is a lazy val and would otherwise hit cache on repeats.)
+    // We do this by allocating fresh Items per repeat.
+    report("encode N items (fresh per repeat)", repeats) {
+      val fresh = (1 to itemCount).map(makeItem).toVector
+      var i = 0
+      while (i < fresh.size) {
+        fresh(i).encodeCBOR()
+        i += 1
+      }
+    }
+    val cborBytes = items.map(_.encodeCBOR())
+    val totalCborBytes = cborBytes.map(_.length.toLong).sum
+    println(
+      f"  CBOR size: total $totalCborBytes B, avg ${totalCborBytes.toDouble / itemCount}%.1f B/Item"
+    )
+    println()
+
+    println("Phase 2 — CBOR decode each Item:")
+    report("decode N items", repeats) {
+      var i = 0
+      while (i < cborBytes.size) {
+        Item.decode(cborBytes(i)).get
+        i += 1
+      }
+    }
+    println()
+
+    println("Phase 3 — MemStorage write/read (String-keyed in-memory map):")
+    report("write N items into MemStorage", repeats) {
+      val storage = MemStorage(None)
+      var i = 0
+      while (i < items.size) {
+        val item = items(i)
+        storage.write(item.identifierString, _ => Some(item), _ => "")
+        i += 1
+      }
+    }
+    val populatedStorage = {
+      val s = MemStorage(None)
+      items.foreach(item =>
+        s.write(item.identifierString, _ => Some(item), _ => "")
+      )
+      s
+    }
+    report("read N items from MemStorage", repeats) {
+      var i = 0
+      while (i < items.size) {
+        populatedStorage.read(items(i).identifierString)
+        i += 1
+      }
+    }
+    println()
+
+    println("Phase 4 — GraphManager.writeEntries (CBOR-on-disk):")
+    val tempDir = Files.createTempDirectory("gr-bench").toFile()
+    try {
+      var lastTotalGrdBytes = 0L
+      report("writeEntries to disk", repeats) {
+        // Clean dir each repeat so each run writes fresh files.
+        tempDir.listFiles().foreach(_.delete())
+        GraphManager.writeEntries(tempDir, items.iterator)
+        lastTotalGrdBytes =
+          tempDir.listFiles().filter(_.getName.endsWith(".grd")).map(_.length).sum
+      }
+      println(
+        f"  GRD on-disk size: total $lastTotalGrdBytes B, avg ${lastTotalGrdBytes.toDouble / itemCount}%.1f B/Item"
+      )
+      println()
+
+      // (Phases 6+ executed below outside the temp-dir cleanup.)
+
+      println("Phase 5 — GRDWalker.readNext (read all back from disk):")
+      // GRDWalker.items() walks to EOF, but the GRD format ends with a
+      // 2-byte sentinel and 8-byte back-pointer that GRDWalker.readNext
+      // doesn't recognise as an end marker (a pre-existing edge case in the
+      // codebase). For the benchmark we know exactly how many items were
+      // written, so we drive readNext that many times.
+      val grdFiles =
+        tempDir.listFiles().filter(_.getName.endsWith(".grd")).toVector
+      report("read N items via GRDWalker.readNext", repeats) {
+        var count = 0
+        for (grd <- grdFiles) {
+          val ch = new FileInputStream(grd).getChannel()
+          try {
+            val w = new GRDWalker(ch)
+            w.open().get
+            while (count < itemCount) {
+              w.readNext() match {
+                case Some(_) => count += 1
+                case None    => count = itemCount
+              }
+            }
+          } finally ch.close()
+        }
+      }
+    } finally {
+      Helpers.deleteDirectory(tempDir.toPath())
+    }
+    println()
+
+    // ------------------------------------------------------------------------
+    // Hashing-oriented phases. The hypothesis: with `Item.identifier:
+    // Identifier` backed by `ArraySeq.ofByte`, `Identifier.hashCode` (and
+    // therefore `Item.hashCode`) is recomputed O(N) on every call, where it
+    // was effectively O(1) when identifier was a `String` (because
+    // `String.hashCode` is cached on the String). Hash-heavy code paths —
+    // HashSet/HashMap operations on `Item` or `Identifier` — should pay
+    // dearly without a hashCode cache.
+    //
+    // If the focused benchmark also shows these phases are slow, this likely
+    // explains the test-suite-level slowdown we saw with binary CBOR
+    // (which itself is fast in encode/decode).
+    // ------------------------------------------------------------------------
+
+    println("Phase 6 — Identifier.hashCode (isolated):")
+    val identifiers = items.map(_.identifier)
+    report("compute Identifier.hashCode N times", repeats) {
+      var i = 0
+      var acc = 0
+      while (i < identifiers.size) {
+        acc ^= identifiers(i).##
+        i += 1
+      }
+      if (acc == Int.MinValue) throw new RuntimeException("dce-guard")
+    }
+    println()
+
+    println("Phase 7 — Item.hashCode (auto-generated case-class):")
+    report("compute Item.hashCode N times", repeats) {
+      var i = 0
+      var acc = 0
+      while (i < items.size) {
+        acc ^= items(i).##
+        i += 1
+      }
+      if (acc == Int.MinValue) throw new RuntimeException("dce-guard")
+    }
+    println()
+
+    println("Phase 8 — HashSet[Item] build + contains:")
+    report("build immutable HashSet[Item] of N items", repeats) {
+      var s = scala.collection.immutable.HashSet.empty[Item]
+      var i = 0
+      while (i < items.size) {
+        s = s + items(i)
+        i += 1
+      }
+    }
+    val populatedSet =
+      items.foldLeft(scala.collection.immutable.HashSet.empty[Item])(_ + _)
+    report("contains() N items in HashSet[Item]", repeats) {
+      var i = 0
+      while (i < items.size) {
+        populatedSet.contains(items(i))
+        i += 1
+      }
+    }
+    println()
+
+    println("Phase 9 — HashMap[Identifier, Int] build + lookup:")
+    report("build immutable HashMap[Identifier, Int]", repeats) {
+      var m = scala.collection.immutable.HashMap.empty[Identifier, Int]
+      var i = 0
+      while (i < items.size) {
+        m = m.updated(items(i).identifier, i)
+        i += 1
+      }
+    }
+    val populatedMap = items.zipWithIndex.foldLeft(
+      scala.collection.immutable.HashMap.empty[Identifier, Int]
+    ) { case (m, (item, i)) => m.updated(item.identifier, i) }
+    report("get() N keys in HashMap[Identifier, Int]", repeats) {
+      var i = 0
+      while (i < identifiers.size) {
+        populatedMap.get(identifiers(i))
+        i += 1
+      }
+    }
+    println()
+    println("Done.")
+  }
+}

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
+
 /** Phase 2 TDD Tests: ProcessingState.maybePackageTag contract
   *
   * These tests verify:

--- a/src/test/scala/strategies/CertificatesAssertionsTests.scala
+++ b/src/test/scala/strategies/CertificatesAssertionsTests.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import scala.collection.immutable.TreeMap
@@ -55,7 +56,7 @@ class CertificatesAssertionsTests extends FunSuite {
     val connections =
       TreeSet.from(purls.map(p => EdgeType.aliasFrom -> p))
     Item(
-      identifier = "gitoid:blob:sha256:test",
+      identifier = Gitoid("gitoid:blob:sha256:test"),
       connections = connections,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(
@@ -165,7 +166,7 @@ class CertificatesAssertionsTests extends FunSuite {
   test("purlsOf does not include non-pkg: edges") {
     // alias:from edges may legitimately carry gitoid: hashes too.
     val item = Item(
-      identifier = "gitoid:blob:sha256:test",
+      identifier = Gitoid("gitoid:blob:sha256:test"),
       connections = TreeSet(
         EdgeType.aliasFrom -> "gitoid:blob:sha1:hashA",
         EdgeType.aliasFrom -> "pkg:generic/x509/spki-sha256@abc"

--- a/src/test/scala/strategies/CertificatesAssertionsTests.scala
+++ b/src/test/scala/strategies/CertificatesAssertionsTests.scala
@@ -56,7 +56,7 @@ class CertificatesAssertionsTests extends FunSuite {
     val connections =
       TreeSet.from(purls.map(p => EdgeType.aliasFrom -> p))
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:test"),
+      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       connections = connections,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(
@@ -166,9 +166,9 @@ class CertificatesAssertionsTests extends FunSuite {
   test("purlsOf does not include non-pkg: edges") {
     // alias:from edges may legitimately carry gitoid: hashes too.
     val item = Item(
-      identifier = Gitoid("gitoid:blob:sha256:test"),
+      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       connections = TreeSet(
-        EdgeType.aliasFrom -> "gitoid:blob:sha1:hashA",
+        EdgeType.aliasFrom -> "gitoid:blob:sha1:7bec97ea6269f46f9778a3b063c2fddb74f48730",
         EdgeType.aliasFrom -> "pkg:generic/x509/spki-sha256@abc"
       ),
       bodyMimeType = Some(ItemMetaData.mimeType),

--- a/src/test/scala/strategies/CertificatesAssertionsTests.scala
+++ b/src/test/scala/strategies/CertificatesAssertionsTests.scala
@@ -56,7 +56,7 @@ class CertificatesAssertionsTests extends FunSuite {
     val connections =
       TreeSet.from(purls.map(p => EdgeType.aliasFrom -> p))
     Item(
-      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
       connections = connections,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(
@@ -166,7 +166,7 @@ class CertificatesAssertionsTests extends FunSuite {
   test("purlsOf does not include non-pkg: edges") {
     // alias:from edges may legitimately carry gitoid: hashes too.
     val item = Item(
-      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
       connections = TreeSet(
         EdgeType.aliasFrom -> "gitoid:blob:sha1:7bec97ea6269f46f9778a3b063c2fddb74f48730",
         EdgeType.aliasFrom -> "pkg:generic/x509/spki-sha256@abc"

--- a/src/test/scala/strategies/CertificatesLeakSuite.scala
+++ b/src/test/scala/strategies/CertificatesLeakSuite.scala
@@ -61,7 +61,7 @@ class CertificatesLeakSuite extends FunSuite {
   ).map(Pattern.compile)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:1738f894c151411b2c2dbc1d824894212453b8e1c7817d6ef7eda2253aeb7d64",
+    identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:1738f894c151411b2c2dbc1d824894212453b8e1c7817d6ef7eda2253aeb7d64"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesLeakSuite.scala
+++ b/src/test/scala/strategies/CertificatesLeakSuite.scala
@@ -8,6 +8,7 @@ import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -60,7 +61,7 @@ class CertificatesLeakSuite extends FunSuite {
   ).map(Pattern.compile)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase8-leak-suite-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase8-leak-suite-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesLeakSuite.scala
+++ b/src/test/scala/strategies/CertificatesLeakSuite.scala
@@ -61,7 +61,7 @@ class CertificatesLeakSuite extends FunSuite {
   ).map(Pattern.compile)
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase8-leak-suite-stub"),
+    identifier = "gitoid:blob:sha256:1738f894c151411b2c2dbc1d824894212453b8e1c7817d6ef7eda2253aeb7d64",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
+++ b/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
@@ -18,6 +18,7 @@ import io.bullet.borer.Dom
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ItemTagData
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -56,7 +57,7 @@ import scala.collection.immutable.TreeSet
 class CertificatesPipelineRunnerTests extends FunSuite {
 
   private def primaryItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(
@@ -70,14 +71,14 @@ class CertificatesPipelineRunnerTests extends FunSuite {
   )
 
   private def aliasStubItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = None,
     body = None
   )
 
   private def tagItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemTagData.mimeType),
     body = Some(ItemTagData(Dom.NullElem))

--- a/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
+++ b/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
@@ -57,7 +57,7 @@ import scala.collection.immutable.TreeSet
 class CertificatesPipelineRunnerTests extends FunSuite {
 
   private def primaryItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(
@@ -71,14 +71,14 @@ class CertificatesPipelineRunnerTests extends FunSuite {
   )
 
   private def aliasStubItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = None,
     body = None
   )
 
   private def tagItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemTagData.mimeType),
     body = Some(ItemTagData(Dom.NullElem))

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -648,8 +648,9 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
 
   private def stubItem(): io.spicelabs.goatrodeo.omnibor.Item = {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
+    import io.spicelabs.goatrodeo.util.Gitoid
     Item(
-      identifier = "gitoid:blob:sha256:phase8-property-stub",
+      identifier = Gitoid("gitoid:blob:sha256:phase8-property-stub"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -650,7 +650,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
     import io.spicelabs.goatrodeo.util.Gitoid
     Item(
-      identifier = "gitoid:blob:sha256:c74dd91102c1295a01b77df6080167fe58d21fc89104f77ff9a823291d7e83fe",
+      identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:c74dd91102c1295a01b77df6080167fe58d21fc89104f77ff9a823291d7e83fe"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -650,7 +650,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
     import io.spicelabs.goatrodeo.util.Gitoid
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:phase8-property-stub"),
+      identifier = "gitoid:blob:sha256:c74dd91102c1295a01b77df6080167fe58d21fc89104f77ff9a823291d7e83fe",
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -24,6 +24,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.CertificatesState
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.CryptoDetector
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import scala.collection.immutable.TreeMap
@@ -73,7 +74,7 @@ class CertificatesStubTests extends FunSuite {
     ByteWrapper("hello goat rodeo".getBytes("UTF-8"), name, None)
 
   private def syntheticItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase1-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase1-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -74,7 +74,7 @@ class CertificatesStubTests extends FunSuite {
     ByteWrapper("hello goat rodeo".getBytes("UTF-8"), name, None)
 
   private def syntheticItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase1-stub"),
+    identifier = "gitoid:blob:sha256:a5ab2af4d45fb8b97fdfd0b9ae633211884b0f1a765c8bae85b1d5aea257b1e0",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -74,7 +74,7 @@ class CertificatesStubTests extends FunSuite {
     ByteWrapper("hello goat rodeo".getBytes("UTF-8"), name, None)
 
   private def syntheticItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:a5ab2af4d45fb8b97fdfd0b9ae633211884b0f1a765c8bae85b1d5aea257b1e0",
+    identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:a5ab2af4d45fb8b97fdfd0b9ae633211884b0f1a765c8bae85b1d5aea257b1e0"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/GenericTestSuite.scala
+++ b/src/test/scala/strategies/GenericTestSuite.scala
@@ -30,7 +30,7 @@ class GenericTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/strategies/GenericTestSuite.scala
+++ b/src/test/scala/strategies/GenericTestSuite.scala
@@ -21,6 +21,7 @@ import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.omnibor.strategies.GenericFile
 import io.spicelabs.goatrodeo.omnibor.strategies.GenericFileState
 import io.spicelabs.goatrodeo.util.ByteWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -29,7 +30,7 @@ class GenericTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -41,8 +41,7 @@ class MavenTestSuite extends munit.FunSuite {
 </project>"""
 
   def createTestItem(id: String): Item = {
-    Item(
-      Gitoid(id),
+    Item(      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -227,16 +226,15 @@ class MavenTestSuite extends munit.FunSuite {
 
   test("MavenState.postChildProcessing - captures sources for Sources marker") {
     val storage = MemStorage(None)
-    val sourceItem = Item(
-      Gitoid("gitoid:blob:sha256:source123"),
+    val sourceItem = Item(      "gitoid:blob:sha256:66b242a56899be4c47f7825315f721c0401ccaeeb6410c16f8175678b3317459",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("Source.java"), TreeSet(), 100, TreeMap()))
     )
-    storage.write(sourceItem.identifier(), _ => Some(sourceItem), _ => "")
+    storage.write(sourceItem.identifier, _ => Some(sourceItem), _ => "")
 
     val state = MavenState()
-    val kids = Some(Vector(sourceItem.identifier))
+    val kids: Some[Vector[Gitoid]] = Some(Vector(Gitoid(sourceItem.identifier)))
     val newState =
       state.postChildProcessing(kids, storage, MavenMarkers.Sources)
 

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -22,6 +22,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.MavenState
 import io.spicelabs.goatrodeo.omnibor.strategies.MavenToProcess
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.File
@@ -41,7 +42,7 @@ class MavenTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -227,12 +228,12 @@ class MavenTestSuite extends munit.FunSuite {
   test("MavenState.postChildProcessing - captures sources for Sources marker") {
     val storage = MemStorage(None)
     val sourceItem = Item(
-      "gitoid:blob:sha256:source123",
+      Gitoid("gitoid:blob:sha256:source123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("Source.java"), TreeSet(), 100, TreeMap()))
     )
-    storage.write(sourceItem.identifier, _ => Some(sourceItem), _ => "")
+    storage.write(sourceItem.identifier(), _ => Some(sourceItem), _ => "")
 
     val state = MavenState()
     val kids = Some(Vector(sourceItem.identifier))

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -226,15 +226,15 @@ class MavenTestSuite extends munit.FunSuite {
 
   test("MavenState.postChildProcessing - captures sources for Sources marker") {
     val storage = MemStorage(None)
-    val sourceItem = Item(      "gitoid:blob:sha256:66b242a56899be4c47f7825315f721c0401ccaeeb6410c16f8175678b3317459",
+    val sourceItem = Item(io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:66b242a56899be4c47f7825315f721c0401ccaeeb6410c16f8175678b3317459"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("Source.java"), TreeSet(), 100, TreeMap()))
     )
-    storage.write(sourceItem.identifier, _ => Some(sourceItem), _ => "")
+    storage.write(sourceItem.identifierString, _ => Some(sourceItem), _ => "")
 
     val state = MavenState()
-    val kids: Some[Vector[Gitoid]] = Some(Vector(Gitoid(sourceItem.identifier)))
+    val kids: Some[Vector[Gitoid]] = Some(Vector(Gitoid(sourceItem.identifierString)))
     val newState =
       state.postChildProcessing(kids, storage, MavenMarkers.Sources)
 

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -196,7 +196,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
     * actually read the Item, but the signature requires one.
     */
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:576b69f3080f6cb38372ca5b9e08fce957f5d00b0c1ff9e40029b74cccbac4af",
+    identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:576b69f3080f6cb38372ca5b9e08fce957f5d00b0c1ff9e40029b74cccbac4af"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -196,7 +196,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
     * actually read the Item, but the signature requires one.
     */
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:pgp-property-test"),
+    identifier = "gitoid:blob:sha256:576b69f3080f6cb38372ca5b9e08fce957f5d00b0c1ff9e40029b74cccbac4af",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
@@ -195,7 +196,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
     * actually read the Item, but the signature requires one.
     */
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:pgp-property-test",
+    identifier = Gitoid("gitoid:blob:sha256:pgp-property-test"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -63,7 +63,7 @@ class PrivateKeyLogCaptureTests extends FunSuite {
   }
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase7-log-capture-stub"),
+    identifier = "gitoid:blob:sha256:dc88a2967453fc0e5270985c475b412dbf7f47a24432bb8cf5177441758bb0f5",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -62,7 +63,7 @@ class PrivateKeyLogCaptureTests extends FunSuite {
   }
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase7-log-capture-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase7-log-capture-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -63,7 +63,7 @@ class PrivateKeyLogCaptureTests extends FunSuite {
   }
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:dc88a2967453fc0e5270985c475b412dbf7f47a24432bb8cf5177441758bb0f5",
+    identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:dc88a2967453fc0e5270985c475b412dbf7f47a24432bb8cf5177441758bb0f5"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyPropertyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyPropertyTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
@@ -75,7 +76,7 @@ class PrivateKeyPropertyTests extends ScalaCheckSuite {
     FileWrapper(f, f.getName, None)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase7-prop-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase7-prop-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyPropertyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyPropertyTests.scala
@@ -76,7 +76,7 @@ class PrivateKeyPropertyTests extends ScalaCheckSuite {
     FileWrapper(f, f.getName, None)
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase7-prop-stub"),
+    identifier = "gitoid:blob:sha256:d589945ab6586fdfdfc7c727c260e7dfe63f6520df3e5de4c1d88b470d9e6f28",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyPropertyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyPropertyTests.scala
@@ -76,7 +76,7 @@ class PrivateKeyPropertyTests extends ScalaCheckSuite {
     FileWrapper(f, f.getName, None)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:d589945ab6586fdfdfc7c727c260e7dfe63f6520df3e5de4c1d88b470d9e6f28",
+    identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:d589945ab6586fdfdfc7c727c260e7dfe63f6520df3e5de4c1d88b470d9e6f28"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -643,7 +643,7 @@ class PrivateKeyStrategyTests extends FunSuite {
     import io.spicelabs.goatrodeo.util.Gitoid
     import scala.collection.immutable.{TreeMap, TreeSet}
     Item(
-      identifier = "gitoid:blob:sha256:1d8d5fa9ef663970b0e15351ea4a8c5f11a3011c1999dbb0c98c38ab0348acda",
+      identifier = io.spicelabs.goatrodeo.util.Identifier("gitoid:blob:sha256:1d8d5fa9ef663970b0e15351ea4a8c5f11a3011c1999dbb0c98c38ab0348acda"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -640,9 +640,10 @@ class PrivateKeyStrategyTests extends FunSuite {
 
   private def stubItem(): io.spicelabs.goatrodeo.omnibor.Item = {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
+    import io.spicelabs.goatrodeo.util.Gitoid
     import scala.collection.immutable.{TreeMap, TreeSet}
     Item(
-      identifier = "gitoid:blob:sha256:phase7-test-stub",
+      identifier = Gitoid("gitoid:blob:sha256:phase7-test-stub"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -643,7 +643,7 @@ class PrivateKeyStrategyTests extends FunSuite {
     import io.spicelabs.goatrodeo.util.Gitoid
     import scala.collection.immutable.{TreeMap, TreeSet}
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:phase7-test-stub"),
+      identifier = "gitoid:blob:sha256:1d8d5fa9ef663970b0e15351ea4a8c5f11a3011c1999dbb0c98c38ab0348acda",
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(


### PR DESCRIPTION
### Summary

**DO NOT MERGE...yet**

This brings a number of performance improvements to the ADG generation and output, but changes the format (now called v4) in the process. Corresponding changes are required in Big Tent. These are complete and tested, but haven't been PRed yet.

### Changes

- **Add more typesafety to Gitoids**
- **Use an efficient internal representation of `Gitoid`s**
- **Make `PackageUrl`s typesafe (like `Gitoid`s)**
- **Compact on-disk edge encoding (v2) and alias-table collapse (v3)**
- **Drop inverse content edges on write**
- **Cluster.canonicalise / reverseEdges helpers + envelope/EOF read fixes**
- **Introduce `Identifier` opaque type subsuming `Gitoid`**
- **Move alias map out of DataFileEnvelope into a .gra sidecar (v4)**
- **Sort .gri index entries by MD5 before writing**
- **MemStorage: ConcurrentHashMap instead of CoW + global lock**
- **GraphManager.writeABlock: batch item writes into a 4 MiB buffer**

### Tests

All Goat Rodeo tests pass. All Big Tent tests pass on data generated from the modified Goat Rodeo. Further integration testing needs to be done before merge.

### Impact

- Big Tent will break if this is merged without corresponding changes to its ADG parsing
- Generation of ADGs should be about 30% faster
- Data files are about 3x smaller

N.B. PackageURLs are currently treated as bijective aliases, which is wrong. PackageURLs are potentially many-to-many relationships. In the test data, however, there are no one-to-many relations involving Purls. But this will need to be addressed before we run GoatRodeo on Maven Central.

## Detailed Summary for Review /cc @dpp

1. Tightens up the in-memory model with opaque types (`Gitoid`, `PackageUrl`, then a unifying `Identifier`).
2. Compacts the on-disk wire format (streamed `WireEdge` encoding, alias-table collapse, stripped inverse edges, sidecar alias map).
3. Adds reader-side helpers on `GoatRodeoCluster` to surface the relationships the writer strips.
4. Fixes three latent reader/writer bugs (envelope length asymmetry, EOF-sentinel size, index sort order).
5. Two pure-perf commits at the end (storage map, write batching) — no format implications.

The combined effect on the ADG corpus: ~887 MB → ~278 MB on-disk, no measurable wall-clock change on the read path.

---

## What changes in BigTent

### Same in v1 and v4 (verified)

For a **canonical identifier** (a `gitoid:blob:sha256:…` that's in the `.gri` index):

- `/item/<canonical>` returns the same `connections` set, body, body_mime_type, and identifier.
  - 5 × `alias:from` edges (stripped by the writer, synthesised by the reader from the `.gra` sidecar).
  - 14 × `contained:down` edges (stripped by the writer, synthesised by the reader from the lazy cluster-level inverse-edge index).
  - All forward content edges (`contained:up`, `build:down`, …) come through unchanged.
- `/aa/<canonical>` matches.
- `/flatten/<canonical>` is **byte-identical** to the v1 baseline (verified on the `HP1973-Source.zip` root).
- `/north/<canonical>` traversal hasn't been tested as a one-off but uses only forward upward edges that the v4 writer still emits.

### Also preserved (alias-identifier lookups)

For an **alias identifier** (the sha1, md5, sha256, sha512 hashes that point at a canonical gitoid):

| Endpoint | v1 behaviour | v4 (with BigTent #153 sidecar fallback) |
|---|---|---|
| `/item/<alias>` | stub Item with `alias:to → canonical`, no body | **byte-identical** to v1 — synthesised from the `.gra` sidecar on lookup miss |
| `/aa/<alias>` | follows the stub's `alias:to` to the canonical's full Item | identical to v1 modulo the per-build random `tag:from` gitoid |
| `/flatten/<alias>` | walks via antialias resolution to canonical | same as v1 |
| `/has/<alias>` | true | true |

In v1 each alias was a stand-alone Item with a single `alias:to` edge, indexed in the `.gri`. In v4 those Items don't exist on disk — the relationship lives in the cluster-wide `.gra` sidecar. BigTent #153 loads the sidecar at cluster-open time and, on a lookup miss, synthesises the same pointer Item v1 would have stored. Downstream consumers (`antialias_for`, `impl_stream_flattened_items`, `impl_north_send`) already know how to chase `alias:to`, so they inherit correct behaviour for free.

### Smaller / countable differences

- **`/node_count`** drops by however much the alias collapse compresses: on the QA corpus from 233 → 36. This is the *intended* number — canonical items only — and matches the writer's `Post-sort … items after collapse: N` log message.
- The on-disk `.grd` is ~3× smaller because edges are now streamed `WireEdge`s and alternates aren't stored as their own items.
- A new `.gra` sidecar file appears in every v4 cluster that has aliases (referenced by `ClusterFileEnvelope.alias_map_file`).
- `DataFileEnvelope.version` bumps from 1 to 4; `ClusterFileEnvelope.version` bumps from 3 to 4. v1 envelopes still read fine through the legacy codec path.

---

## Per-commit summary

Listed oldest → newest, matching the order in [PR #264](https://github.com/spice-labs-inc/goatrodeo/pull/264). The base commit (`2a09e69`) is the CI disk-space fix from [#265](https://github.com/spice-labs-inc/goatrodeo/pull/265).

### [Add more typesafety to Gitoids](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/7570977)

Prelude. Turns `Gitoid` (previously a `String`) into a stricter type alias and tightens the call sites that used it as a raw String. No on-disk implications; lots of trivial knock-on edits in `ToProcess` / `Builder` / strategies / tests. Skim by commit, no specific file to focus on.

### [Use an efficient internal representation of `Gitoid`s](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/3e2fe6d)

The substantive typesafety change. `Gitoid` becomes an opaque `ArraySeq.ofByte` (1-byte header packing `ObjectType.ordinal << 2 | HashAlgorithm.ordinal` + the raw hash bytes). The URL-style String form is still computed lazily for callers that need it but the in-memory and CBOR-encoded forms are now bytes.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/3e2fe6d/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala) — the entire `object Gitoid` body. The Borer `Encoder`/`Decoder` switches from `Encoder.forString.contramap[Gitoid](toUrlString)` to `w.writeBytes(bytes(g))`. **This is a wire-format change** — Items written by this commit are not readable by earlier code, but it doesn't matter in isolation since the rest of v2/v3 lands together.
- Knock-on: `Helpers.scala` loses ~140 lines of String-based hex/parse helpers that are now folded into `Opaques`.

### [Make `PackageUrl`s typesafe (like `Gitoid`s)](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/f338719)

Same treatment for PackageUrl — opaque type with a validation in `apply(canonical: String)` that round-trips through `com.github.packageurl.PackageURL`. Smaller blast radius because PackageUrl is less load-bearing than Gitoid.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/f338719/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala) — the new `opaque type PackageUrl` block.

### [Compact on-disk edge encoding (v2) and alias-table collapse (v3)](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/86a3eab)

**The substantive wire-format commit.** Three things bundled together because they share the same `prepareForWrite()` machinery:

1. **Streamed `WireEdge` encoding** — connections in v ≥ 2 data files are no longer the legacy `(String, String)` tuples; they're discriminator-tagged variants (`SameFile(et, off)`, `CrossFile(et, fo, off)`, `External(et, target)`, `UnknownType(et, target)`) that back-reference items by `(file_ordinal, byte_offset)` within the cluster. Up to ~84-byte gitoid strings collapse to 8-byte back-references.
   - [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/86a3eab/src/main/scala/io/spicelabs/goatrodeo/omnibor/Struct.scala) — `WireEdge` ADT + Borer codecs.
   - [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/86a3eab/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala) — new `encodeStreamed(item, WriteContext): Array[Byte]` and `decodeStreamed(bytes, ReadContext): Item`. The legacy `encodeCBOR` / `decode` are still around for v1.
   - [`src/main/scala/io/spicelabs/goatrodeo/util/EdgeTypeId.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/86a3eab/src/main/scala/io/spicelabs/goatrodeo/util/EdgeTypeId.scala) — new file: byte IDs for the eight well-known edge types. Values are part of the wire format.

2. **Alias-table collapse** — `Storage.prepareForWrite()` runs union-find over `alias:from` / `alias:to` edges, picks a canonical per class (`gitoid:blob:sha256:` preferred, else lex-smallest Item-backed), merges the alternates' Items into the canonical via `Item.merge`, and strips alias edges from the canonical. The class is recorded in a `TreeMap[String, TreeSet[String]]` (canonical → alternates) that the writer threads through to its output. **This is the change with the biggest semantic implications** — on read, alternates are no longer items, only entries in the alias map.
   - [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/86a3eab/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala) — the new `prepareForWrite()` method on `ListFileNames`.

3. **`DataFileEnvelope` version → 3** with the new `aliasMap` field embedded (later moved out in `45b3aab`).
   - [`src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/86a3eab/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala).

`Builder.scala` and `GraphManager.scala` adopt these new paths.

### [Drop inverse content edges on write](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/0e20c60)

Tiny commit (20 lines). In `prepareForWrite()`, after the alias-collapse pass, strip `contained:down` and `build:up` from every Item. These are inverse halves of `contained:up` / `build:down` — pure redundancy on disk. The reader synthesises them back from the cluster's forward-edge index. The post-strip `Item.connections` is exactly what BigTent sees in `read_item_at` until the inverse-index augmentation runs.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/0e20c60/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala) — search for the `(EdgeType.containedDown | EdgeType.buildUp) ⇒` filter in `prepareForWrite`.

### [Cluster.canonicalise / reverseEdges helpers + envelope/EOF read fixes](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/2f7ea20)

Two unrelated things in one commit:

1. **Reader-side helpers on `GoatRodeoCluster`** — `canonicalise(id): String`, `aliasInverseMap: Map[String, String]`, `forwardEdgeIndex: Map[(String, String), Set[String]]`, `reverseEdges(id, edgeType): Set[String]`. These let any consumer (the test suite, future external tools) recover the inverse-content-edge / alias-from views that the writer no longer emits.
   - [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/2f7ea20/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala) — the new methods on `GoatRodeoCluster`.

2. **Three latent bug fixes**:
   - `Helpers.readCBOR` was forgetting to `dest.position(0)` before `Cbor.decode`, so subsequent reads from the same ByteBuffer decoded garbage.
   - `Cluster.scala`'s envelope-length reads used a 4-byte `readLenAndCBOR` against a 2-byte length written by `GraphManager`. Symmetry restored.
   - `GraphManager.writeABlock` wrote the EOF sentinel as a `Short(-1)` but `readNext` reads it as `Int(-1)`. Promoted to `Int` on the write side.

### [Introduce `Identifier` opaque type subsuming `Gitoid`](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/fb73107)

The biggest single conceptual change: `Gitoid` becomes one case of a more general `Identifier`. Both share an `ArraySeq.ofByte` layout — a 1-byte header where the high nibble is the **kind** (0 = Gitoid, 1 = RawHash, 2 = PackageUrl, 3 = Sentinel) and the low nibble is kind-specific. The rest of the bytes are raw hash bytes (Gitoid / RawHash) or UTF-8 (PackageUrl / Sentinel).

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/fb73107/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala) — the `Identifier` opaque type, its `Kind` and `RawHashAlgorithm` enums, `fromGitoid` / `fromPackageUrl` / `sentinel` / `rawHash` / `apply(canonical: String)` constructors, and the extension methods (`apply()`, `kind`, `isGitoid`, `asGitoid`, `md5`, `md5Hex`, `startsWith`). Gitoid's header byte is repacked in this commit so its layout matches Identifier's, making the two convertible zero-copy.
- Gitoid's Borer codec doesn't change again — already on bytes — but Identifier's codec is added here.
- One important consequence: `Identifier.md5` hashes the **binary** layout, not the canonical String form, and the `.gri` index now keys by this binary-form MD5. BigTent's `md5hash_str` had to be updated to match in [#153](https://github.com/spice-labs-inc/bigtent/pull/153).
- Bundled: a new `src/test/scala/benchmarks/GraphBenchmark.scala` (326 LOC) JMH-style scaffold. Independent of the Identifier work, just landed alongside.

### [Move alias map out of DataFileEnvelope into a .gra sidecar (v4)](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/45b3aab)

Withdraws the embedded `aliasMap` field introduced in v3 and moves it into a separate `<hash>.gra` sidecar file referenced by hash from the cluster envelope. The DataFileEnvelope had a 16-bit length prefix on its CBOR payload, and the embedded alias map on real corpora routinely exceeds 64 KiB — Borer's `writeShort` silently truncates via `num & 0xffff` so v3 envelopes were silently corrupted at scale.

- [`src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/45b3aab/src/main/scala/io/spicelabs/goatrodeo/envelopes/Envelope.scala) — `DataFileEnvelope` drops `aliasMap` and bumps to v4; `ClusterFileEnvelope` gains `aliasMapFile: Option[Long]` and bumps to v4.
- [`src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/45b3aab/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala) — new `writeAliasMapFile(targetDirectory, aliasMap): Long`, called from `writeEntries` after the data + index files.
- [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/45b3aab/src/main/scala/io/spicelabs/goatrodeo/omnibor/Cluster.scala) — new `loadAliasMapFile(dir, hash)` companion-object method, called from `GoatRodeoCluster.open` when the envelope's `aliasMapFile` is `Some(_)`.

The `.gra` file is a 4-byte magic `0x0a11a5ed` followed by a single CBOR-encoded `TreeMap[String, TreeSet[String]]` with no length prefix — the file boundary is the delimiter, so arbitrary sizes round-trip.

### [Sort .gri index entries by MD5 before writing](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/ccc4430)

Bug fix exposed by `86a3eab`. `Storage.prepareForWrite` returns Items in topological order along forward content edges, not MD5 order. The writer was emitting `.gri` index entries in that same order, so the index was unsorted — which broke the binary-search lookup path that both `GRDWalker` and BigTent rely on. The per-entry `.grd` offset is recorded as items are written, so the index can be reordered before flushing without disturbing the write positions.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/ccc4430/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala) — the new `sortWith` block right before `for { v <- sortedPairs }`.

### [MemStorage: ConcurrentHashMap instead of CoW + global lock](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/a0709cb)

Pure perf. No format implications. `MemStorage.write` previously copied an immutable `Map[String, Item]` on every update under a global mutex; now it uses `ConcurrentHashMap.compute(path, BiFunction)`. The per-path waiter-counter machinery (`locks: HashMap[String, AtomicInteger]`) and its contention-log threshold disappear. The `context` callback on `write` is kept in the signature for source compatibility but has no consumers now.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/a0709cb/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala) — the `class MemStorage` rewrite.

### [GraphManager.writeABlock: batch item writes into a 4 MiB buffer](https://github.com/spice-labs-inc/goatrodeo/pull/264/commits/d8fd7b3)

Pure perf. No format implications. Output bytes are identical to the pre-change writer (verified on the ADGTests corpus). Per-Item `ByteBuffer.allocate(256 + entryBytes.length)` + one `FileChannel.write` syscall becomes a single reusable 4 MiB heap buffer flushed on overflow, with `logicalPosition` standing in for `writer.position()` for index/back-ref recording.

- Key file: [`src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala`](https://github.com/spice-labs-inc/goatrodeo/blob/d8fd7b3/src/main/scala/io/spicelabs/goatrodeo/omnibor/GraphManager.scala) — the per-Item loop in `writeABlock`.

---

## Loose ends

1. The `GraphBenchmark.scala` is independent of the typesafety work and could land as its own commit. Not blocking; cosmetic.
2. The `context` callback on `Storage.write` is now dead. Could be removed in a future cleanup.

Verified that all 1,329 goatrodeo tests pass, and the v1 → v4 round-trip through BigTent is byte-identical for canonical-identifier lookups and `/flatten` (the QA results are in the BigTent PR's body).
