### PR TITLE
add ProgressListener for progress callbacks

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -359,6 +359,20 @@ class GoatRodeoBuilder {
     }
   }
 
+  /** Attach a progress listener that is notified at phase boundaries
+    * (Scanning, Writing, Done) and periodically during the Processing
+    * phase. See [[ProgressListener]] for cadence and threading semantics.
+    *
+    * Passing `null` clears any previously attached listener.
+    *
+    * @param listener the listener to attach, or `null` to clear
+    * @return this builder
+    */
+  def withProgressListener(listener: ProgressListener): GoatRodeoBuilder = {
+    config = config.copy(progressListener = Option(listener))
+    this
+  }
+
   /** Execute the Goat Rodeo build with the current configuration.
     */
   def run(): Unit = {

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -88,6 +88,16 @@ object Howdy {
 
     val logger = Logger(getClass())
 
+    // Phase boundaries for any caller-supplied ProgressListener. Scanning fires
+    // before the filesystem walk; Done fires in a finally so it's guaranteed
+    // even on early failure.
+    ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Scanning)
+    try runInner(params, logger)
+    finally ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Done)
+  }
+
+  private def runInner(params: Config, logger: Logger): Unit = {
+
     val fileListers = params.getFileListBuilders()
 
     if (!params.nonexistantDirectories.isEmpty) {

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -88,18 +88,6 @@ object Howdy {
 
     val logger = Logger(getClass())
 
-    // Phase boundaries for any caller-supplied ProgressListener. Scanning fires
-    // before the filesystem walk; Done fires in a finally so it's guaranteed
-    // even on early failure.
-    ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Scanning)
-    try {
-      runInner(params, logger)
-    } finally {
-      ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Done)
-    }
-  }
-
-  private def runInner(params: Config, logger: Logger): Unit = {
     val fileListers = params.getFileListBuilders()
 
     if (!params.nonexistantDirectories.isEmpty) {

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -92,12 +92,14 @@ object Howdy {
     // before the filesystem walk; Done fires in a finally so it's guaranteed
     // even on early failure.
     ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Scanning)
-    try runInner(params, logger)
-    finally ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Done)
+    try {
+      runInner(params, logger)
+    } finally {
+      ProgressListener.safeNotify(params.progressListener, ProgressListener.Phase.Done)
+    }
   }
 
   private def runInner(params: Config, logger: Logger): Unit = {
-
     val fileListers = params.getFileListBuilders()
 
     if (!params.nonexistantDirectories.isEmpty) {

--- a/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
@@ -65,7 +65,27 @@ object ProgressListener {
     * straight to `Done` on early failure without entering later phases.
     */
   enum Phase {
-    case Scanning, Processing, Writing, Done
+
+    /** Walking the filesystem and characterizing artifacts (MIME, crypto).
+      * The total file count is not yet known at this point.
+      */
+    case Scanning
+
+    /** Building the GitOID graph from artifacts — the hot loop. Periodic
+      * updates carry real `(processed, total)` counts.
+      */
+    case Processing
+
+    /** Sorting, serializing to CBOR, and writing the output bundle. Fires
+      * once when processing is complete and only write work remains.
+      */
+    case Writing
+
+    /** The run has finished (successfully or otherwise). Fires exactly once
+      * per `Howdy.run` invocation, in a `finally` block, so listeners can
+      * reliably release resources or publish a terminal status.
+      */
+    case Done
   }
 
   private val logger = Logger(getClass())
@@ -82,8 +102,9 @@ object ProgressListener {
       total: Long = 0L
   ): Unit = {
     listener.foreach { l =>
-      try l.onProgress(phase, current, total)
-      catch {
+      try {
+        l.onProgress(phase, current, total)
+      } catch {
         case t: Throwable =>
           logger.warn(s"ProgressListener threw on phase=$phase", t)
       }

--- a/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
@@ -1,0 +1,92 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo
+
+import com.typesafe.scalalogging.Logger
+
+/** A callback for receiving progress notifications during a Goat Rodeo run.
+  *
+  * Implementations are notified when the build crosses a phase boundary
+  * ([[ProgressListener.Phase.Scanning]], [[ProgressListener.Phase.Writing]],
+  * [[ProgressListener.Phase.Done]]) and periodically during the long-running
+  * [[ProgressListener.Phase.Processing]] phase — at the same cadence as the
+  * existing "Processed N of M" log emission (every 1,000 items or 30 seconds,
+  * whichever fires first).
+  *
+  * The listener is invoked on whichever thread emitted the event, including
+  * worker threads during processing, so implementations must be thread-safe
+  * and return quickly. Exceptions thrown by the listener are caught and
+  * logged; they never abort the build.
+  *
+  * The trait has a single abstract method, so Java callers may pass a
+  * lambda directly:
+  *
+  * {{{
+  * goatRodeo.withProgressListener((phase, current, total) -> {
+  *     // ...
+  * });
+  * }}}
+  *
+  * @see [[GoatRodeoBuilder.withProgressListener]]
+  */
+trait ProgressListener {
+
+  /** Receive a progress notification.
+    *
+    * For [[ProgressListener.Phase.Processing]], `current` is the number of
+    * top-level artifacts processed so far and `total` is the number
+    * discovered during the initial filesystem walk. For the other phases
+    * both values are `0` — the call marks only the transition into that
+    * phase.
+    *
+    * @param phase   the phase the build is currently in
+    * @param current items processed so far (Processing only; 0 otherwise)
+    * @param total   items in scope (Processing only; 0 otherwise)
+    */
+  def onProgress(phase: ProgressListener.Phase, current: Long, total: Long): Unit
+}
+
+object ProgressListener {
+
+  /** The phases a Goat Rodeo run passes through, in order:
+    * `Scanning` → `Processing` → `Writing` → `Done`. A run may transition
+    * straight to `Done` on early failure without entering later phases.
+    */
+  enum Phase {
+    case Scanning, Processing, Writing, Done
+  }
+
+  private val logger = Logger(getClass())
+
+  /** Invoke a listener, swallowing and logging any exception. Internal
+    * helper used by call sites in [[io.spicelabs.goatrodeo.omnibor.Builder]]
+    * and [[Howdy]] so a misbehaving listener can never abort a multi-hour
+    * build.
+    */
+  private[goatrodeo] def safeNotify(
+      listener: Option[ProgressListener],
+      phase: Phase,
+      current: Long = 0L,
+      total: Long = 0L
+  ): Unit = {
+    listener.foreach { l =>
+      try l.onProgress(phase, current, total)
+      catch {
+        case t: Throwable =>
+          logger.warn(s"ProgressListener threw on phase=$phase", t)
+      }
+    }
+  }
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/ProgressListener.scala
@@ -18,23 +18,34 @@ import com.typesafe.scalalogging.Logger
 
 /** A callback for receiving progress notifications during a Goat Rodeo run.
   *
-  * Implementations are notified when the build crosses a phase boundary
-  * ([[ProgressListener.Phase.Scanning]], [[ProgressListener.Phase.Writing]],
-  * [[ProgressListener.Phase.Done]]) and periodically during the long-running
-  * [[ProgressListener.Phase.Processing]] phase — at the same cadence as the
-  * existing "Processed N of M" log emission (every 1,000 items or 30 seconds,
-  * whichever fires first).
+  * The listener is invoked periodically while items flow through the build
+  * pipeline, at the same cadence as the existing "Processed N of M" log
+  * emission (every 1,000 items or 30 seconds, whichever fires first).
   *
-  * The listener is invoked on whichever thread emitted the event, including
-  * worker threads during processing, so implementations must be thread-safe
-  * and return quickly. Exceptions thrown by the listener are caught and
-  * logged; they never abort the build.
+  * No phase or boundary signals are exposed — Goat Rodeo's filesystem walk,
+  * artifact processing, and per-batch output writing all overlap freely on
+  * separate threads, so any "phase boundary" would be a fiction. A caller
+  * that needs phase-like UI states can synthesize them from `current/total`
+  * (e.g. "Starting" before the first event, "Processing N of M" while
+  * `current < total`, "Finalizing" once `current == total` and `onProgress`
+  * stops firing) and from the synchronous return of `Howdy.run` /
+  * `GoatRodeoBuilder.run`, which signals overall completion.
+  *
+  * Events arrive from worker threads — typically several in parallel — so
+  * implementations must be thread-safe. Goat Rodeo enforces monotonic
+  * `current` per run (out-of-order ticks from racing threads are dropped)
+  * so the listener never sees backwards progress within a run, but two
+  * callbacks can still overlap in time; serialize on the listener side if
+  * that matters.
+  *
+  * Exceptions thrown by the listener are caught and logged; they never
+  * abort the build.
   *
   * The trait has a single abstract method, so Java callers may pass a
   * lambda directly:
   *
   * {{{
-  * goatRodeo.withProgressListener((phase, current, total) -> {
+  * goatRodeo.withProgressListener((current, total) -> {
   *     // ...
   * });
   * }}}
@@ -45,68 +56,62 @@ trait ProgressListener {
 
   /** Receive a progress notification.
     *
-    * For [[ProgressListener.Phase.Processing]], `current` is the number of
-    * top-level artifacts processed so far and `total` is the number
-    * discovered during the initial filesystem walk. For the other phases
-    * both values are `0` — the call marks only the transition into that
-    * phase.
+    * `current` is the number of top-level artifacts processed so far;
+    * `total` is the number discovered by the filesystem walk and may
+    * continue to grow until the walk completes. Both are non-negative;
+    * `current <= total` always holds.
     *
-    * @param phase   the phase the build is currently in
-    * @param current items processed so far (Processing only; 0 otherwise)
-    * @param total   items in scope (Processing only; 0 otherwise)
+    * @param current items processed so far
+    * @param total   items discovered so far (may still be growing)
     */
-  def onProgress(phase: ProgressListener.Phase, current: Long, total: Long): Unit
+  def onProgress(current: Long, total: Long): Unit
 }
 
 object ProgressListener {
 
-  /** The phases a Goat Rodeo run passes through, in order:
-    * `Scanning` → `Processing` → `Writing` → `Done`. A run may transition
-    * straight to `Done` on early failure without entering later phases.
+  /** Build a per-run dispatcher that wraps `listener` with monotonic-current
+    * enforcement and exception safety. Internal — Goat Rodeo's pipeline
+    * instantiates one per `Howdy.run` invocation and forwards every tick
+    * through it from inside the worker-thread callback.
     */
-  enum Phase {
+  private[goatrodeo] def notifier(listener: Option[ProgressListener]): Notifier =
+    new Notifier(listener)
 
-    /** Walking the filesystem and characterizing artifacts (MIME, crypto).
-      * The total file count is not yet known at this point.
-      */
-    case Scanning
-
-    /** Building the GitOID graph from artifacts — the hot loop. Periodic
-      * updates carry real `(processed, total)` counts.
-      */
-    case Processing
-
-    /** Sorting, serializing to CBOR, and writing the output bundle. Fires
-      * once when processing is complete and only write work remains.
-      */
-    case Writing
-
-    /** The run has finished (successfully or otherwise). Fires exactly once
-      * per `Howdy.run` invocation, in a `finally` block, so listeners can
-      * reliably release resources or publish a terminal status.
-      */
-    case Done
-  }
-
-  private val logger = Logger(getClass())
-
-  /** Invoke a listener, swallowing and logging any exception. Internal
-    * helper used by call sites in [[io.spicelabs.goatrodeo.omnibor.Builder]]
-    * and [[Howdy]] so a misbehaving listener can never abort a multi-hour
-    * build.
+  /** Per-run dispatcher. Holds the monotonic-current state for one
+    * `Howdy.run` invocation so each run starts fresh and concurrent fires
+    * from worker threads can't deliver backwards ticks. Safe to call from
+    * multiple threads.
+    *
+    * Delivery is serialized under an intrinsic lock so the wrapped
+    * listener observes calls in strict `current`-increasing order — a
+    * weaker guarantee (monotonic CAS without serialized delivery) would
+    * still let two threads race past their state update and call
+    * `onProgress` in the wrong order, which is exactly the backwards
+    * progress the listener wants to never see. The lock is uncontended
+    * outside the rare moments when multiple worker threads cross the
+    * "Processed N of M" emission cadence (every 1,000 items or 30s)
+    * simultaneously, so the cost is negligible.
     */
-  private[goatrodeo] def safeNotify(
-      listener: Option[ProgressListener],
-      phase: Phase,
-      current: Long = 0L,
-      total: Long = 0L
-  ): Unit = {
-    listener.foreach { l =>
-      try {
-        l.onProgress(phase, current, total)
-      } catch {
-        case t: Throwable =>
-          logger.warn(s"ProgressListener threw on phase=$phase", t)
+  private[goatrodeo] final class Notifier(listener: Option[ProgressListener]) {
+
+    private val logger = Logger(getClass())
+    private var lastReportedCurrent = -1L
+
+    /** Forward a tick to the wrapped listener if and only if `current`
+      * strictly exceeds every value previously forwarded by this notifier.
+      * Listener exceptions are caught and logged.
+      */
+    def notify(current: Long, total: Long): Unit = synchronized {
+      if (current > lastReportedCurrent) {
+        lastReportedCurrent = current
+        listener.foreach { l =>
+          try {
+            l.onProgress(current, total)
+          } catch {
+            case t: Throwable =>
+              logger.warn(s"ProgressListener threw on current=$current total=$total", t)
+          }
+        }
       }
     }
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -86,6 +86,9 @@ object Builder {
       fsFilePaths: Boolean = false
   ): Unit = {
     val totalStart = Instant.now()
+    // Fresh per-run dispatcher; enforces monotonic current and catches
+    // exceptions thrown by the caller-supplied ProgressListener.
+    val progressNotifier = ProgressListener.notifier(args.progressListener)
 
     val runningCnt = AtomicInteger(0)
     val dead_? = AtomicBoolean(false)
@@ -206,6 +209,7 @@ object Builder {
         writeThreadCnt = writeThreadCnt,
         tempDir = tempDir,
         args = args,
+        progressNotifier = progressNotifier,
         preWriteDB = preWriteDB
       )
 
@@ -216,11 +220,6 @@ object Builder {
       )
       updatedDest = destWithCount(dest, loopCnt)
     }
-
-    // Processing loop has exited; only the per-batch write threads remain.
-    // Mark the boundary so a ProgressListener can flip the dashboard from
-    // "Processing N of M" to "Writing bundle".
-    ProgressListener.safeNotify(args.progressListener, ProgressListener.Phase.Writing)
 
     logger.debug("Waiting for write threads")
 
@@ -254,6 +253,7 @@ object Builder {
       writeThreadCnt: AtomicInteger,
       tempDir: Option[File],
       args: Config,
+      progressNotifier: ProgressListener.Notifier,
       preWriteDB: Vector[Storage => Boolean] = Vector()
   ): Option[Thread] = {
 
@@ -398,12 +398,7 @@ object Builder {
                         f"Processed ${updatedCnt} of ${totalItems} at ${totalDuration}/${processDuration}${avgMsg}. ${toProcess.main} took ${theDuration} vertices ${String
                             .format("%,d", storage.size())}"
                       )
-                      ProgressListener.safeNotify(
-                        args.progressListener,
-                        ProgressListener.Phase.Processing,
-                        current = updatedCnt.toLong,
-                        total = totalItems.toLong
-                      )
+                      progressNotifier.notify(updatedCnt.toLong, totalItems.toLong)
                     }
                   }
                 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -17,6 +17,7 @@ package io.spicelabs.goatrodeo.omnibor
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
+import io.spicelabs.goatrodeo.ProgressListener
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
@@ -216,6 +217,11 @@ object Builder {
       updatedDest = destWithCount(dest, loopCnt)
     }
 
+    // Processing loop has exited; only the per-batch write threads remain.
+    // Mark the boundary so a ProgressListener can flip the dashboard from
+    // "Processing N of M" to "Writing bundle".
+    ProgressListener.safeNotify(args.progressListener, ProgressListener.Phase.Writing)
+
     logger.debug("Waiting for write threads")
 
     // loop while we wait for the end of processing
@@ -391,6 +397,12 @@ object Builder {
                       logger.info(
                         f"Processed ${updatedCnt} of ${totalItems} at ${totalDuration}/${processDuration}${avgMsg}. ${toProcess.main} took ${theDuration} vertices ${String
                             .format("%,d", storage.size())}"
+                      )
+                      ProgressListener.safeNotify(
+                        args.progressListener,
+                        ProgressListener.Phase.Processing,
+                        current = updatedCnt.toLong,
+                        total = totalItems.toLong
                       )
                     }
                   }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -3,6 +3,7 @@ package io.spicelabs.goatrodeo.util
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
+import io.spicelabs.goatrodeo.ProgressListener
 import io.spicelabs.goatrodeo.util.Config.ExpandFiles.fixTilde
 import org.apache.commons.io.filefilter.WildcardFileFilter
 import scopt.OParser
@@ -72,6 +73,10 @@ import scala.util.Using
   * @param tagDate
   *   optional date to include in top-level tag JSON (parsed flexibly, stored as
   *   Date)
+  * @param progressListener
+  *   optional callback notified at phase boundaries and during the main
+  *   processing loop. Set via [[io.spicelabs.goatrodeo.GoatRodeoBuilder.withProgressListener]];
+  *   not exposed on the command line.
   */
 case class Config(
     out: Option[File] = None,
@@ -99,7 +104,8 @@ case class Config(
     packageTags: Boolean = false,
     packageTagsShortName: Boolean = false,
     tagVersion: Option[String] = None,
-    tagDate: Option[Date] = None
+    tagDate: Option[Date] = None,
+    progressListener: Option[ProgressListener] = None
 ) {
 
   /** Build a list of file list builders from the configuration.

--- a/src/test/scala/ProgressListenerIntegrationTest.scala
+++ b/src/test/scala/ProgressListenerIntegrationTest.scala
@@ -1,0 +1,110 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo
+
+import io.spicelabs.goatrodeo.ProgressListener.Phase
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+
+/** End-to-end check that a real `Howdy.run` invocation emits progress events
+  * in the documented order (`Scanning → Processing(>=1) → Writing → Done`).
+  * The payload is synthetic — just over a thousand tiny text files, sized to
+  * clear the production-cadence throttle of 1,000 items between
+  * `Processing` emissions.
+  */
+class ProgressListenerIntegrationTest extends munit.FunSuite {
+
+  override val munitTimeout = scala.concurrent.duration.Duration(2, "minutes")
+
+  private class Recorder extends ProgressListener {
+    private val events = new ConcurrentLinkedQueue[(Phase, Long, Long)]()
+    override def onProgress(phase: Phase, current: Long, total: Long): Unit =
+      events.add((phase, current, total))
+    def recorded: List[(Phase, Long, Long)] = events.iterator().asScala.toList
+  }
+
+  private def writeTinyFiles(dir: File, count: Int): Unit = {
+    for (i <- 0 until count) {
+      val f = new File(dir, f"f$i%05d.txt")
+      Files.writeString(f.toPath, s"hello $i\n")
+    }
+  }
+
+  test("Howdy.run emits Scanning → Processing(>=1) → Writing → Done") {
+    val payloadDir = Files.createTempDirectory("gr-progress-payload").toFile
+    val outputDir = Files.createTempDirectory("gr-progress-output").toFile
+    try {
+      // Just over the 1,000-item Processing throttle so at least one
+      // Processing event is guaranteed to fire.
+      writeTinyFiles(payloadDir, 1050)
+
+      val recorder = new Recorder
+      GoatRodeo
+        .builder()
+        .withPayload(payloadDir.getAbsolutePath)
+        .withOutput(outputDir.getAbsolutePath)
+        .withThreads(2)
+        .withProgressListener(recorder)
+        .run()
+
+      val events = recorder.recorded
+      val phases = events.map(_._1)
+
+      // Boundary phases land in the documented order.
+      assertEquals(phases.head, Phase.Scanning, s"first event should be Scanning, got: $phases")
+      assertEquals(phases.last, Phase.Done, s"last event should be Done, got: $phases")
+      assert(
+        phases.contains(Phase.Writing),
+        s"Writing event missing from sequence: $phases"
+      )
+      assert(
+        phases.indexOf(Phase.Writing) < phases.lastIndexOf(Phase.Done),
+        s"Writing must precede Done, got: $phases"
+      )
+
+      // At least one Processing event with sane counts.
+      val processing = events.collect { case (Phase.Processing, c, t) => (c, t) }
+      assert(
+        processing.nonEmpty,
+        s"expected at least one Processing event for a 1050-file payload, got: $phases"
+      )
+      processing.foreach { case (c, t) =>
+        assert(c >= 1L, s"Processing.current must be >= 1, got $c")
+        assert(t >= c, s"Processing.total ($t) must be >= current ($c)")
+      }
+
+      // Every Processing event must precede the Writing transition.
+      val firstWriting = phases.indexOf(Phase.Writing)
+      val lastProcessing = phases.lastIndexOf(Phase.Processing)
+      assert(
+        lastProcessing < firstWriting,
+        s"Processing must not arrive after Writing, got: $phases"
+      )
+    } finally {
+      deleteRecursively(payloadDir)
+      deleteRecursively(outputDir)
+    }
+  }
+
+  private def deleteRecursively(f: File): Unit = {
+    if (f.isDirectory) {
+      Option(f.listFiles()).foreach(_.foreach(deleteRecursively))
+    }
+    val _ = f.delete()
+  }
+}

--- a/src/test/scala/ProgressListenerIntegrationTest.scala
+++ b/src/test/scala/ProgressListenerIntegrationTest.scala
@@ -14,28 +14,27 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo
 
-import io.spicelabs.goatrodeo.ProgressListener.Phase
-
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters._
 
-/** End-to-end check that a real `Howdy.run` invocation emits progress events
-  * in the documented order (`Scanning → Processing(>=1) → Writing → Done`).
-  * The payload is synthetic — just over a thousand tiny text files, sized to
-  * clear the production-cadence throttle of 1,000 items between
-  * `Processing` emissions.
+/** End-to-end check that a real `Howdy.run` delivers progress events to a
+  * caller-supplied listener: at least one event, strictly increasing
+  * `current`, and `current <= total` invariant maintained across deliveries.
+  * The payload is synthetic — just over a thousand tiny text files, sized
+  * to clear the production-cadence throttle of 1,000 items between
+  * emissions.
   */
 class ProgressListenerIntegrationTest extends munit.FunSuite {
 
   override val munitTimeout = scala.concurrent.duration.Duration(2, "minutes")
 
   private class Recorder extends ProgressListener {
-    private val events = new ConcurrentLinkedQueue[(Phase, Long, Long)]()
-    override def onProgress(phase: Phase, current: Long, total: Long): Unit =
-      events.add((phase, current, total))
-    def recorded: List[(Phase, Long, Long)] = events.iterator().asScala.toList
+    private val events = new ConcurrentLinkedQueue[(Long, Long)]()
+    override def onProgress(current: Long, total: Long): Unit =
+      events.add((current, total))
+    def recorded: List[(Long, Long)] = events.iterator().asScala.toList
   }
 
   private def writeTinyFiles(dir: File, count: Int): Unit = {
@@ -45,12 +44,11 @@ class ProgressListenerIntegrationTest extends munit.FunSuite {
     }
   }
 
-  test("Howdy.run emits Scanning → Processing(>=1) → Writing → Done") {
+  test("Howdy.run delivers monotonic progress to a ProgressListener") {
     val payloadDir = Files.createTempDirectory("gr-progress-payload").toFile
     val outputDir = Files.createTempDirectory("gr-progress-output").toFile
     try {
-      // Just over the 1,000-item Processing throttle so at least one
-      // Processing event is guaranteed to fire.
+      // Just over the 1,000-item throttle so at least one event is guaranteed.
       writeTinyFiles(payloadDir, 1050)
 
       val recorder = new Recorder
@@ -58,43 +56,23 @@ class ProgressListenerIntegrationTest extends munit.FunSuite {
         .builder()
         .withPayload(payloadDir.getAbsolutePath)
         .withOutput(outputDir.getAbsolutePath)
-        .withThreads(2)
+        .withThreads(4)
         .withProgressListener(recorder)
         .run()
 
       val events = recorder.recorded
-      val phases = events.map(_._1)
+      assert(events.nonEmpty, "expected at least one progress event for a 1050-file payload")
 
-      // Boundary phases land in the documented order.
-      assertEquals(phases.head, Phase.Scanning, s"first event should be Scanning, got: $phases")
-      assertEquals(phases.last, Phase.Done, s"last event should be Done, got: $phases")
-      assert(
-        phases.contains(Phase.Writing),
-        s"Writing event missing from sequence: $phases"
+      val currents = events.map(_._1)
+      assertEquals(
+        currents,
+        currents.sorted.distinct,
+        s"delivered current values must be strictly increasing; got: $currents"
       )
-      assert(
-        phases.indexOf(Phase.Writing) < phases.lastIndexOf(Phase.Done),
-        s"Writing must precede Done, got: $phases"
-      )
-
-      // At least one Processing event with sane counts.
-      val processing = events.collect { case (Phase.Processing, c, t) => (c, t) }
-      assert(
-        processing.nonEmpty,
-        s"expected at least one Processing event for a 1050-file payload, got: $phases"
-      )
-      processing.foreach { case (c, t) =>
-        assert(c >= 1L, s"Processing.current must be >= 1, got $c")
-        assert(t >= c, s"Processing.total ($t) must be >= current ($c)")
+      events.foreach { case (c, t) =>
+        assert(c >= 1L, s"current must be >= 1, got $c")
+        assert(t >= c, s"total ($t) must be >= current ($c)")
       }
-
-      // Every Processing event must precede the Writing transition.
-      val firstWriting = phases.indexOf(Phase.Writing)
-      val lastProcessing = phases.lastIndexOf(Phase.Processing)
-      assert(
-        lastProcessing < firstWriting,
-        s"Processing must not arrive after Writing, got: $phases"
-      )
     } finally {
       deleteRecursively(payloadDir)
       deleteRecursively(outputDir)

--- a/src/test/scala/ProgressListenerTest.scala
+++ b/src/test/scala/ProgressListenerTest.scala
@@ -1,0 +1,74 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo
+
+import io.spicelabs.goatrodeo.ProgressListener.Phase
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+
+class ProgressListenerTest extends munit.FunSuite {
+
+  /** A listener that records every event it receives. */
+  private class Recorder extends ProgressListener {
+    private val events = new ConcurrentLinkedQueue[(Phase, Long, Long)]()
+    override def onProgress(phase: Phase, current: Long, total: Long): Unit =
+      events.add((phase, current, total))
+    def recorded: List[(Phase, Long, Long)] = events.iterator().asScala.toList
+  }
+
+  test("safeNotify forwards (phase, current, total) verbatim to the listener") {
+    val rec = Recorder()
+    ProgressListener.safeNotify(Some(rec), Phase.Processing, 47L, 1200L)
+    assertEquals(rec.recorded, List((Phase.Processing, 47L, 1200L)))
+  }
+
+  test("safeNotify defaults current/total to 0 for phase-boundary calls") {
+    val rec = Recorder()
+    ProgressListener.safeNotify(Some(rec), Phase.Scanning)
+    ProgressListener.safeNotify(Some(rec), Phase.Writing)
+    ProgressListener.safeNotify(Some(rec), Phase.Done)
+    assertEquals(
+      rec.recorded,
+      List(
+        (Phase.Scanning, 0L, 0L),
+        (Phase.Writing, 0L, 0L),
+        (Phase.Done, 0L, 0L)
+      )
+    )
+  }
+
+  test("safeNotify with None is a silent no-op") {
+    // Just shouldn't throw — no listener attached.
+    ProgressListener.safeNotify(None, Phase.Processing, 1L, 10L)
+  }
+
+  test("safeNotify swallows exceptions thrown by the listener") {
+    val throwing = new ProgressListener {
+      override def onProgress(phase: Phase, current: Long, total: Long): Unit =
+        throw new RuntimeException("listener exploded")
+    }
+    // Must not propagate the RuntimeException — a misbehaving listener should
+    // never abort a multi-hour goat-rodeo run.
+    ProgressListener.safeNotify(Some(throwing), Phase.Processing, 5L, 10L)
+  }
+
+  test("Phase enum exposes all four cases in declared order") {
+    assertEquals(
+      Phase.values.toList,
+      List(Phase.Scanning, Phase.Processing, Phase.Writing, Phase.Done)
+    )
+  }
+}

--- a/src/test/scala/ProgressListenerTest.scala
+++ b/src/test/scala/ProgressListenerTest.scala
@@ -14,61 +14,105 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo
 
-import io.spicelabs.goatrodeo.ProgressListener.Phase
-
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import scala.jdk.CollectionConverters._
 
 class ProgressListenerTest extends munit.FunSuite {
 
-  /** A listener that records every event it receives. */
+  /** A listener that records every event it receives. Thread-safe; events
+    * land in arrival order because the underlying queue is FIFO.
+    */
   private class Recorder extends ProgressListener {
-    private val events = new ConcurrentLinkedQueue[(Phase, Long, Long)]()
-    override def onProgress(phase: Phase, current: Long, total: Long): Unit =
-      events.add((phase, current, total))
-    def recorded: List[(Phase, Long, Long)] = events.iterator().asScala.toList
+    private val events = new ConcurrentLinkedQueue[(Long, Long)]()
+    override def onProgress(current: Long, total: Long): Unit =
+      events.add((current, total))
+    def recorded: List[(Long, Long)] = events.iterator().asScala.toList
   }
 
-  test("safeNotify forwards (phase, current, total) verbatim to the listener") {
-    val rec = Recorder()
-    ProgressListener.safeNotify(Some(rec), Phase.Processing, 47L, 1200L)
-    assertEquals(rec.recorded, List((Phase.Processing, 47L, 1200L)))
+  test("notifier forwards (current, total) to the listener") {
+    val rec = new Recorder
+    val n = ProgressListener.notifier(Some(rec))
+    n.notify(47L, 1200L)
+    assertEquals(rec.recorded, List((47L, 1200L)))
   }
 
-  test("safeNotify defaults current/total to 0 for phase-boundary calls") {
-    val rec = Recorder()
-    ProgressListener.safeNotify(Some(rec), Phase.Scanning)
-    ProgressListener.safeNotify(Some(rec), Phase.Writing)
-    ProgressListener.safeNotify(Some(rec), Phase.Done)
-    assertEquals(
-      rec.recorded,
-      List(
-        (Phase.Scanning, 0L, 0L),
-        (Phase.Writing, 0L, 0L),
-        (Phase.Done, 0L, 0L)
-      )
-    )
+  test("notifier with no listener is a silent no-op") {
+    val n = ProgressListener.notifier(None)
+    n.notify(1L, 10L)
   }
 
-  test("safeNotify with None is a silent no-op") {
-    // Just shouldn't throw — no listener attached.
-    ProgressListener.safeNotify(None, Phase.Processing, 1L, 10L)
-  }
-
-  test("safeNotify swallows exceptions thrown by the listener") {
+  test("notifier swallows exceptions thrown by the listener") {
     val throwing = new ProgressListener {
-      override def onProgress(phase: Phase, current: Long, total: Long): Unit =
+      override def onProgress(current: Long, total: Long): Unit =
         throw new RuntimeException("listener exploded")
     }
-    // Must not propagate the RuntimeException — a misbehaving listener should
-    // never abort a multi-hour goat-rodeo run.
-    ProgressListener.safeNotify(Some(throwing), Phase.Processing, 5L, 10L)
+    val n = ProgressListener.notifier(Some(throwing))
+    // Must not propagate — a misbehaving listener should never abort a build.
+    n.notify(5L, 10L)
   }
 
-  test("Phase enum exposes all four cases in declared order") {
+  test("notifier drops non-monotonic (backwards or equal) current") {
+    val rec = new Recorder
+    val n = ProgressListener.notifier(Some(rec))
+    n.notify(100L, 1000L)
+    n.notify(50L, 1000L) // backwards — dropped
+    n.notify(100L, 1000L) // equal — dropped
+    n.notify(101L, 1000L) // forward — delivered
+    assertEquals(rec.recorded, List((100L, 1000L), (101L, 1000L)))
+  }
+
+  test("notifiers are independent (per-run state, no JVM-global)") {
+    // Two notifiers track their own monotonic counters, so a second run
+    // starts fresh even when the first ran in the same JVM.
+    val recA = new Recorder
+    val recB = new Recorder
+    val nA = ProgressListener.notifier(Some(recA))
+    val nB = ProgressListener.notifier(Some(recB))
+    nA.notify(500L, 1000L)
+    nB.notify(10L, 1000L) // would be dropped if state were shared with nA
+    assertEquals(recA.recorded, List((500L, 1000L)))
+    assertEquals(recB.recorded, List((10L, 1000L)))
+  }
+
+  test("notifier under concurrent fire delivers strictly-monotonic current") {
+    // Each worker thread fires a unique sequence of current values; with N
+    // threads racing, the listener must see a strictly increasing sequence
+    // (some ticks are dropped by design when a later thread CAS-wins).
+    val rec = new Recorder
+    val n = ProgressListener.notifier(Some(rec))
+    val threadCount = 16
+    val itemsPerThread = 200
+    val start = new CountDownLatch(1)
+    val pool = Executors.newFixedThreadPool(threadCount)
+    try {
+      val futures = (0 until threadCount).map { t =>
+        pool.submit(new Runnable {
+          def run(): Unit = {
+            start.await()
+            for (i <- 0 until itemsPerThread) {
+              // Interleave values across threads so races are likely.
+              val current = (i.toLong * threadCount) + t
+              n.notify(current, 100_000L)
+            }
+          }
+        })
+      }
+      start.countDown()
+      futures.foreach(_.get())
+    } finally {
+      pool.shutdown()
+      val _ = pool.awaitTermination(10, TimeUnit.SECONDS)
+    }
+
+    val delivered = rec.recorded.map(_._1)
+    assert(delivered.nonEmpty, "expected some deliveries under concurrent fire")
     assertEquals(
-      Phase.values.toList,
-      List(Phase.Scanning, Phase.Processing, Phase.Writing, Phase.Done)
+      delivered,
+      delivered.sorted.distinct,
+      s"deliveries must be strictly increasing; got: $delivered"
     )
   }
 }


### PR DESCRIPTION
simplify ProgressListener: drop Phase enum, serialize monotonic delivery

  - trait reduced to a single SAM: onProgress(current, total)
  - per-run Notifier instance wraps the listener; instantiated in Builder.buildDB
  - Notifier.notify is synchronized: monotonic-current check + delivery atomic
  - worker threads call notifier.notify in place of Phase-tagged safeNotify
  - Howdy.run no longer fires Scanning/Done; Builder no longer fires Writing
  - tests rewritten; concurrent-fire test covers monotonic delivery under races
