### PR TITLE
CI: free runner disk space before ADGTests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -22,6 +22,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: true
+    - name: Free up disk space on the runner
+      # ADGTests downloads repo_ea.tgz (~5.2 GiB) and untars it (~5.2 GiB)
+      # into test_data/download/adg_tests/. On ubuntu-24.04 the default
+      # ~14 GiB of free space is just barely enough; if the runner has
+      # any other consumers (Docker, browser stacks, etc.) the untar
+      # silently truncates and ADGTests later fails with missing-JAR
+      # errors. Reclaim the chunky pre-installed toolchains we don't use
+      # before the test data is materialised.
+      run: |
+        df -h /
+        sudo rm -rf /usr/share/dotnet /usr/share/swift /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+        sudo docker image prune --all --force || true
+        df -h /
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
## Summary

CI was failing on PR #264, and the LLM verdict is that it's because we are filling up the disk. I'm suspicious that this has started _now_, but this should serve to test the theory. It just deletes a lot of stuff we don't need before starting. Even if it doesn't fix the CI failures, this should be harmless.

LLM analysis:

- ADGTests downloads `repo_ea.tgz` (~5.2 GiB) and untars it into `test_data/download/adg_tests/repo_ea/` (~5.2 GiB). On the stock `ubuntu-24.04` runner the ~14 GiB of free space leaves almost no headroom once the rest of the build artefacts land, and `tar -xzvf` inside `build.sbt`'s `Tests.Setup` silently truncates on ENOSPC.
- The setup block only re-extracts when the tgz doesn't already exist, so once a partial extraction happens the runner can't recover without a clean checkout. The CI failure mode is misleading: the first ADGTest fails on a hardcoded filename check (`adif-processor-1.0.65.jar`) and the second on `tagCount > 8000` — neither error message hints at "out of disk space".
- This PR reclaims the chunky pre-installed toolchains GoatRodeo doesn't use (dotnet, swift, Android SDK, GHC, CodeQL cache, Docker images) before test data is materialised. Recovers ~30–40 GiB on a stock `ubuntu-24.04` runner.

A durable follow-up would be to make `build.sbt`'s setup block either always re-extract or assert a sentinel file is present after extraction, so that "extraction failed" surfaces as a clear failure instead of being deferred to a misleading test-assertion message. Out of scope for this PR.

## Test plan

- [x] CI passes on this PR (free-space step shows non-trivial space recovered, test_data extraction completes, ADGTests pass).
- [x] No change to test code or test_data; only the workflow YAML is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)