### PR TITLE
Add typesafety to Gitoid and PackageUrl

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -268,7 +268,7 @@ object Builder {
           "tags",
           item =>
             Some(
-              Item(Gitoid("tags"), TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
+              Item(Item.tagsRootIdentifier, TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
             ),
           item => "set up tags"
         )
@@ -277,7 +277,7 @@ object Builder {
           item =>
             Some(
               Item(
-                tag.gitoid,
+                tag.gitoid(),
                 TreeSet(EdgeType.tagFrom -> "tags"),
                 Some(ItemTagData.mimeType),
                 Some(ItemTagData(tag.json))

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -19,6 +19,7 @@ import io.bullet.borer.Dom
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.ProgressListener
 import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
 
@@ -148,14 +149,14 @@ object Builder {
     }
 
     // Get the gitoids to block
-    val blockGitoids: Set[String] = blockList match {
+    val blockGitoids: Set[Gitoid] = blockList match {
       case None => Set()
       case Some(file) =>
         Try {
           import scala.jdk.CollectionConverters.CollectionHasAsScala
 
           val lines = Files.readAllLines(file.toPath()).asScala.toSet
-          lines
+          lines.map(Gitoid(_))
         }.toOption match {
           case None    => Set()
           case Some(s) => s
@@ -243,7 +244,7 @@ object Builder {
       maxRecords: Int,
       queue: ConcurrentLinkedQueue[ToProcess],
       stillWorking: AtomicBoolean,
-      blockGitoids: Set[String],
+      blockGitoids: Set[Gitoid],
       cnt: AtomicInteger,
       tag: Option[TagPass],
       runningCnt: AtomicInteger,
@@ -267,12 +268,12 @@ object Builder {
           "tags",
           item =>
             Some(
-              Item("tags", TreeSet(EdgeType.tagTo -> tag.gitoid), None, None)
+              Item(Gitoid("tags"), TreeSet(EdgeType.tagTo -> tag.gitoid()), None, None)
             ),
           item => "set up tags"
         )
         storage.write(
-          tag.gitoid,
+          tag.gitoid(),
           item =>
             Some(
               Item(
@@ -563,4 +564,4 @@ object Builder {
   }
 }
 
-case class TagPass(gitoid: String, jsonStr: String, json: Dom.Element)
+case class TagPass(gitoid: Gitoid, jsonStr: String, json: Dom.Element)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -9,7 +9,7 @@ import io.bullet.borer.Reader
 import io.bullet.borer.Writer
 import io.bullet.borer.derivation.key
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.Helpers
 
@@ -34,7 +34,7 @@ import scala.util.Try
   *   optional metadata about this Item (either ItemMetaData or ItemTagData)
   */
 case class Item(
-    identifier: String,
+    identifier: Gitoid,
     // reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
@@ -70,7 +70,7 @@ case class Item(
   def withConnection(edgeType: String, id: String): Item =
     this.copy(connections = this.connections + (edgeType -> id))
 
-  private lazy val md5 = Helpers.computeMD5(identifier)
+  private lazy val md5 = Helpers.computeMD5(identifier())
 
   /** Lazily cached CBOR-encoded representation of this Item. */
   lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
@@ -90,8 +90,8 @@ case class Item(
     *   true if this Item's hash is lexicographically less than the other's
     */
   def cmpMd5(that: Item): Boolean = {
-    val myHash = Helpers.md5hashHex(identifier)
-    val thatHash = Helpers.md5hashHex(that.identifier)
+    val myHash = Helpers.md5hashHex(identifier())
+    val thatHash = Helpers.md5hashHex(that.identifier())
     myHash < thatHash
   }
 
@@ -102,7 +102,7 @@ case class Item(
   def isRoot(): Boolean = {
     if (this.bodyMimeType != Some(ItemMetaData.mimeType)) {
       false
-    } else if (this.identifier == "tags") {
+    } else if (this.identifier() == "tags") {
       false
     } else if (
       this.connections
@@ -169,7 +169,7 @@ case class Item(
   def createOrUpdateInStore(store: Storage, context: Item => String): Item = {
     store
       .write(
-        identifier,
+        identifier(),
         {
           case None        => Some(this)
           case Some(other) => Some(this.merge(other))
@@ -189,15 +189,15 @@ case class Item(
             case Some(item) =>
               Some(
                 item.copy(connections =
-                  item.connections + (aliasType -> this.identifier)
+                  item.connections + (aliasType -> this.identifier())
                 )
               )
             case None =>
               Some(
                 Item(
-                  itemNeedingAlias,
+                  Gitoid(itemNeedingAlias),
                   // noopLocationReference,
-                  TreeSet(aliasType -> this.identifier),
+                  TreeSet(aliasType -> this.identifier()),
                   None,
                   None
                 )
@@ -311,7 +311,7 @@ case class Item(
     *   the enhanced `Item`
     */
   def enhanceWithMetadata(
-      maybeParent: Option[GitOID] = None,
+      maybeParent: Option[Gitoid] = None,
       extra: TreeMap[String, TreeSet[StringOrPair]] = TreeMap(),
       filenames: Seq[String] = Vector(),
       mimeTypes: Seq[String] = Vector()
@@ -359,7 +359,7 @@ case class Item(
   }
 
   def getMd5(): Array[Byte] = this.md5
-  def getIdentifier(): String = identifier
+  def getIdentifier(): String = identifier()
   def isRootWorkItem(): Boolean = isRoot()
 }
 
@@ -380,14 +380,14 @@ object Item {
     * @return
     *   the created item
     */
-  def itemFrom(artifact: ArtifactWrapper, container: Option[GitOID]): Item = {
+  def itemFrom(artifact: ArtifactWrapper, container: Option[Gitoid]): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
       id,
       // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
-      ) ++ container.toSeq.map(c => EdgeType.containedBy -> c),
+      ) ++ container.toSeq.map(c => EdgeType.containedBy -> c()),
       Some(ItemMetaData.mimeType),
       Some(
         ItemMetaData(
@@ -418,7 +418,7 @@ object Item {
       items: Seq[Item],
       nameFilter: String => Boolean = s => true,
       mimeFilter: Set[String] => Boolean = s => true
-  ): Map[String, GitOID] = {
+  ): Map[String, Gitoid] = {
     val mapping = for {
       item <- items
       metadata <- item.body match {
@@ -505,7 +505,7 @@ object Item {
         assert(r.readString() == "connections")
         val connections: TreeSet[Edge] = r.read[TreeSet[Edge]]()
         assert(r.readString() == "identifier")
-        val identifier = r.readString()
+        val identifier = Gitoid(r.readString())
 
         val ret = Item(
           identifier,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -34,7 +34,7 @@ import scala.util.Try
   *   optional metadata about this Item (either ItemMetaData or ItemTagData)
   */
 case class Item(
-    identifier: Gitoid,
+    identifier: String,
     // reference: LocationReference,
     connections: TreeSet[Edge],
     @key("body_mime_type") bodyMimeType: Option[String],
@@ -70,7 +70,7 @@ case class Item(
   def withConnection(edgeType: String, id: String): Item =
     this.copy(connections = this.connections + (edgeType -> id))
 
-  private lazy val md5 = Helpers.computeMD5(identifier())
+  private lazy val md5 = Helpers.computeMD5(identifier)
 
   /** Lazily cached CBOR-encoded representation of this Item. */
   lazy val cachedCBOR: Array[Byte] = Cbor.encode(this).toByteArray
@@ -90,8 +90,8 @@ case class Item(
     *   true if this Item's hash is lexicographically less than the other's
     */
   def cmpMd5(that: Item): Boolean = {
-    val myHash = Helpers.md5hashHex(identifier())
-    val thatHash = Helpers.md5hashHex(that.identifier())
+    val myHash = Helpers.md5hashHex(identifier)
+    val thatHash = Helpers.md5hashHex(that.identifier)
     myHash < thatHash
   }
 
@@ -102,7 +102,7 @@ case class Item(
   def isRoot(): Boolean = {
     if (this.bodyMimeType != Some(ItemMetaData.mimeType)) {
       false
-    } else if (this.identifier() == "tags") {
+    } else if (this.identifier == Item.tagsRootIdentifier) {
       false
     } else if (
       this.connections
@@ -169,7 +169,7 @@ case class Item(
   def createOrUpdateInStore(store: Storage, context: Item => String): Item = {
     store
       .write(
-        identifier(),
+        identifier,
         {
           case None        => Some(this)
           case Some(other) => Some(this.merge(other))
@@ -189,15 +189,15 @@ case class Item(
             case Some(item) =>
               Some(
                 item.copy(connections =
-                  item.connections + (aliasType -> this.identifier())
+                  item.connections + (aliasType -> this.identifier)
                 )
               )
             case None =>
               Some(
                 Item(
-                  Gitoid(itemNeedingAlias),
+                  itemNeedingAlias,
                   // noopLocationReference,
-                  TreeSet(aliasType -> this.identifier()),
+                  TreeSet(aliasType -> this.identifier),
                   None,
                   None
                 )
@@ -343,7 +343,7 @@ case class Item(
             case Some(parent)
                 if baseFileNames.size > 1 || (baseFileNames.size == 1 && !baseFileNames
                   .contains(name)) =>
-              Vector(name, f"${parent}/${name}")
+              Vector(name, f"${parent()}/${name}")
             case _ => Vector(name)
           }
         )
@@ -359,7 +359,7 @@ case class Item(
   }
 
   def getMd5(): Array[Byte] = this.md5
-  def getIdentifier(): String = identifier()
+  def getIdentifier(): String = identifier
   def isRootWorkItem(): Boolean = isRoot()
 }
 
@@ -367,6 +367,10 @@ case class Item(
   * utilities.
   */
 object Item {
+
+  /** The sentinel identifier used for the "tags" root Item — the Item under
+    * which per-package tag references are anchored. Not a real gitoid URL. */
+  val tagsRootIdentifier: String = "tags"
   protected val logger: Logger = Logger(getClass())
 
   /** Given an ArtifactWrapper, create an `Item` based on the hashes/gitoids for
@@ -383,7 +387,7 @@ object Item {
   def itemFrom(artifact: ArtifactWrapper, container: Option[Gitoid]): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
     Item(
-      id,
+      id(),
       // Item.noopLocationReference,
       TreeSet(
         hashes.map(hash => EdgeType.aliasFrom -> hash)*
@@ -427,7 +431,7 @@ object Item {
         case _ => None.toSeq
       }
       filename <- metadata.fileNames.toSeq if nameFilter(filename)
-    } yield filename -> item.identifier
+    } yield filename -> Gitoid(item.identifier)
 
     Map(mapping*)
   }
@@ -505,7 +509,7 @@ object Item {
         assert(r.readString() == "connections")
         val connections: TreeSet[Edge] = r.read[TreeSet[Edge]]()
         assert(r.readString() == "identifier")
-        val identifier = Gitoid(r.readString())
+        val identifier = r.readString()
 
         val ret = Item(
           identifier,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -17,7 +17,7 @@ package io.spicelabs.goatrodeo.omnibor
 import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.BufferedOutputStream
@@ -94,8 +94,10 @@ trait Storage {
     *
     * @return
     */
-  def gitoidKeys(): Set[GitOID] =
-    keys().filter(_.startsWith("gitoid:blob:sha256:"))
+  def gitoidKeys(): Set[Gitoid] =
+    keys().collect {
+      case k if k.startsWith("gitoid:blob:sha256:") => Gitoid(k)
+    }
 
   def destDirectory(): Option[File]
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -19,6 +19,7 @@ import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.PackageUrl
 
 import java.io.BufferedOutputStream
 import java.io.File
@@ -110,9 +111,9 @@ trait Storage {
   /** Get the purls
     *
     * @return
-    *   the purls
+    *   the purls (each a validated canonical pURL string)
     */
-  def purls(): TreeSet[String]
+  def purls(): TreeSet[PackageUrl]
 
   def emitRootsToDir(dir: File): Unit = {
     dir.mkdirs()
@@ -221,9 +222,8 @@ class MemStorage(val targetDir: Option[File])
   // synchronize access to the database
   private val dbSync = new Object()
   private var db: AtomicReference[Map[String, Item]] = AtomicReference(Map())
-  private var thePurls: AtomicReference[TreeSet[String]] = AtomicReference(
-    TreeSet()
-  )
+  private var thePurls: AtomicReference[TreeSet[PackageUrl]] =
+    AtomicReference(TreeSet())
   private val locks: java.util.HashMap[String, AtomicInteger] =
     java.util.HashMap()
   def keys(): Set[String] = {
@@ -246,12 +246,12 @@ class MemStorage(val targetDir: Option[File])
     */
   def addPurl(purl: PackageURL): Unit = {
     thePurls.synchronized {
-      val next = thePurls.get() + purl.canonicalize()
+      val next = thePurls.get() + PackageUrl(purl)
       thePurls.set(next)
     }
   }
 
-  def purls(): TreeSet[String] = thePurls.get()
+  def purls(): TreeSet[PackageUrl] = thePurls.get()
 
   override def size(): Int = db.get().size
 
@@ -326,7 +326,7 @@ class MemStorage(val targetDir: Option[File])
     db.set(Map()); locks.clear()
   }
 
-  def getPurls(): Set[String] = {
+  def getPurls(): Set[PackageUrl] = {
     thePurls.synchronized {
       thePurls.get()
     }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -152,7 +152,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       parent: Option[ParentScope],
       augmentationByHash: Map[String, Vector[Augmentation]]
   ): ParentScope =
-    ParentScope.forAndWith(item.identifier(), parent, augmentationByHash)
+    ParentScope.forAndWith(item.identifier, parent, augmentationByHash)
 }
 
 abstract class ParentScope(
@@ -317,6 +317,12 @@ trait ToProcess {
   ): Seq[Gitoid] = {
     if (keepRunning()) {
 
+      // `blockList` is `Set[Gitoid]` (validated gitoid URLs from the user). Item
+      // identifiers, however, are plain Strings — sometimes gitoid URLs,
+      // sometimes alias hashes ("md5:..." etc.) for back-reference stubs. We
+      // compare in String space.
+      val blockListAsStrings: Set[String] = blockList.map(_())
+
       val (elements, initialState) = getElementsToProcess()
       val (finalState, ret) =
         elements.foldLeft(initialState -> Vector[Gitoid]()) {
@@ -324,7 +330,7 @@ trait ToProcess {
             val itemRaw = Item.itemFrom(artifact, parentId)
 
             // in blocklist do nothing
-            if (blockList.contains(itemRaw.identifier)) {
+            if (blockListAsStrings.contains(itemRaw.identifier)) {
               orgState -> alreadyDone
             } else {
               val aliases = itemRaw.connections.toVector
@@ -422,7 +428,7 @@ trait ToProcess {
                       item =>
                         Some(
                           Item(
-                            tagGitoid,
+                            tagGitoid(),
                             TreeSet(EdgeType.tagFrom -> "tags"),
                             Some(ItemTagData.mimeType),
                             Some(ItemTagData(tagJson))
@@ -445,7 +451,7 @@ trait ToProcess {
                           case None =>
                             Some(
                               Item(
-                                Gitoid("tags"),
+                                Item.tagsRootIdentifier,
                                 TreeSet(EdgeType.tagTo -> tagGitoid()),
                                 None,
                                 None
@@ -477,7 +483,7 @@ trait ToProcess {
                 parentScope.finalAugmentation(store, artifact, item4)
 
               // if we've seen the gitoid before we write it
-              val hasBeenSeen = store.contains(itemScope4.identifier())
+              val hasBeenSeen = store.contains(itemScope4.identifier)
 
               // update back-references for this item
               // this is *only* for the the pre-merged `Item`
@@ -494,15 +500,15 @@ trait ToProcess {
                       case Some(item) =>
                         Some(
                           item.copy(connections =
-                            item.connections + (aliasType -> itemScope4.identifier())
+                            item.connections + (aliasType -> itemScope4.identifier)
                           )
                         )
                       case None =>
                         Some(
                           Item(
-                            Gitoid(itemNeedingAlias),
+                            itemNeedingAlias,
                             // noopLocationReference,
-                            TreeSet(aliasType -> itemScope4.identifier()),
+                            TreeSet(aliasType -> itemScope4.identifier),
                             None,
                             None
                           )
@@ -523,7 +529,7 @@ trait ToProcess {
               // write
               val answerItem = store
                 .write(
-                  itemScope4.identifier(),
+                  itemScope4.identifier,
                   {
                     case None            => Some(itemScope4)
                     case Some(otherItem) => Some(otherItem.merge(itemScope4))
@@ -569,7 +575,7 @@ trait ToProcess {
                       )
                       processSet.flatMap(tp =>
                         tp.process(
-                          Some(answerItem.identifier),
+                          Some(Gitoid(answerItem.identifier)),
                           store,
                           thisParentScope,
                           None,
@@ -585,7 +591,7 @@ trait ToProcess {
               val state5 =
                 state4.postChildProcessing(childGitoids, store, marker)
 
-              state5 -> (alreadyDone :+ answerItem.identifier)
+              state5 -> (alreadyDone :+ Gitoid(answerItem.identifier))
             }
         }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -7,7 +7,7 @@ import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWalker
 import io.spicelabs.goatrodeo.util.FileWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import io.spicelabs.goatrodeo.util.StaticMetadata
@@ -127,7 +127,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
     *   an updated state
     */
   def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: PM
   ): ME
@@ -152,7 +152,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       parent: Option[ParentScope],
       augmentationByHash: Map[String, Vector[Augmentation]]
   ): ParentScope =
-    ParentScope.forAndWith(item.identifier, parent, augmentationByHash)
+    ParentScope.forAndWith(item.identifier(), parent, augmentationByHash)
 }
 
 abstract class ParentScope(
@@ -306,20 +306,20 @@ trait ToProcess {
     * @return
     */
   def process(
-      parentId: Option[GitOID],
+      parentId: Option[Gitoid],
       store: Storage,
       parentScope: ParentScope,
       tag: Option[TagPass],
       args: Config,
-      blockList: Set[GitOID] = Set(),
+      blockList: Set[Gitoid] = Set(),
       keepRunning: () => Boolean = () => true,
-      atEnd: (Option[GitOID], Item) => Unit = (_, _) => ()
-  ): Seq[GitOID] = {
+      atEnd: (Option[Gitoid], Item) => Unit = (_, _) => ()
+  ): Seq[Gitoid] = {
     if (keepRunning()) {
 
       val (elements, initialState) = getElementsToProcess()
       val (finalState, ret) =
-        elements.foldLeft(initialState -> Vector[GitOID]()) {
+        elements.foldLeft(initialState -> Vector[Gitoid]()) {
           case ((orgState, alreadyDone), (artifact, marker)) =>
             val itemRaw = Item.itemFrom(artifact, parentId)
 
@@ -372,7 +372,7 @@ trait ToProcess {
                 case None => itemScopePre3
                 case Some(tag) =>
                   itemScopePre3.copy(connections =
-                    itemScopePre3.connections + (EdgeType.tagFrom -> tag.gitoid)
+                    itemScopePre3.connections + (EdgeType.tagFrom -> tag.gitoid())
                   )
               }
 
@@ -418,7 +418,7 @@ trait ToProcess {
 
                     // Write tag item — unified with "tags" root
                     store.write(
-                      tagGitoid,
+                      tagGitoid(),
                       item =>
                         Some(
                           Item(
@@ -439,14 +439,14 @@ trait ToProcess {
                           case Some(item) =>
                             Some(
                               item.copy(connections =
-                                item.connections + (EdgeType.tagTo -> tagGitoid)
+                                item.connections + (EdgeType.tagTo -> tagGitoid())
                               )
                             )
                           case None =>
                             Some(
                               Item(
-                                "tags",
-                                TreeSet(EdgeType.tagTo -> tagGitoid),
+                                Gitoid("tags"),
+                                TreeSet(EdgeType.tagTo -> tagGitoid()),
                                 None,
                                 None
                               )
@@ -457,7 +457,7 @@ trait ToProcess {
 
                     // Add tagFrom to main artifact
                     itemScope3.copy(connections =
-                      itemScope3.connections + (EdgeType.tagFrom -> tagGitoid)
+                      itemScope3.connections + (EdgeType.tagFrom -> tagGitoid())
                     )
                   case None => itemScope3
                 }
@@ -477,7 +477,7 @@ trait ToProcess {
                 parentScope.finalAugmentation(store, artifact, item4)
 
               // if we've seen the gitoid before we write it
-              val hasBeenSeen = store.contains(itemScope4.identifier)
+              val hasBeenSeen = store.contains(itemScope4.identifier())
 
               // update back-references for this item
               // this is *only* for the the pre-merged `Item`
@@ -494,15 +494,15 @@ trait ToProcess {
                       case Some(item) =>
                         Some(
                           item.copy(connections =
-                            item.connections + (aliasType -> itemScope4.identifier)
+                            item.connections + (aliasType -> itemScope4.identifier())
                           )
                         )
                       case None =>
                         Some(
                           Item(
-                            itemNeedingAlias,
+                            Gitoid(itemNeedingAlias),
                             // noopLocationReference,
-                            TreeSet(aliasType -> itemScope4.identifier),
+                            TreeSet(aliasType -> itemScope4.identifier()),
                             None,
                             None
                           )
@@ -523,7 +523,7 @@ trait ToProcess {
               // write
               val answerItem = store
                 .write(
-                  itemScope4.identifier,
+                  itemScope4.identifier(),
                   {
                     case None            => Some(itemScope4)
                     case Some(otherItem) => Some(otherItem.merge(itemScope4))
@@ -544,7 +544,7 @@ trait ToProcess {
 
               atEnd(parentId, answerItem)
 
-              val childGitoids: Option[Vector[GitOID]] =
+              val childGitoids: Option[Vector[Gitoid]] =
                 // if the gitoid has already been seen, do not recurse into the potential child
                 if (hasBeenSeen) None
                 else {
@@ -854,7 +854,7 @@ object ToProcess {
       store: Storage = MemStorage(None),
       args: Config,
       purlOut: PackageURL => Unit = _ => (),
-      block: Set[GitOID] = Set()
+      block: Set[Gitoid] = Set()
   ): Storage = {
 
     for { individual <- toProcess } {
@@ -895,7 +895,7 @@ object ToProcess {
       args: Config,
       store: Storage = MemStorage(None),
       purlOut: PackageURL => Unit = _ => (),
-      block: Set[GitOID] = Set()
+      block: Set[Gitoid] = Set()
   ): Storage = {
 
     // generate the strategy

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -17,7 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 
 import scala.collection.immutable.TreeMap
@@ -130,7 +130,7 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
     item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): AnnattoState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -16,7 +16,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
@@ -233,7 +233,7 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
   ): (Item, BaharatState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): BaharatState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
@@ -25,7 +25,7 @@ import io.spicelabs.goatrodeo.omnibor.Storage
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.omnibor.strategies.Certificates.KVPair
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers.sha256Hex
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 
@@ -787,7 +787,7 @@ class CertificatesState(
 
   /** Certificates never recurses into child Items. */
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): CertificatesState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -163,7 +163,7 @@ case class DockerState(
 
       // Associate the item's hash with the item's gitoid/identifier
       updatedItem -> this.copy(layerToGitoidMapping =
-        this.layerToGitoidMapping + (hash -> updatedItem.identifier)
+        this.layerToGitoidMapping + (hash -> Gitoid(updatedItem.identifier))
       )
 
     case DockerMarkers.Config(info) =>
@@ -191,7 +191,7 @@ case class DockerState(
             )
           case None => None
         },
-        _.identifier()
+        _.identifier
       )
       val updatedItem = item.enhanceWithMetadata(mimeTypes =
         Vector(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -15,7 +15,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
 
@@ -56,7 +56,7 @@ enum DockerMarkers extends ProcessingMarker {
   *   map of layer SHA256 hashes to their GitOIDs
   */
 case class DockerState(
-    layerToGitoidMapping: Map[String, String],
+    layerToGitoidMapping: Map[String, Gitoid],
     configInfo: Option[ManifestInfo] = None
 ) extends ProcessingState[DockerMarkers, DockerState] {
 
@@ -191,7 +191,7 @@ case class DockerState(
             )
           case None => None
         },
-        _.identifier
+        _.identifier()
       )
       val updatedItem = item.enhanceWithMetadata(mimeTypes =
         Vector(
@@ -209,7 +209,7 @@ case class DockerState(
             case None => item
             case Some(gitoid) =>
               item.copy(connections =
-                item.connections + (EdgeType.contains -> gitoid)
+                item.connections + (EdgeType.contains -> gitoid())
               )
           }
       }
@@ -220,7 +220,7 @@ case class DockerState(
   }
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: DockerMarkers
   ): DockerState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -19,7 +19,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.DotnetDetector
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.Helpers.toHex
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
@@ -278,7 +278,7 @@ class DotnetState(
   ): (Item, DotnetState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): DotnetState = {

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
@@ -11,7 +11,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -66,7 +66,7 @@ class GenericFileState extends ProcessingState[SingleMarker, GenericFileState] {
   ): (Item, GenericFileState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: SingleMarker
   ): GenericFileState = this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -16,7 +16,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.FileWalker
-import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.PURLHelpers.Ecosystems
@@ -66,7 +66,7 @@ case class MavenState(
     pomFile: String = "",
     pomXml: NodeSeq = NodeSeq.Empty,
     sources: Map[String, Item] = Map(),
-    sourceGitoids: Map[String, GitOID] = Map(),
+    sourceGitoids: Map[String, Gitoid] = Map(),
     groupId: Option[String] = None,
     artifactId: Option[String] = None,
     version: Option[String] = None,
@@ -301,14 +301,14 @@ case class MavenState(
   ): (Item, MavenState) = item -> this
 
   override def postChildProcessing(
-      kids: Option[Vector[GitOID]],
+      kids: Option[Vector[Gitoid]],
       store: Storage,
       marker: MavenMarkers
   ): MavenState = (marker, kids) match {
     case (MavenMarkers.Sources, Some(kids)) =>
       val items = for {
         gitoid <- kids
-        item <- store.read(gitoid).toVector
+        item <- store.read(gitoid()).toVector
         metadata <- item.bodyAsItemMetaData.toVector
         filename <- metadata.fileNames.toVector
       } yield filename -> item
@@ -352,11 +352,11 @@ case class MavenState(
       // the code that associates source with class files
       new ParentScope(augmentationByHash) {
 
-        def scopeFor(): String = item.identifier
+        def scopeFor(): String = item.identifier()
         def parentOfParentScope(): Option[ParentScope] = parentScope
 
         def parentScopeInformation(): String =
-          f"Maven/JAR Scope for ${item.identifier}${parentScope match {
+          f"Maven/JAR Scope for ${item.identifier()}${parentScope match {
               case None     => ""
               case Some(ps) => f" Parent: ${ps.parentScopeInformation()}"
             }}"
@@ -371,11 +371,11 @@ case class MavenState(
             associatedFiles = sourceGitoids
           )
           sources.foldLeft(item) { case (item, source) =>
-            item.withConnection(EdgeType.builtFrom, source)
+            item.withConnection(EdgeType.builtFrom, source())
           }
         }
       }
-    case _ => ParentScope.forAndWith(item.identifier, parentScope, Map())
+    case _ => ParentScope.forAndWith(item.identifier(), parentScope, Map())
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -314,7 +314,7 @@ case class MavenState(
       } yield filename -> item
       val ret = this.copy(
         sources = Map(items*),
-        sourceGitoids = Map(items.map { case (k, v) => k -> v.identifier }*)
+        sourceGitoids = Map(items.map { case (k, v) => k -> Gitoid(v.identifier) }*)
       )
       ret
     case _ => this
@@ -352,11 +352,11 @@ case class MavenState(
       // the code that associates source with class files
       new ParentScope(augmentationByHash) {
 
-        def scopeFor(): String = item.identifier()
+        def scopeFor(): String = item.identifier
         def parentOfParentScope(): Option[ParentScope] = parentScope
 
         def parentScopeInformation(): String =
-          f"Maven/JAR Scope for ${item.identifier()}${parentScope match {
+          f"Maven/JAR Scope for ${item.identifier}${parentScope match {
               case None     => ""
               case Some(ps) => f" Parent: ${ps.parentScopeInformation()}"
             }}"
@@ -375,7 +375,7 @@ case class MavenState(
           }
         }
       }
-    case _ => ParentScope.forAndWith(item.identifier(), parentScope, Map())
+    case _ => ParentScope.forAndWith(item.identifier, parentScope, Map())
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -1178,78 +1178,45 @@ object GitOIDUtils {
     (str.substring(0, 3), str.substring(3, 6), str.substring(6))
   }
 
-  /** The object type
-    */
-  enum ObjectType {
-    case Blob, Tree, Commit, Tag
+  // Aliases to the canonical Gitoid enums. The legacy `.gitoidName()` /
+  // `.hashTypeName()` methods are preserved via extension methods below so
+  // existing call sites keep working without source changes.
+  type ObjectType = Gitoid.ObjectType
+  val ObjectType: Gitoid.ObjectType.type = Gitoid.ObjectType
 
-    /** Get the canonical name for the Object Type
-      *
-      * @return
-      *   the canonical name for the object type
-      */
-    def gitoidName(): String = {
-      this match {
-        case Blob   => "blob"
-        case Tree   => "tree"
-        case Commit => "commit"
-        case Tag    => "tag"
-      }
+  type HashType = Gitoid.HashAlgorithm
+  val HashType: Gitoid.HashAlgorithm.type = Gitoid.HashAlgorithm
+  // Legacy enum-value names (SHA1 / SHA256) used at call sites.
+  val SHA1 = Gitoid.HashAlgorithm.Sha1
+  val SHA256 = Gitoid.HashAlgorithm.Sha256
+
+  extension (t: Gitoid.ObjectType) def gitoidName(): String = t.name
+  extension (a: Gitoid.HashAlgorithm) {
+    def hashTypeName(): String = a.name
+    def getDigest(): MessageDigest = a match {
+      case Gitoid.HashAlgorithm.Sha1   => MessageDigest.getInstance("SHA-1")
+      case Gitoid.HashAlgorithm.Sha256 => MessageDigest.getInstance("SHA-256")
     }
   }
 
-  /** Takes a set of gitoids, sorts them, converts to binary, and generates the
-    * Gitoid tree
-    *
-    * @param gitoids
-    *   the gitoids to build the tree for
-    *
-    * @return
-    *   the computed tree
-    */
+  /** Takes a set of gitoids, sorts them, and generates the merkle Gitoid tree.
+    * Each gitoid contributes its raw hash bytes directly — no hex round-trip. */
   def merkleTreeFromGitoids(
       gitoids: Vector[Gitoid],
-      hashType: HashType = HashType.SHA256
+      hashType: HashType = HashType.Sha256
   ): Gitoid = {
     val sorted = gitoids.sorted
-    val out = new ByteArrayOutputStream()
+    val md = hashType.getDigest()
+    var totalLen = 0L
+    for (gitoid <- sorted) totalLen += gitoid.hash.length
+    val prefix =
+      String.format("%s %d ", ObjectType.Tree.name, totalLen).getBytes()
+    md.update(prefix)
     for (gitoid <- sorted) {
-      Helpers.convertHexToBinaryAndAppendToStream(gitoid(), out)
+      val h = gitoid.hash.asInstanceOf[Array[Byte]]
+      md.update(h, 0, h.length)
     }
-    out.flush()
-    val ba = out.toByteArray()
-    val in = new ByteArrayInputStream(ba)
-    url(in, ba.length, hashType, ObjectType.Tree)
-  }
-
-  /** The hash type
-    */
-  enum HashType {
-    case SHA1, SHA256
-
-    /** Based on the hash type, get the MessageDigest
-      *
-      * @return
-      *   the MessageDigest for the type
-      */
-    def getDigest(): MessageDigest = {
-      this match {
-        case SHA1   => MessageDigest.getInstance("SHA-1")
-        case SHA256 => MessageDigest.getInstance("SHA-256")
-      }
-    }
-
-    /** Get the canonical name for the hash type
-      *
-      * @return
-      *   the canonical name
-      */
-    def hashTypeName(): String = {
-      this match {
-        case SHA1   => "sha1"
-        case SHA256 => "sha256"
-      }
-    }
+    Gitoid(ObjectType.Tree, hashType, md.digest())
   }
 
   /** Given an object type, String, and a hash type, compute the GitOID
@@ -1265,7 +1232,7 @@ object GitOIDUtils {
     */
   def computeGitOIDForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): Array[Byte] = {
     val bytes = str.getBytes("UTF-8")
@@ -1287,7 +1254,7 @@ object GitOIDUtils {
   def computeGitOID(
       bytes: InputStream,
       len: Long,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): Array[Byte] = {
     // get the prefix bytes in local encoding... which should be okay given that
@@ -1327,7 +1294,7 @@ object GitOIDUtils {
   def hashAsHex(
       bytes: InputStream,
       len: Long,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): String = {
     Helpers.toHex(
@@ -1349,7 +1316,7 @@ object GitOIDUtils {
     */
   def hashAsHexForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
   ): String = {
     Helpers.toHex(
@@ -1368,16 +1335,7 @@ object GitOIDUtils {
       len: Long,
       hashType: HashType,
       tpe: ObjectType = ObjectType.Blob
-  ): Gitoid = {
-    Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        tpe.gitoidName(),
-        hashType.hashTypeName(),
-        hashAsHex(inputStream, len, hashType, tpe)
-      )
-    )
-  }
+  ): Gitoid = Gitoid(tpe, hashType, computeGitOID(inputStream, len, hashType, tpe))
 
   /** A `gitoid` URL. See
     * https://www.iana.org/assignments/uri-schemes/prov/gitoid
@@ -1387,18 +1345,10 @@ object GitOIDUtils {
     */
   def urlForString(
       str: String,
-      hashType: HashType = HashType.SHA256,
+      hashType: HashType = HashType.Sha256,
       tpe: ObjectType = ObjectType.Blob
-  ): Gitoid = {
-    Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        tpe.gitoidName(),
-        hashType.hashTypeName(),
-        hashAsHexForString(str, hashType, tpe)
-      )
-    )
-  }
+  ): Gitoid =
+    Gitoid(tpe, hashType, computeGitOIDForString(str, hashType, tpe))
 
   def computeAllHashes(
       theFile: ArtifactWrapper
@@ -1431,22 +1381,16 @@ object GitOIDUtils {
       }
     }
 
-    val gitoidSha256Str = Gitoid(
-      String.format(
-        "gitoid:%s:%s:%s",
-        ObjectType.Blob.gitoidName(),
-        HashType.SHA256.hashTypeName(),
-        Helpers.toHex(gitoidSha256.digest())
-      )
-    )
+    val gitoidSha256Result =
+      Gitoid(ObjectType.Blob, HashType.Sha256, gitoidSha256.digest())
 
     (
-      gitoidSha256Str,
+      gitoidSha256Result,
       Vector(
         String.format(
           "gitoid:%s:%s:%s",
           ObjectType.Blob.gitoidName(),
-          HashType.SHA1.hashTypeName(),
+          HashType.Sha1.hashTypeName(),
           Helpers.toHex(gitoidSha1.digest())
         ),
         String.format("sha1:%s", Helpers.toHex(sha1.digest())),

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -50,11 +50,6 @@ import scala.collection.immutable.TreeSet
 import scala.jdk.CollectionConverters.SetHasAsScala
 import scala.util.Try
 
-/** Type alias for Git Object Identifiers (GitOIDs). A GitOID is a
-  * content-addressable identifier based on Git's object hashing scheme.
-  */
-type GitOID = String
-
 /** A collection of utility functions for file I/O, hashing, byte manipulation,
   * and various helper operations used throughout the Goat Rodeo project.
   *
@@ -198,8 +193,8 @@ object Helpers {
     */
   def computeAssociatedSource(
       file: ArtifactWrapper,
-      associatedFiles: Map[String, GitOID]
-  ): TreeSet[GitOID] = {
+      associatedFiles: Map[String, Gitoid]
+  ): TreeSet[Gitoid] = {
     file.mimeType match {
       case maybeClass if javaClassMimeTypes.intersect(maybeClass).nonEmpty =>
         val sourceName: Option[String] =
@@ -1213,13 +1208,13 @@ object GitOIDUtils {
     *   the computed tree
     */
   def merkleTreeFromGitoids(
-      gitoids: Vector[String],
+      gitoids: Vector[Gitoid],
       hashType: HashType = HashType.SHA256
-  ): String = {
+  ): Gitoid = {
     val sorted = gitoids.sorted
     val out = new ByteArrayOutputStream()
     for (gitoid <- sorted) {
-      Helpers.convertHexToBinaryAndAppendToStream(gitoid, out)
+      Helpers.convertHexToBinaryAndAppendToStream(gitoid(), out)
     }
     out.flush()
     val ba = out.toByteArray()
@@ -1373,12 +1368,14 @@ object GitOIDUtils {
       len: Long,
       hashType: HashType,
       tpe: ObjectType = ObjectType.Blob
-  ): String = {
-    String.format(
-      "gitoid:%s:%s:%s",
-      tpe.gitoidName(),
-      hashType.hashTypeName(),
-      hashAsHex(inputStream, len, hashType, tpe)
+  ): Gitoid = {
+    Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        tpe.gitoidName(),
+        hashType.hashTypeName(),
+        hashAsHex(inputStream, len, hashType, tpe)
+      )
     )
   }
 
@@ -1392,46 +1389,70 @@ object GitOIDUtils {
       str: String,
       hashType: HashType = HashType.SHA256,
       tpe: ObjectType = ObjectType.Blob
-  ): String = {
-    String.format(
-      "gitoid:%s:%s:%s",
-      tpe.gitoidName(),
-      hashType.hashTypeName(),
-      hashAsHexForString(str, hashType, tpe)
+  ): Gitoid = {
+    Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        tpe.gitoidName(),
+        hashType.hashTypeName(),
+        hashAsHexForString(str, hashType, tpe)
+      )
     )
   }
 
   def computeAllHashes(
       theFile: ArtifactWrapper
-  ): (String, Vector[String]) = {
+  ): (Gitoid, Vector[String]) = {
+    val len = theFile.size()
+    val gitoidPrefix =
+      String.format("%s %d ", ObjectType.Blob.gitoidName(), len).getBytes()
 
-    val gitoidSha256 =
-      theFile.withStream(url(_, theFile.size(), HashType.SHA256))
+    val gitoidSha1 = MessageDigest.getInstance("SHA-1")
+    val gitoidSha256 = MessageDigest.getInstance("SHA-256")
+    val sha1 = MessageDigest.getInstance("SHA-1")
+    val sha256 = MessageDigest.getInstance("SHA-256")
+    val sha512 = MessageDigest.getInstance("SHA-512")
+    val md5 = MessageDigest.getInstance("MD5")
+
+    gitoidSha1.update(gitoidPrefix)
+    gitoidSha256.update(gitoidPrefix)
+
+    theFile.withStream { in =>
+      val buf = new Array[Byte](64 * 1024)
+      var read = in.read(buf)
+      while (read > 0) {
+        gitoidSha1.update(buf, 0, read)
+        gitoidSha256.update(buf, 0, read)
+        sha1.update(buf, 0, read)
+        sha256.update(buf, 0, read)
+        sha512.update(buf, 0, read)
+        md5.update(buf, 0, read)
+        read = in.read(buf)
+      }
+    }
+
+    val gitoidSha256Str = Gitoid(
+      String.format(
+        "gitoid:%s:%s:%s",
+        ObjectType.Blob.gitoidName(),
+        HashType.SHA256.hashTypeName(),
+        Helpers.toHex(gitoidSha256.digest())
+      )
+    )
 
     (
-      gitoidSha256,
+      gitoidSha256Str,
       Vector(
-        theFile.withStream(url(_, theFile.size(), HashType.SHA1)),
-        String
-          .format(
-            "sha1:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA1(_)))
-          ),
-        String
-          .format(
-            "sha256:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA256(_)))
-          ),
-        String
-          .format(
-            "sha512:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA512(_)))
-          ),
-        String
-          .format(
-            "md5:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeMD5(_)))
-          )
+        String.format(
+          "gitoid:%s:%s:%s",
+          ObjectType.Blob.gitoidName(),
+          HashType.SHA1.hashTypeName(),
+          Helpers.toHex(gitoidSha1.digest())
+        ),
+        String.format("sha1:%s", Helpers.toHex(sha1.digest())),
+        String.format("sha256:%s", Helpers.toHex(sha256.digest())),
+        String.format("sha512:%s", Helpers.toHex(sha512.digest())),
+        String.format("md5:%s", Helpers.toHex(md5.digest()))
       )
     )
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -14,25 +14,320 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.util
 
-import io.bullet.borer.Encoder
 import io.bullet.borer.Decoder
+import io.bullet.borer.Encoder
+
+import scala.annotation.targetName
+import scala.collection.immutable.ArraySeq
 
 object Opaques {
-  opaque type Gitoid = String
+
+  /** A Gitoid — a content-addressable identifier with an object type and hash
+    * algorithm.
+    *
+    * Internally a single `ArraySeq.ofByte` of length `1 + algorithm.byteLength`:
+    *   - byte 0: header — high nibble = `ObjectType.ordinal`, low nibble = `HashAlgorithm.ordinal`
+    *   - bytes 1..n: raw hash bytes
+    *
+    * `ArraySeq.ofByte` is backed by a single `Array[Byte]` (no per-element
+    * boxing) and provides structural equality / hashCode, which is required
+    * for `Set[Gitoid]` and `Map[Gitoid, _]` semantics.
+    */
+  opaque type Gitoid = ArraySeq.ofByte
 
   object Gitoid {
-    def apply(string: String): Gitoid = string
 
-    given Ordering[Gitoid] = Ordering.String
-    given Encoder[Gitoid] = Encoder.forString.write(_, _)
-    given Decoder[Gitoid] = Decoder.forString.read(_)
+    enum ObjectType {
+      case Blob, Tree, Commit, Tag
+
+      def name: String = this match {
+        case Blob   => "blob"
+        case Tree   => "tree"
+        case Commit => "commit"
+        case Tag    => "tag"
+      }
+    }
+
+    enum HashAlgorithm {
+      case Sha1, Sha256
+
+      def name: String = this match {
+        case Sha1   => "sha1"
+        case Sha256 => "sha256"
+      }
+
+      def byteLength: Int = this match {
+        case Sha1   => 20
+        case Sha256 => 32
+      }
+    }
+
+    private inline def headerByte(t: ObjectType, a: HashAlgorithm): Byte =
+      (((t.ordinal & 0xf) << 4) | (a.ordinal & 0xf)).toByte
+
+    /** Internal byte accessor — returns the backing array directly (zero-copy).
+      * Do not mutate. */
+    private[Opaques] inline def bytes(g: Gitoid): Array[Byte] = g.unsafeArray
+
+    private inline def hexNibble(c: Char): Int = c match {
+      case '0'       => 0
+      case '1'       => 1
+      case '2'       => 2
+      case '3'       => 3
+      case '4'       => 4
+      case '5'       => 5
+      case '6'       => 6
+      case '7'       => 7
+      case '8'       => 8
+      case '9'       => 9
+      case 'a' | 'A' => 10
+      case 'b' | 'B' => 11
+      case 'c' | 'C' => 12
+      case 'd' | 'D' => 13
+      case 'e' | 'E' => 14
+      case 'f' | 'F' => 15
+      case _ =>
+        throw new IllegalArgumentException(s"Invalid hex character: '$c'")
+    }
+
+    private inline def hexChar(b: Int): Char = (b & 0xf) match {
+      case 0  => '0'
+      case 1  => '1'
+      case 2  => '2'
+      case 3  => '3'
+      case 4  => '4'
+      case 5  => '5'
+      case 6  => '6'
+      case 7  => '7'
+      case 8  => '8'
+      case 9  => '9'
+      case 10 => 'a'
+      case 11 => 'b'
+      case 12 => 'c'
+      case 13 => 'd'
+      case 14 => 'e'
+      case 15 => 'f'
+    }
+
+    /** Build a Gitoid directly from binary hash bytes — no String materialised. */
+    @targetName("fromIArray")
+    def apply(
+        objectType: ObjectType,
+        algorithm: HashAlgorithm,
+        hash: IArray[Byte]
+    ): Gitoid =
+      apply(objectType, algorithm, hash.asInstanceOf[Array[Byte]])
+
+    /** Build a Gitoid from a mutable `Array[Byte]` (e.g. straight from
+      * `MessageDigest.digest()`). Defensive copy. */
+    @targetName("fromArray")
+    def apply(
+        objectType: ObjectType,
+        algorithm: HashAlgorithm,
+        hash: Array[Byte]
+    ): Gitoid = {
+      val expected = algorithm.byteLength
+      if (hash.length != expected)
+        throw new IllegalArgumentException(
+          s"Hash length ${hash.length} does not match ${algorithm.name} byte length $expected"
+        )
+      val out = new Array[Byte](1 + expected)
+      out(0) = headerByte(objectType, algorithm)
+      System.arraycopy(hash, 0, out, 1, expected)
+      new ArraySeq.ofByte(out)
+    }
+
+    /** Parse a `gitoid:<type>:<algo>:<hex>` URL into a Gitoid. Walks the input
+      * character by character; one final `Array[Byte]` allocation. Throws
+      * `IllegalArgumentException` on malformed input. */
+    def apply(s: String): Gitoid = {
+      val len = s.length
+      val prefix = "gitoid:"
+      if (len < prefix.length || !s.startsWith(prefix))
+        throw new IllegalArgumentException(s"Not a gitoid URL: '$s'")
+      var i = prefix.length
+
+      val tStart = i
+      while (i < len && s.charAt(i) != ':') i += 1
+      if (i >= len)
+        throw new IllegalArgumentException(s"Missing object type separator in: '$s'")
+      val objectType = parseObjectType(s, tStart, i)
+      i += 1
+
+      val aStart = i
+      while (i < len && s.charAt(i) != ':') i += 1
+      if (i >= len)
+        throw new IllegalArgumentException(s"Missing hash algorithm separator in: '$s'")
+      val algorithm = parseHashAlgorithm(s, aStart, i)
+      i += 1
+
+      val expectedHexLen = algorithm.byteLength * 2
+      if (len - i != expectedHexLen)
+        throw new IllegalArgumentException(
+          s"Expected $expectedHexLen hex characters for ${algorithm.name}, got ${len - i} in: '$s'"
+        )
+      val out = new Array[Byte](1 + algorithm.byteLength)
+      out(0) = headerByte(objectType, algorithm)
+      var j = 0
+      while (j < algorithm.byteLength) {
+        val hi = hexNibble(s.charAt(i + j * 2))
+        val lo = hexNibble(s.charAt(i + j * 2 + 1))
+        out(1 + j) = ((hi << 4) | lo).toByte
+        j += 1
+      }
+      new ArraySeq.ofByte(out)
+    }
+
+    private def parseObjectType(s: String, from: Int, until: Int): ObjectType = {
+      val tokenLen = until - from
+      if (tokenLen == 4) {
+        if (s.charAt(from) == 'b' && s.charAt(from + 1) == 'l' &&
+          s.charAt(from + 2) == 'o' && s.charAt(from + 3) == 'b')
+          ObjectType.Blob
+        else if (s.charAt(from) == 't' && s.charAt(from + 1) == 'r' &&
+          s.charAt(from + 2) == 'e' && s.charAt(from + 3) == 'e')
+          ObjectType.Tree
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else if (tokenLen == 6) {
+        if (s.charAt(from) == 'c' && s.charAt(from + 1) == 'o' &&
+          s.charAt(from + 2) == 'm' && s.charAt(from + 3) == 'm' &&
+          s.charAt(from + 4) == 'i' && s.charAt(from + 5) == 't')
+          ObjectType.Commit
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else if (tokenLen == 3) {
+        if (s.charAt(from) == 't' && s.charAt(from + 1) == 'a' &&
+          s.charAt(from + 2) == 'g')
+          ObjectType.Tag
+        else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+      } else throw new IllegalArgumentException(s"Unknown object type token in '$s'")
+    }
+
+    private def parseHashAlgorithm(
+        s: String,
+        from: Int,
+        until: Int
+    ): HashAlgorithm = {
+      val tokenLen = until - from
+      if (tokenLen == 4) {
+        if (s.charAt(from) == 's' && s.charAt(from + 1) == 'h' &&
+          s.charAt(from + 2) == 'a' && s.charAt(from + 3) == '1')
+          HashAlgorithm.Sha1
+        else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+      } else if (tokenLen == 6) {
+        if (s.charAt(from) == 's' && s.charAt(from + 1) == 'h' &&
+          s.charAt(from + 2) == 'a' && s.charAt(from + 3) == '2' &&
+          s.charAt(from + 4) == '5' && s.charAt(from + 5) == '6')
+          HashAlgorithm.Sha256
+        else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+      } else throw new IllegalArgumentException(s"Unknown hash algorithm token in '$s'")
+    }
+
+    /** Pattern-match accessor. Returns `(objectType, algorithm, hash)`. */
+    def unapply(g: Gitoid): Some[(ObjectType, HashAlgorithm, IArray[Byte])] = {
+      val gb = bytes(g)
+      val header = gb(0) & 0xff
+      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
+      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val n = algorithm.byteLength
+      val hashCopy = new Array[Byte](n)
+      var i = 0
+      while (i < n) {
+        hashCopy(i) = gb(1 + i)
+        i += 1
+      }
+      Some((objectType, algorithm, IArray.unsafeFromArray(hashCopy)))
+    }
+
+    /** URL-form-equivalent ordering: by type name, then algo name, then hash
+      * bytes (unsigned). Matches the prior `Ordering.String` over URL strings
+      * for any two well-formed gitoids, keeping merkle outputs stable. */
+    given Ordering[Gitoid] = (a: Gitoid, b: Gitoid) => {
+      val ab = bytes(a)
+      val bb = bytes(b)
+      val aType = ObjectType.fromOrdinal((ab(0) & 0xff) >>> 4 & 0xf)
+      val bType = ObjectType.fromOrdinal((bb(0) & 0xff) >>> 4 & 0xf)
+      val typeCmp = aType.name.compareTo(bType.name)
+      if (typeCmp != 0) typeCmp
+      else {
+        val aAlgo = HashAlgorithm.fromOrdinal(ab(0) & 0xf)
+        val bAlgo = HashAlgorithm.fromOrdinal(bb(0) & 0xf)
+        val algoCmp = aAlgo.name.compareTo(bAlgo.name)
+        if (algoCmp != 0) algoCmp
+        else {
+          val n = math.min(ab.length, bb.length)
+          var i = 1
+          var result = 0
+          while (i < n && result == 0) {
+            result = (ab(i) & 0xff) - (bb(i) & 0xff)
+            i += 1
+          }
+          if (result != 0) result else ab.length - bb.length
+        }
+      }
+    }
+
+    /** Borer wire format: encode/decode as the URL string. Preserves on-disk
+      * compatibility with existing ADGs. */
+    given Encoder[Gitoid] =
+      Encoder.forString.contramap[Gitoid](toUrlString)
+    given Decoder[Gitoid] =
+      Decoder.forString.map(Gitoid(_))
+
+    /** Reconstruct the `gitoid:<type>:<algo>:<hex>` URL. One `StringBuilder`
+      * allocation sized exactly. */
+    private[Opaques] def toUrlString(g: Gitoid): String = {
+      val gb = bytes(g)
+      val header = gb(0) & 0xff
+      val objectType = ObjectType.fromOrdinal((header >>> 4) & 0xf)
+      val algorithm = HashAlgorithm.fromOrdinal(header & 0xf)
+      val typeName = objectType.name
+      val algoName = algorithm.name
+      val n = algorithm.byteLength
+      val totalLen =
+        "gitoid:".length + typeName.length + 1 + algoName.length + 1 + n * 2
+      val sb = new java.lang.StringBuilder(totalLen)
+      sb.append("gitoid:").append(typeName).append(':').append(algoName).append(':')
+      var i = 0
+      while (i < n) {
+        val b = gb(1 + i) & 0xff
+        sb.append(hexChar(b >>> 4))
+        sb.append(hexChar(b & 0xf))
+        i += 1
+      }
+      sb.toString
+    }
   }
 
-  extension (gitoid: Gitoid) {
-    def apply(): String = gitoid
-    def length: Int = (gitoid: String).length
-    def startsWith(prefix: String): Boolean = (gitoid: String).startsWith(prefix)
-    def isBlobSha256: Boolean = (gitoid: String).startsWith("gitoid:blob:sha256:")
+  extension (g: Gitoid) {
+    /** Reconstruct the URL form. Allocates a fresh String. */
+    def apply(): String = Gitoid.toUrlString(g)
+
+    def objectType: Gitoid.ObjectType =
+      Gitoid.ObjectType.fromOrdinal((Gitoid.bytes(g)(0) & 0xff) >>> 4 & 0xf)
+
+    def hashAlgorithm: Gitoid.HashAlgorithm =
+      Gitoid.HashAlgorithm.fromOrdinal(Gitoid.bytes(g)(0) & 0xf)
+
+    /** A copy of the hash bytes (without the header). */
+    def hash: IArray[Byte] = {
+      val gb = Gitoid.bytes(g)
+      val n = gb.length - 1
+      val out = new Array[Byte](n)
+      var i = 0
+      while (i < n) {
+        out(i) = gb(1 + i)
+        i += 1
+      }
+      IArray.unsafeFromArray(out)
+    }
+
+    def isBlobSha256: Boolean = Gitoid.bytes(g)(0) == ((0 << 4) | 1).toByte
+
+    /** Does the URL form start with the given prefix? Materialises the URL
+      * string — callers in performance-sensitive paths should prefer
+      * `objectType` / `hashAlgorithm` checks. */
+    def startsWith(prefix: String): Boolean =
+      Gitoid.toUrlString(g).startsWith(prefix)
   }
 }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -1,0 +1,39 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.util
+
+import io.bullet.borer.Encoder
+import io.bullet.borer.Decoder
+
+object Opaques {
+  opaque type Gitoid = String
+
+  object Gitoid {
+    def apply(string: String): Gitoid = string
+
+    given Ordering[Gitoid] = Ordering.String
+    given Encoder[Gitoid] = Encoder.forString.write(_, _)
+    given Decoder[Gitoid] = Decoder.forString.read(_)
+  }
+
+  extension (gitoid: Gitoid) {
+    def apply(): String = gitoid
+    def length: Int = (gitoid: String).length
+    def startsWith(prefix: String): Boolean = (gitoid: String).startsWith(prefix)
+    def isBlobSha256: Boolean = (gitoid: String).startsWith("gitoid:blob:sha256:")
+  }
+}
+
+export Opaques.Gitoid

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Opaques.scala
@@ -329,6 +329,58 @@ object Opaques {
     def startsWith(prefix: String): Boolean =
       Gitoid.toUrlString(g).startsWith(prefix)
   }
+
+  /** A canonical Package URL (https://github.com/package-url/purl-spec).
+    *
+    * Internally just the canonical `String` — `PackageURL` objects are
+    * ephemeral and we never carry them around in long-lived state; the
+    * canonical form is the wire format and the in-memory representation alike.
+    * The opaque type adds compile-time type safety at API boundaries (so a
+    * stray non-pURL String can't end up in a pURL position) without changing
+    * any byte on disk or in memory. */
+  opaque type PackageUrl = String
+
+  object PackageUrl {
+
+    /** Wrap a canonical `pkg:...` String. Validates by round-tripping the
+      * input through `com.github.packageurl.PackageURL` and re-canonicalising;
+      * throws `IllegalArgumentException` if the input is malformed or not
+      * already in canonical form. */
+    def apply(canonical: String): PackageUrl = {
+      val parsed = new com.github.packageurl.PackageURL(canonical)
+      val again = parsed.canonicalize()
+      if (again != canonical)
+        throw new IllegalArgumentException(
+          s"Not a canonical PackageURL: '$canonical' canonicalises to '$again'"
+        )
+      canonical
+    }
+
+    /** Wrap a `PackageURL` directly — the common case in production where
+      * we build pURLs via `PackageURLBuilder`. */
+    def apply(purl: com.github.packageurl.PackageURL): PackageUrl =
+      purl.canonicalize()
+
+    given Ordering[PackageUrl] = Ordering.String
+
+    given Encoder[PackageUrl] =
+      Encoder.forString.asInstanceOf[Encoder[PackageUrl]]
+    given Decoder[PackageUrl] =
+      Decoder.forString.asInstanceOf[Decoder[PackageUrl]]
+  }
+
+  extension (p: PackageUrl) {
+    /** The canonical `pkg:...` String form. */
+    def apply(): String = p
+
+    /** Parse the canonical form back into a mutable `PackageURL` object for
+      * field access (`getType`, `getNamespace`, `getQualifiers`, etc.). */
+    def parsed: com.github.packageurl.PackageURL =
+      new com.github.packageurl.PackageURL(p)
+
+    def startsWith(prefix: String): Boolean = (p: String).startsWith(prefix)
+  }
 }
 
 export Opaques.Gitoid
+export Opaques.PackageUrl

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -12,6 +12,7 @@ import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
 import io.spicelabs.goatrodeo.util.Gitoid
+import io.spicelabs.goatrodeo.util.PackageUrl
 import org.json4s.*
 import org.json4s.JsonAST.*
 import org.json4s.native.*
@@ -49,7 +50,7 @@ class DockerSuite extends munit.FunSuite {
 
     assertEquals(
       result,
-      TreeSet("pkg:docker/bigtent@2025_03_22")
+      TreeSet(PackageUrl("pkg:docker/bigtent@2025_03_22"))
     )
 
     val item = store1.read("pkg:docker/bigtent@2025_03_22").get
@@ -94,12 +95,12 @@ class DockerSuite extends munit.FunSuite {
 
     val result = store1.purls().filter(_.startsWith("pkg:docker"))
     val expectedpurls = TreeSet(
-      "pkg:docker/postgres@16.6",
-      "pkg:docker/postgres@9.6.12",
-      "pkg:docker/spicelabs%2Fbigtent@0.8.3",
-      "pkg:docker/spicelabs%2Fbigtent@latest",
-      "pkg:docker/spicelabs%2Fgrinder@0.1.0",
-      "pkg:docker/spicelabs%2Fgrinder@latest"
+      PackageUrl("pkg:docker/postgres@16.6"),
+      PackageUrl("pkg:docker/postgres@9.6.12"),
+      PackageUrl("pkg:docker/spicelabs%2Fbigtent@0.8.3"),
+      PackageUrl("pkg:docker/spicelabs%2Fbigtent@latest"),
+      PackageUrl("pkg:docker/spicelabs%2Fgrinder@0.1.0"),
+      PackageUrl("pkg:docker/spicelabs%2Fgrinder@latest")
     )
 
     assertEquals(result, expectedpurls)
@@ -107,7 +108,7 @@ class DockerSuite extends munit.FunSuite {
     for {
       purl <- expectedpurls
     } {
-      val item = store1.read(purl).get
+      val item = store1.read(purl()).get
       val aliasTo = item.connections
         .collect { case (t, v) if EdgeType.isAliasTo(t) => v }
         .headOption

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -11,6 +11,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.DockerToProcess
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import org.json4s.*
 import org.json4s.JsonAST.*
 import org.json4s.native.*
@@ -23,7 +24,7 @@ class DockerSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -24,7 +24,7 @@ class DockerSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -245,6 +245,6 @@ class DotNetTesting extends munit.FunSuite {
 
     val result = store1.purls()
     assertEquals(result.size, 1)
-    result.foreach(s => assertEquals(s, "pkg:nuget/BDInfo@0.8.0"))
+    result.foreach(s => assertEquals(s(), "pkg:nuget/BDInfo@0.8.0"))
   }
 }

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -8,6 +8,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.DotnetState
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import java.io.File
 import scala.collection.immutable.TreeMap
@@ -20,7 +21,7 @@ class DotNetTesting extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/DotNetTesting.scala
+++ b/src/test/scala/DotNetTesting.scala
@@ -21,7 +21,7 @@ class DotNetTesting extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/GitOIDUtilsTestSuite.scala
+++ b/src/test/scala/GitOIDUtilsTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.GitOIDUtils.HashType
 import io.spicelabs.goatrodeo.util.GitOIDUtils.ObjectType
+import io.spicelabs.goatrodeo.util.GitOIDUtils.{getDigest, hashTypeName, gitoidName}
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.ByteArrayInputStream
@@ -87,20 +88,20 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   // ==================== HashType Tests ====================
 
   test("HashType.hashTypeName - returns sha1 for SHA1") {
-    assertEquals(HashType.SHA1.hashTypeName(), "sha1")
+    assertEquals(HashType.Sha1.hashTypeName(), "sha1")
   }
 
   test("HashType.hashTypeName - returns sha256 for SHA256") {
-    assertEquals(HashType.SHA256.hashTypeName(), "sha256")
+    assertEquals(HashType.Sha256.hashTypeName(), "sha256")
   }
 
   test("HashType.getDigest - returns SHA1 digest") {
-    val digest = HashType.SHA1.getDigest()
+    val digest = HashType.Sha1.getDigest()
     assertEquals(digest.getAlgorithm(), "SHA-1")
   }
 
   test("HashType.getDigest - returns SHA256 digest") {
-    val digest = HashType.SHA256.getDigest()
+    val digest = HashType.Sha256.getDigest()
     assertEquals(digest.getAlgorithm(), "SHA-256")
   }
 
@@ -118,7 +119,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val input = "hello"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.computeGitOID(stream, bytes.length, HashType.SHA1)
+    val result = GitOIDUtils.computeGitOID(stream, bytes.length, HashType.Sha1)
     assertEquals(result.length, 20, "SHA1 should produce 20 bytes")
   }
 
@@ -162,18 +163,18 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val input = "test"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.url(stream, bytes.length, HashType.SHA256)
+    val result = GitOIDUtils.url(stream, bytes.length, HashType.Sha256)
     assert(result.startsWith("gitoid:blob:sha256:"))
-    assertEquals(result.length, "gitoid:blob:sha256:".length + 64)
+    assertEquals(result().length, "gitoid:blob:sha256:".length + 64)
   }
 
   test("url - generates SHA1 URL") {
     val input = "test"
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
-    val result = GitOIDUtils.url(stream, bytes.length, HashType.SHA1)
+    val result = GitOIDUtils.url(stream, bytes.length, HashType.Sha1)
     assert(result.startsWith("gitoid:blob:sha1:"))
-    assertEquals(result.length, "gitoid:blob:sha1:".length + 40)
+    assertEquals(result().length, "gitoid:blob:sha1:".length + 40)
   }
 
   test("url - generates tree object URL") {
@@ -181,7 +182,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
     val bytes = input.getBytes("UTF-8")
     val stream = new ByteArrayInputStream(bytes)
     val result =
-      GitOIDUtils.url(stream, bytes.length, HashType.SHA256, ObjectType.Tree)
+      GitOIDUtils.url(stream, bytes.length, HashType.Sha256, ObjectType.Tree)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
@@ -191,7 +192,7 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   }
 
   test("urlForString - generates SHA1 URL") {
-    val result = GitOIDUtils.urlForString("test", HashType.SHA1)
+    val result = GitOIDUtils.urlForString("test", HashType.Sha1)
     assert(result.startsWith("gitoid:blob:sha1:"))
   }
 
@@ -243,15 +244,15 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   test("merkleTreeFromGitoids - computes tree hash from gitoids") {
     val gitoids: Vector[Gitoid] = Vector(
       Gitoid("gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
-      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
+      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
     )
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - sorts gitoids before hashing") {
-    val gitoids1: Vector[Gitoid] = Vector(Gitoid("aaaa"), Gitoid("bbbb"))
-    val gitoids2: Vector[Gitoid] = Vector(Gitoid("bbbb"), Gitoid("aaaa"))
+    val gitoids1: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aaaa"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("bbbb"))
+    val gitoids2: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("bbbb"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aaaa"))
     val result1 = GitOIDUtils.merkleTreeFromGitoids(gitoids1)
     val result2 = GitOIDUtils.merkleTreeFromGitoids(gitoids2)
     assertEquals(result1, result2, "Order should not matter")
@@ -264,14 +265,14 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   }
 
   test("merkleTreeFromGitoids - handles single gitoid") {
-    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"))
+    val gitoids: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aabbccdd"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - can use SHA1") {
-    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"), Gitoid("eeff0011"))
-    val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.SHA1)
+    val gitoids: Vector[Gitoid] = Vector(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("aabbccdd"), io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("eeff0011"))
+    val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.Sha1)
     assert(result.startsWith("gitoid:tree:sha1:"))
   }
 
@@ -293,8 +294,8 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
 
   test("url - empty content produces valid URL") {
     val stream = new ByteArrayInputStream(Array[Byte]())
-    val result = GitOIDUtils.url(stream, 0, HashType.SHA256)
+    val result = GitOIDUtils.url(stream, 0, HashType.Sha256)
     assert(result.startsWith("gitoid:blob:sha256:"))
-    assertEquals(result.length, "gitoid:blob:sha256:".length + 64)
+    assertEquals(result().length, "gitoid:blob:sha256:".length + 64)
   }
 }

--- a/src/test/scala/GitOIDUtilsTestSuite.scala
+++ b/src/test/scala/GitOIDUtilsTestSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.GitOIDUtils
 import io.spicelabs.goatrodeo.util.GitOIDUtils.HashType
 import io.spicelabs.goatrodeo.util.GitOIDUtils.ObjectType
@@ -240,36 +241,36 @@ class GitOIDUtilsTestSuite extends munit.FunSuite {
   // ==================== merkleTreeFromGitoids Tests ====================
 
   test("merkleTreeFromGitoids - computes tree hash from gitoids") {
-    val gitoids = Vector(
-      "gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
-      "gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2"
+    val gitoids: Vector[Gitoid] = Vector(
+      Gitoid("gitoid:blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
+      Gitoid("gitoid:blob:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2")
     )
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - sorts gitoids before hashing") {
-    val gitoids1 = Vector("aaaa", "bbbb")
-    val gitoids2 = Vector("bbbb", "aaaa")
+    val gitoids1: Vector[Gitoid] = Vector(Gitoid("aaaa"), Gitoid("bbbb"))
+    val gitoids2: Vector[Gitoid] = Vector(Gitoid("bbbb"), Gitoid("aaaa"))
     val result1 = GitOIDUtils.merkleTreeFromGitoids(gitoids1)
     val result2 = GitOIDUtils.merkleTreeFromGitoids(gitoids2)
     assertEquals(result1, result2, "Order should not matter")
   }
 
   test("merkleTreeFromGitoids - handles empty vector") {
-    val gitoids = Vector[String]()
+    val gitoids = Vector[Gitoid]()
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - handles single gitoid") {
-    val gitoids = Vector("aabbccdd")
+    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids)
     assert(result.startsWith("gitoid:tree:sha256:"))
   }
 
   test("merkleTreeFromGitoids - can use SHA1") {
-    val gitoids = Vector("aabbccdd", "eeff0011")
+    val gitoids: Vector[Gitoid] = Vector(Gitoid("aabbccdd"), Gitoid("eeff0011"))
     val result = GitOIDUtils.merkleTreeFromGitoids(gitoids, HashType.SHA1)
     assert(result.startsWith("gitoid:tree:sha1:"))
   }

--- a/src/test/scala/GitoidFixtures.scala
+++ b/src/test/scala/GitoidFixtures.scala
@@ -1,0 +1,50 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.goatrodeo.test
+
+import io.spicelabs.goatrodeo.util.Gitoid
+
+import java.security.MessageDigest
+
+/** Test helpers for constructing valid Gitoid values from arbitrary labels.
+  *
+  * The strict Gitoid parser only accepts well-formed `gitoid:<type>:<algo>:<hex>`
+  * URLs with the correct hash length. Many existing tests use short or
+  * non-hex placeholder strings as identifiers; this helper hashes the label
+  * deterministically so the test fixture is always a valid Gitoid while
+  * preserving distinctness between different labels.
+  */
+object GitoidFixtures {
+
+  /** Produce a deterministic valid blob/sha256 Gitoid URL string from any
+    * label.
+    *
+    * If `label` already parses as a Gitoid URL, returns it verbatim; otherwise
+    * synthesises a Gitoid by hashing the UTF-8 bytes of the label and returns
+    * its URL form. */
+  def gitoidFor(label: String): String = {
+    if (label.startsWith("gitoid:")) {
+      val _ = Gitoid(label) // validate
+      label
+    } else {
+      val md = MessageDigest.getInstance("SHA-256")
+      val hash = md.digest(label.getBytes("UTF-8"))
+      Gitoid(Gitoid.ObjectType.Blob, Gitoid.HashAlgorithm.Sha256, hash).apply()
+    }
+  }
+
+  /** Convenience: Gitoid form for use as a value in `Map[String, Gitoid]` etc. */
+  def gitoidForAsGitoid(label: String): Gitoid = Gitoid(gitoidFor(label))
+}

--- a/src/test/scala/GraphManagerTestSuite.scala
+++ b/src/test/scala/GraphManagerTestSuite.scala
@@ -32,7 +32,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)] = TreeSet()
   ): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -177,7 +177,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       val connections = TreeSet(
         EdgeType.aliasFrom -> "sha256:alias1",
-        EdgeType.containedBy -> "gitoid:blob:sha256:parent"
+        EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"
       )
       val items = Vector(
         createTestItem(
@@ -254,7 +254,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -274,7 +274,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -296,7 +296,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Simple test with minimal items - complex items have encoding issues
       val item = Item(
-        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
+        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
         TreeSet(),
         None,
         None
@@ -316,7 +316,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       val connections = TreeSet(
         EdgeType.aliasFrom -> "sha256:hash1",
-        EdgeType.containedBy -> "gitoid:blob:sha256:parent123"
+        EdgeType.containedBy -> "gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"
       )
       val item = createTestItem(
         "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",

--- a/src/test/scala/GraphManagerTestSuite.scala
+++ b/src/test/scala/GraphManagerTestSuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.GRDWalker
 import io.spicelabs.goatrodeo.omnibor.GraphManager
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.FileInputStream
@@ -31,7 +32,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)] = TreeSet()
   ): Item = {
     Item(
-      id,
+      Gitoid(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -253,7 +254,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -273,7 +274,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Use simple items without metadata for reliable serialization
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None
@@ -295,7 +296,7 @@ class GraphManagerTestSuite extends munit.FunSuite {
     try {
       // Simple test with minimal items - complex items have encoding issues
       val item = Item(
-        "gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111",
+        Gitoid("gitoid:blob:sha256:aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffff0000000011111111"),
         TreeSet(),
         None,
         None

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.util.ByteWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -26,7 +27,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   def createBasicItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -45,7 +46,7 @@ class ItemTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)]
   ): Item = {
     Item(
-      id,
+      Gitoid(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -72,7 +73,7 @@ class ItemTestSuite extends munit.FunSuite {
     val bytes = item.encodeCBOR()
     val decoded = Item.decode(bytes)
     assert(decoded.isSuccess)
-    assertEquals(decoded.get.identifier, "test-id")
+    assertEquals(decoded.get.identifier(), "test-id")
   }
 
   test("Item - round-trip CBOR preserves identifier") {
@@ -122,12 +123,12 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item.itemFrom - includes container if provided") {
     val data = "test content".getBytes("UTF-8")
     val wrapper = ByteWrapper(data, "test.txt", None)
-    val container = Some("gitoid:blob:sha256:parent123")
+    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
     val item = Item.itemFrom(wrapper, container)
 
     assert(
       item.connections.exists(e =>
-        e._1 == EdgeType.containedBy && e._2 == container.get
+        e._1 == EdgeType.containedBy && e._2 == container.get()
       )
     )
   }
@@ -186,7 +187,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.isRoot - returns false for tags identifier") {
     val item = Item(
-      "tags",
+      Gitoid("tags"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet(), TreeSet(), 0, TreeMap()))
@@ -195,7 +196,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.isRoot - returns false for non-metadata body type") {
-    val item = Item("test-id", TreeSet(), None, None)
+    val item = Item(Gitoid("test-id"), TreeSet(), None, None)
     assert(!item.isRoot())
   }
 
@@ -261,13 +262,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.merge - merges metadata bodies") {
     val item1 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1"), TreeSet("mime1"), 100, TreeMap()))
     )
     val item2 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2"), TreeSet("mime2"), 100, TreeMap()))
@@ -284,12 +285,12 @@ class ItemTestSuite extends munit.FunSuite {
     val item2 = createBasicItem("id-2")
 
     val merged = item1.merge(item2)
-    assertEquals(merged.identifier, "id-1")
+    assertEquals(merged.identifier(), "id-1")
   }
 
   test("Item.merge - handles None body") {
     val item1 = createBasicItem("id")
-    val item2 = Item("id", TreeSet(), None, None)
+    val item2 = Item(Gitoid("id"), TreeSet(), None, None)
 
     val merged = item1.merge(item2)
     assert(merged.bodyAsItemMetaData.isDefined)
@@ -300,13 +301,13 @@ class ItemTestSuite extends munit.FunSuite {
     val extra2 = TreeMap("key2" -> TreeSet(StringOrPair("val2")))
     // ItemMetaData.merge requires non-empty fileNames
     val item1 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra1))
     )
     val item2 = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra2))
@@ -378,7 +379,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - creates body if none exists") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -416,7 +417,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceWithMetadata - creates body if none exists") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("file.txt"))
     assert(enhanced.bodyAsItemMetaData.isDefined)
@@ -425,13 +426,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceWithMetadata - includes parent gitoid for duplicate filenames") {
     val item = Item(
-      "id",
+      Gitoid("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("existing.txt"), TreeSet(), 100, TreeMap()))
     )
 
-    val parent = Some("gitoid:blob:sha256:parent123")
+    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
     val enhanced = item.enhanceWithMetadata(
       maybeParent = parent,
       filenames = Seq("newfile.txt")
@@ -445,26 +446,26 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - creates filename to gitoid map") {
     val item1 = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1.txt"), TreeSet(), 100, TreeMap()))
     )
     val item2 = Item(
-      "gitoid:blob:sha256:def456",
+      Gitoid("gitoid:blob:sha256:def456"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2.txt"), TreeSet(), 100, TreeMap()))
     )
 
     val map = Item.itemsToFilenameGitOIDMap(Seq(item1, item2))
-    assertEquals(map.get("file1.txt"), Some("gitoid:blob:sha256:abc123"))
-    assertEquals(map.get("file2.txt"), Some("gitoid:blob:sha256:def456"))
+    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:abc123")))
+    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:def456")))
   }
 
   test("itemsToFilenameGitOIDMap - applies name filter") {
     val item = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -484,7 +485,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies mime filter") {
     val item1 = Item(
-      "gitoid:blob:sha256:abc123",
+      Gitoid("gitoid:blob:sha256:abc123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -497,7 +498,7 @@ class ItemTestSuite extends munit.FunSuite {
       )
     )
     val item2 = Item(
-      "gitoid:blob:sha256:def456",
+      Gitoid("gitoid:blob:sha256:def456"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -514,7 +515,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("itemsToFilenameGitOIDMap - handles items without body") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     val map = Item.itemsToFilenameGitOIDMap(Seq(item))
     assert(map.isEmpty)
   }
@@ -527,7 +528,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.bodyAsItemMetaData - returns None for no body") {
-    val item = Item("id", TreeSet(), None, None)
+    val item = Item(Gitoid("id"), TreeSet(), None, None)
     assertEquals(item.bodyAsItemMetaData, None)
   }
 

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -27,7 +27,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   def createBasicItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -46,7 +46,7 @@ class ItemTestSuite extends munit.FunSuite {
       connections: TreeSet[(String, String)]
   ): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       connections,
       Some(ItemMetaData.mimeType),
       Some(
@@ -73,7 +73,7 @@ class ItemTestSuite extends munit.FunSuite {
     val bytes = item.encodeCBOR()
     val decoded = Item.decode(bytes)
     assert(decoded.isSuccess)
-    assertEquals(decoded.get.identifier(), "test-id")
+    assertEquals(decoded.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"))
   }
 
   test("Item - round-trip CBOR preserves identifier") {
@@ -86,7 +86,7 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item - round-trip CBOR preserves connections") {
     val connections = TreeSet(
       EdgeType.aliasFrom -> "sha256:abc123",
-      EdgeType.containedBy -> "gitoid:blob:sha256:parent"
+      EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"
     )
     val item = createItemWithConnections("test-id", connections)
     val bytes = item.encodeCBOR()
@@ -123,7 +123,7 @@ class ItemTestSuite extends munit.FunSuite {
   test("Item.itemFrom - includes container if provided") {
     val data = "test content".getBytes("UTF-8")
     val wrapper = ByteWrapper(data, "test.txt", None)
-    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
+    val container: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"))
     val item = Item.itemFrom(wrapper, container)
 
     assert(
@@ -167,27 +167,27 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== isRoot Tests ====================
 
   test("Item.isRoot - returns true for root item") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     assert(item.isRoot())
   }
 
   test("Item.isRoot - returns false for item with aliasTo") {
-    val connections = TreeSet(EdgeType.aliasTo -> "gitoid:blob:sha256:target")
+    val connections = TreeSet(EdgeType.aliasTo -> "gitoid:blob:sha256:34a04005bcaf206eec990bd9637d9fdb6725e0a0c0d4aebf003f17f4c956eb5c")
     val item = createItemWithConnections("sha256:abc123", connections)
     assert(!item.isRoot())
   }
 
   test("Item.isRoot - returns false for item with containedBy") {
     val connections =
-      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:parent")
+      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c")
     val item =
-      createItemWithConnections("gitoid:blob:sha256:abc123", connections)
+      createItemWithConnections("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090", connections)
     assert(!item.isRoot())
   }
 
   test("Item.isRoot - returns false for tags identifier") {
     val item = Item(
-      Gitoid("tags"),
+      Item.tagsRootIdentifier,
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet(), TreeSet(), 0, TreeMap()))
@@ -196,7 +196,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.isRoot - returns false for non-metadata body type") {
-    val item = Item(Gitoid("test-id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"), TreeSet(), None, None)
     assert(!item.isRoot())
   }
 
@@ -204,35 +204,35 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("buildListOfReferences - returns aliasTo for aliasFrom") {
     val connections = TreeSet(EdgeType.aliasFrom -> "sha256:abc123")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
     assert(refs.contains(EdgeType.aliasTo -> "sha256:abc123"))
   }
 
   test("buildListOfReferences - returns buildsTo for builtFrom") {
-    val connections = TreeSet(EdgeType.builtFrom -> "gitoid:blob:sha256:source")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val connections = TreeSet(EdgeType.builtFrom -> "gitoid:blob:sha256:41cf6794ba4200b839c53531555f0f3998df4cbb01a4d5cb0b94e3ca5e23947d")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.buildsTo -> "gitoid:blob:sha256:source"))
+    assert(refs.contains(EdgeType.buildsTo -> "gitoid:blob:sha256:41cf6794ba4200b839c53531555f0f3998df4cbb01a4d5cb0b94e3ca5e23947d"))
   }
 
   test("buildListOfReferences - returns contains for containedBy") {
     val connections =
-      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:parent")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+      TreeSet(EdgeType.containedBy -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.contains -> "gitoid:blob:sha256:parent"))
+    assert(refs.contains(EdgeType.contains -> "gitoid:blob:sha256:e47125968b3b71049fbc4802d1e40a71ea1359decfabacf70b34588037d4ff0c"))
   }
 
   test("buildListOfReferences - returns tagTo for tagFrom") {
-    val connections = TreeSet(EdgeType.tagFrom -> "gitoid:blob:sha256:tag")
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val connections = TreeSet(EdgeType.tagFrom -> "gitoid:blob:sha256:2a1073a6e67f0e5f09a5957c659503c690efe7272be8313df872556a9a684d8c")
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
-    assert(refs.contains(EdgeType.tagTo -> "gitoid:blob:sha256:tag"))
+    assert(refs.contains(EdgeType.tagTo -> "gitoid:blob:sha256:2a1073a6e67f0e5f09a5957c659503c690efe7272be8313df872556a9a684d8c"))
   }
 
   test("buildListOfReferences - handles multiple connections") {
@@ -241,7 +241,7 @@ class ItemTestSuite extends munit.FunSuite {
       EdgeType.aliasFrom -> "sha1:def",
       EdgeType.containedBy -> "parent"
     )
-    val item = createItemWithConnections("gitoid:blob:sha256:main", connections)
+    val item = createItemWithConnections("gitoid:blob:sha256:0d6e4079e36703ebd37c00722f5891d28b0e2811dc114b129215123adcce3605", connections)
 
     val refs = item.buildListOfReferencesForAliasFromBuiltFromContainedBy()
     assertEquals(refs.length, 3)
@@ -262,13 +262,13 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("Item.merge - merges metadata bodies") {
     val item1 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1"), TreeSet("mime1"), 100, TreeMap()))
     )
     val item2 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2"), TreeSet("mime2"), 100, TreeMap()))
@@ -285,12 +285,12 @@ class ItemTestSuite extends munit.FunSuite {
     val item2 = createBasicItem("id-2")
 
     val merged = item1.merge(item2)
-    assertEquals(merged.identifier(), "id-1")
+    assertEquals(merged.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id-1"))
   }
 
   test("Item.merge - handles None body") {
     val item1 = createBasicItem("id")
-    val item2 = Item(Gitoid("id"), TreeSet(), None, None)
+    val item2 = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
 
     val merged = item1.merge(item2)
     assert(merged.bodyAsItemMetaData.isDefined)
@@ -301,13 +301,13 @@ class ItemTestSuite extends munit.FunSuite {
     val extra2 = TreeMap("key2" -> TreeSet(StringOrPair("val2")))
     // ItemMetaData.merge requires non-empty fileNames
     val item1 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra1))
     )
     val item2 = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file.txt"), TreeSet(), 100, extra2))
@@ -322,7 +322,7 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== enhanceItemWithPurls Tests ====================
 
   test("enhanceItemWithPurls - adds purl connections") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -337,7 +337,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - adds purl to filenames") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -352,13 +352,13 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - handles empty purls") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val enhanced = item.enhanceItemWithPurls(Seq())
     assertEquals(enhanced, item)
   }
 
   test("enhanceItemWithPurls - handles multiple purls") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val purl1 = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -379,7 +379,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceItemWithPurls - creates body if none exists") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     val purl = PackageURLBuilder
       .aPackageURL()
       .withType("deb")
@@ -395,7 +395,7 @@ class ItemTestSuite extends munit.FunSuite {
   // ==================== enhanceWithMetadata Tests ====================
 
   test("enhanceWithMetadata - adds extra metadata") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
     val extra = TreeMap("key" -> TreeSet(StringOrPair("value")))
 
     val enhanced = item.enhanceWithMetadata(extra = extra)
@@ -403,21 +403,21 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("enhanceWithMetadata - adds filenames") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("newfile.txt"))
     assert(enhanced.bodyAsItemMetaData.get.fileNames.contains("newfile.txt"))
   }
 
   test("enhanceWithMetadata - adds mime types") {
-    val item = createBasicItem("gitoid:blob:sha256:abc123")
+    val item = createBasicItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")
 
     val enhanced = item.enhanceWithMetadata(mimeTypes = Seq("text/plain"))
     assert(enhanced.bodyAsItemMetaData.get.mimeType.contains("text/plain"))
   }
 
   test("enhanceWithMetadata - creates body if none exists") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
 
     val enhanced = item.enhanceWithMetadata(filenames = Seq("file.txt"))
     assert(enhanced.bodyAsItemMetaData.isDefined)
@@ -426,46 +426,46 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceWithMetadata - includes parent gitoid for duplicate filenames") {
     val item = Item(
-      Gitoid("id"),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("existing.txt"), TreeSet(), 100, TreeMap()))
     )
 
-    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:parent123"))
+    val parent: Option[Gitoid] = Some(Gitoid("gitoid:blob:sha256:82e3edf5f5f3a46b5f94579b61817fd9a1f356adcef5ee22da3b96ef775c4860"))
     val enhanced = item.enhanceWithMetadata(
       maybeParent = parent,
       filenames = Seq("newfile.txt")
     )
     val fileNames = enhanced.bodyAsItemMetaData.get.fileNames
     // Should include parent-qualified filename
-    assert(fileNames.exists(_.contains("parent123")))
+    assert(fileNames.exists(_.contains("82e3edf5")))
   }
 
   // ==================== itemsToFilenameGitOIDMap Tests ====================
 
   test("itemsToFilenameGitOIDMap - creates filename to gitoid map") {
     val item1 = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file1.txt"), TreeSet(), 100, TreeMap()))
     )
     val item2 = Item(
-      Gitoid("gitoid:blob:sha256:def456"),
+      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("file2.txt"), TreeSet(), 100, TreeMap()))
     )
 
     val map = Item.itemsToFilenameGitOIDMap(Seq(item1, item2))
-    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:abc123")))
-    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:def456")))
+    assertEquals(map.get("file1.txt"), Some(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")))
+    assertEquals(map.get("file2.txt"), Some(Gitoid("gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587")))
   }
 
   test("itemsToFilenameGitOIDMap - applies name filter") {
     val item = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -485,7 +485,7 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("itemsToFilenameGitOIDMap - applies mime filter") {
     val item1 = Item(
-      Gitoid("gitoid:blob:sha256:abc123"),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -498,7 +498,7 @@ class ItemTestSuite extends munit.FunSuite {
       )
     )
     val item2 = Item(
-      Gitoid("gitoid:blob:sha256:def456"),
+      "gitoid:blob:sha256:8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -515,7 +515,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("itemsToFilenameGitOIDMap - handles items without body") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     val map = Item.itemsToFilenameGitOIDMap(Seq(item))
     assert(map.isEmpty)
   }
@@ -528,7 +528,7 @@ class ItemTestSuite extends munit.FunSuite {
   }
 
   test("Item.bodyAsItemMetaData - returns None for no body") {
-    val item = Item(Gitoid("id"), TreeSet(), None, None)
+    val item = Item(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("id"), TreeSet(), None, None)
     assertEquals(item.bodyAsItemMetaData, None)
   }
 

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -261,7 +261,7 @@ box but need special configuration, like udhcpc, the dhcp client."""
 
     var meta = gitoids
       .map(oid => {
-        store.read(oid)
+        store.read(oid())
       })
       .flatten
       .map(item => item.body)

--- a/src/test/scala/MetadataSuite.scala
+++ b/src/test/scala/MetadataSuite.scala
@@ -525,7 +525,7 @@ the performance, all instances of the terminal are sharing a single process."""
       mainItemKey: String
   ): ItemMetaData = {
     val purls = store.purls()
-    assertEquals(TreeSet(expectedPurl), purls)
+    assertEquals(TreeSet(io.spicelabs.goatrodeo.util.PackageUrl(expectedPurl)), purls)
     val mainItemOpt = store.read(mainItemKey)
     assert(mainItemOpt.isDefined)
     val metadataOpt = mainItemOpt.get.bodyAsItemMetaData

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -321,7 +321,7 @@ class MySuite extends munit.FunSuite {
       nested,
       args = Config(),
       block = Set(
-        "gitoid:blob:sha256:e3f8d493cb200fd95c4881e248148836628e0f06ddb3c28cb3f95cf784e2f8e4"
+        Gitoid("gitoid:blob:sha256:e3f8d493cb200fd95c4881e248148836628e0f06ddb3c28cb3f95cf784e2f8e4")
       )
     )
 

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ToProcess
 import io.spicelabs.goatrodeo.util.*
+import io.spicelabs.goatrodeo.util.GitOIDUtils.{getDigest, hashTypeName, gitoidName}
 import io.spicelabs.goatrodeo.util.Config
 
 import java.io.ByteArrayInputStream
@@ -54,7 +55,7 @@ class MySuite extends munit.FunSuite {
 
   test("SHA256 hash produces correct hex output") {
     val txt = Array[Byte](49, 50, 51, 10)
-    val digest = GitOIDUtils.HashType.SHA256.getDigest()
+    val digest = GitOIDUtils.HashType.Sha256.getDigest()
     assertEquals(
       Helpers.toHex(digest.digest(txt)),
       "181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b"

--- a/src/test/scala/PropertyBasedTestSuite.scala
+++ b/src/test/scala/PropertyBasedTestSuite.scala
@@ -138,7 +138,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     metadata <-
       if (hasMetadata) genItemMetaData.map(Some(_)) else Gen.const(None)
   } yield Item(
-    identifier = Gitoid(identifier),
+    identifier = identifier,
     connections = connections,
     bodyMimeType = metadata.map(_ => ItemMetaData.mimeType),
     body = metadata
@@ -181,7 +181,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     forAll(genItemMetaData) { metadata =>
       val encoded = metadata.encodeCBOR()
       val item = Item(
-        identifier = Gitoid("gitoid:blob:sha256:" + "a" * 64),
+        identifier = "gitoid:blob:sha256:" + "a" * 64,
         connections = TreeSet(),
         bodyMimeType = Some(ItemMetaData.mimeType),
         body = Some(metadata)
@@ -465,8 +465,8 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
 
   property("Different identifiers produce different MD5s") {
     forAll(genItem, genGitOID) { (item, newId) =>
-      if (item.identifier() != newId) {
-        val item2 = item.copy(identifier = Gitoid(newId))
+      if (item.identifier != newId) {
+        val item2 = item.copy(identifier = newId)
         !item.identifierMD5().sameElements(item2.identifierMD5())
       } else {
         true

--- a/src/test/scala/PropertyBasedTestSuite.scala
+++ b/src/test/scala/PropertyBasedTestSuite.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.PairOf
 import io.spicelabs.goatrodeo.omnibor.StringOf
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.IncludeExclude
 import munit.ScalaCheckSuite
@@ -137,7 +138,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     metadata <-
       if (hasMetadata) genItemMetaData.map(Some(_)) else Gen.const(None)
   } yield Item(
-    identifier = identifier,
+    identifier = Gitoid(identifier),
     connections = connections,
     bodyMimeType = metadata.map(_ => ItemMetaData.mimeType),
     body = metadata
@@ -180,7 +181,7 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
     forAll(genItemMetaData) { metadata =>
       val encoded = metadata.encodeCBOR()
       val item = Item(
-        identifier = "gitoid:blob:sha256:" + "a" * 64,
+        identifier = Gitoid("gitoid:blob:sha256:" + "a" * 64),
         connections = TreeSet(),
         bodyMimeType = Some(ItemMetaData.mimeType),
         body = Some(metadata)
@@ -464,8 +465,8 @@ class PropertyBasedTestSuite extends ScalaCheckSuite {
 
   property("Different identifiers produce different MD5s") {
     forAll(genItem, genGitOID) { (item, newId) =>
-      if (item.identifier != newId) {
-        val item2 = item.copy(identifier = newId)
+      if (item.identifier() != newId) {
+        val item2 = item.copy(identifier = Gitoid(newId))
         !item.identifierMD5().sameElements(item2.identifierMD5())
       } else {
         true

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -205,7 +205,7 @@ class StorageTestSuite extends munit.FunSuite {
 
     val purls = storage.purls()
     assertEquals(purls.size, 1)
-    assert(purls.contains(purl.canonicalize()))
+    assert(purls.contains(io.spicelabs.goatrodeo.util.PackageUrl(purl)))
   }
 
   test("MemStorage - purls returns all added purls") {

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -17,6 +17,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.MemStorage
 import io.spicelabs.goatrodeo.omnibor.Storage
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.nio.file.Files
@@ -27,7 +28,7 @@ class StorageTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String, fileNames: Set[String] = Set()): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -66,7 +67,7 @@ class StorageTestSuite extends munit.FunSuite {
     storage.write("test-id", _ => Some(item), _ => "")
     val result = storage.read("test-id")
     assert(result.isDefined)
-    assertEquals(result.get.identifier, "test-id")
+    assertEquals(result.get.identifier(), "test-id")
   }
 
   test("MemStorage - write creates new item") {
@@ -74,7 +75,7 @@ class StorageTestSuite extends munit.FunSuite {
     val item = createTestItem("new-id")
     val result = storage.write("new-id", _ => Some(item), _ => "")
     assert(result.isDefined)
-    assertEquals(result.get.identifier, "new-id")
+    assertEquals(result.get.identifier(), "new-id")
   }
 
   test("MemStorage - write updates existing item") {
@@ -173,9 +174,9 @@ class StorageTestSuite extends munit.FunSuite {
 
     val gitoids = storage.gitoidKeys()
     assertEquals(gitoids.size, 1)
-    assert(gitoids.contains("gitoid:blob:sha256:abc123"))
-    assert(!gitoids.contains("sha256:def456"))
-    assert(!gitoids.contains("pkg:maven/group/artifact@1.0"))
+    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:abc123")))
+    assert(!gitoids.contains(Gitoid("sha256:def456")))
+    assert(!gitoids.contains(Gitoid("pkg:maven/group/artifact@1.0")))
   }
 
   test("MemStorage - gitoidKeys returns empty for no gitoids") {
@@ -410,7 +411,7 @@ class StorageTestSuite extends munit.FunSuite {
       val storage = MemStorage(None)
       // Create a root item (no aliasTo or containedBy edges)
       val rootItem = Item(
-        "gitoid:blob:sha256:root123",
+        Gitoid("gitoid:blob:sha256:root123"),
         TreeSet(),
         Some(ItemMetaData.mimeType),
         Some(ItemMetaData(TreeSet(), TreeSet(), 100, TreeMap()))

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -27,8 +27,7 @@ import scala.collection.immutable.TreeSet
 class StorageTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String, fileNames: Set[String] = Set()): Item = {
-    Item(
-      Gitoid(id),
+    Item(      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -67,7 +66,7 @@ class StorageTestSuite extends munit.FunSuite {
     storage.write("test-id", _ => Some(item), _ => "")
     val result = storage.read("test-id")
     assert(result.isDefined)
-    assertEquals(result.get.identifier(), "test-id")
+    assertEquals(result.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("test-id"))
   }
 
   test("MemStorage - write creates new item") {
@@ -75,7 +74,7 @@ class StorageTestSuite extends munit.FunSuite {
     val item = createTestItem("new-id")
     val result = storage.write("new-id", _ => Some(item), _ => "")
     assert(result.isDefined)
-    assertEquals(result.get.identifier(), "new-id")
+    assertEquals(result.get.identifier, io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor("new-id"))
   }
 
   test("MemStorage - write updates existing item") {
@@ -157,8 +156,8 @@ class StorageTestSuite extends munit.FunSuite {
   test("MemStorage - gitoidKeys returns only gitoid keys") {
     val storage = MemStorage(None)
     storage.write(
-      "gitoid:blob:sha256:abc123",
-      _ => Some(createTestItem("gitoid:blob:sha256:abc123")),
+      "gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090",
+      _ => Some(createTestItem("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")),
       _ => ""
     )
     storage.write(
@@ -174,9 +173,9 @@ class StorageTestSuite extends munit.FunSuite {
 
     val gitoids = storage.gitoidKeys()
     assertEquals(gitoids.size, 1)
-    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:abc123")))
-    assert(!gitoids.contains(Gitoid("sha256:def456")))
-    assert(!gitoids.contains(Gitoid("pkg:maven/group/artifact@1.0")))
+    assert(gitoids.contains(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090")))
+    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("sha256:def456")))
+    assert(!gitoids.contains(io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidForAsGitoid("pkg:maven/group/artifact@1.0")))
   }
 
   test("MemStorage - gitoidKeys returns empty for no gitoids") {
@@ -410,13 +409,12 @@ class StorageTestSuite extends munit.FunSuite {
     try {
       val storage = MemStorage(None)
       // Create a root item (no aliasTo or containedBy edges)
-      val rootItem = Item(
-        Gitoid("gitoid:blob:sha256:root123"),
+      val rootItem = Item(        "gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8",
         TreeSet(),
         Some(ItemMetaData.mimeType),
         Some(ItemMetaData(TreeSet(), TreeSet(), 100, TreeMap()))
       )
-      storage.write("gitoid:blob:sha256:root123", _ => Some(rootItem), _ => "")
+      storage.write("gitoid:blob:sha256:e14cb9e5c0eeee0ea313a4e04fbd10aa17ac17aa33a3cad4bdfe74b87ca18ef8", _ => Some(rootItem), _ => "")
 
       storage.emitRootsToDir(tempDir)
 

--- a/src/test/scala/ToProcessTestSuite.scala
+++ b/src/test/scala/ToProcessTestSuite.scala
@@ -33,7 +33,7 @@ class ToProcessTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -206,7 +206,7 @@ class ToProcessTestSuite extends munit.FunSuite {
     val store = ToProcess.buildGraphForToProcess(
       toProcess,
       args = Config(),
-      block = Set(Gitoid("gitoid:blob:sha256:abc123"))
+      block = Set(Gitoid("gitoid:blob:sha256:6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"))
     )
 
     assert(store.size() > 0)

--- a/src/test/scala/ToProcessTestSuite.scala
+++ b/src/test/scala/ToProcessTestSuite.scala
@@ -21,6 +21,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.GenericFile
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.File
@@ -32,7 +33,7 @@ class ToProcessTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -205,7 +206,7 @@ class ToProcessTestSuite extends munit.FunSuite {
     val store = ToProcess.buildGraphForToProcess(
       toProcess,
       args = Config(),
-      block = Set("gitoid:blob:sha256:abc123")
+      block = Set(Gitoid("gitoid:blob:sha256:abc123"))
     )
 
     assert(store.size() > 0)

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagContractSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
+
 /** Phase 2 TDD Tests: ProcessingState.maybePackageTag contract
   *
   * These tests verify:

--- a/src/test/scala/strategies/CertificatesAssertionsTests.scala
+++ b/src/test/scala/strategies/CertificatesAssertionsTests.scala
@@ -18,6 +18,7 @@ import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import scala.collection.immutable.TreeMap
@@ -55,7 +56,7 @@ class CertificatesAssertionsTests extends FunSuite {
     val connections =
       TreeSet.from(purls.map(p => EdgeType.aliasFrom -> p))
     Item(
-      identifier = "gitoid:blob:sha256:test",
+      identifier = Gitoid("gitoid:blob:sha256:test"),
       connections = connections,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(
@@ -165,7 +166,7 @@ class CertificatesAssertionsTests extends FunSuite {
   test("purlsOf does not include non-pkg: edges") {
     // alias:from edges may legitimately carry gitoid: hashes too.
     val item = Item(
-      identifier = "gitoid:blob:sha256:test",
+      identifier = Gitoid("gitoid:blob:sha256:test"),
       connections = TreeSet(
         EdgeType.aliasFrom -> "gitoid:blob:sha1:hashA",
         EdgeType.aliasFrom -> "pkg:generic/x509/spki-sha256@abc"

--- a/src/test/scala/strategies/CertificatesAssertionsTests.scala
+++ b/src/test/scala/strategies/CertificatesAssertionsTests.scala
@@ -56,7 +56,7 @@ class CertificatesAssertionsTests extends FunSuite {
     val connections =
       TreeSet.from(purls.map(p => EdgeType.aliasFrom -> p))
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:test"),
+      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       connections = connections,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(
@@ -166,9 +166,9 @@ class CertificatesAssertionsTests extends FunSuite {
   test("purlsOf does not include non-pkg: edges") {
     // alias:from edges may legitimately carry gitoid: hashes too.
     val item = Item(
-      identifier = Gitoid("gitoid:blob:sha256:test"),
+      identifier = "gitoid:blob:sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
       connections = TreeSet(
-        EdgeType.aliasFrom -> "gitoid:blob:sha1:hashA",
+        EdgeType.aliasFrom -> "gitoid:blob:sha1:7bec97ea6269f46f9778a3b063c2fddb74f48730",
         EdgeType.aliasFrom -> "pkg:generic/x509/spki-sha256@abc"
       ),
       bodyMimeType = Some(ItemMetaData.mimeType),

--- a/src/test/scala/strategies/CertificatesLeakSuite.scala
+++ b/src/test/scala/strategies/CertificatesLeakSuite.scala
@@ -8,6 +8,7 @@ import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -60,7 +61,7 @@ class CertificatesLeakSuite extends FunSuite {
   ).map(Pattern.compile)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase8-leak-suite-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase8-leak-suite-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesLeakSuite.scala
+++ b/src/test/scala/strategies/CertificatesLeakSuite.scala
@@ -61,7 +61,7 @@ class CertificatesLeakSuite extends FunSuite {
   ).map(Pattern.compile)
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase8-leak-suite-stub"),
+    identifier = "gitoid:blob:sha256:1738f894c151411b2c2dbc1d824894212453b8e1c7817d6ef7eda2253aeb7d64",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
+++ b/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
@@ -18,6 +18,7 @@ import io.bullet.borer.Dom
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ItemTagData
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -56,7 +57,7 @@ import scala.collection.immutable.TreeSet
 class CertificatesPipelineRunnerTests extends FunSuite {
 
   private def primaryItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(
@@ -70,14 +71,14 @@ class CertificatesPipelineRunnerTests extends FunSuite {
   )
 
   private def aliasStubItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = None,
     body = None
   )
 
   private def tagItem(id: String): Item = Item(
-    identifier = id,
+    identifier = Gitoid(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemTagData.mimeType),
     body = Some(ItemTagData(Dom.NullElem))

--- a/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
+++ b/src/test/scala/strategies/CertificatesPipelineRunnerTests.scala
@@ -57,7 +57,7 @@ import scala.collection.immutable.TreeSet
 class CertificatesPipelineRunnerTests extends FunSuite {
 
   private def primaryItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(
@@ -71,14 +71,14 @@ class CertificatesPipelineRunnerTests extends FunSuite {
   )
 
   private def aliasStubItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = None,
     body = None
   )
 
   private def tagItem(id: String): Item = Item(
-    identifier = Gitoid(id),
+    identifier = io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemTagData.mimeType),
     body = Some(ItemTagData(Dom.NullElem))

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -648,8 +648,9 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
 
   private def stubItem(): io.spicelabs.goatrodeo.omnibor.Item = {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
+    import io.spicelabs.goatrodeo.util.Gitoid
     Item(
-      identifier = "gitoid:blob:sha256:phase8-property-stub",
+      identifier = Gitoid("gitoid:blob:sha256:phase8-property-stub"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -650,7 +650,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
     import io.spicelabs.goatrodeo.util.Gitoid
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:phase8-property-stub"),
+      identifier = "gitoid:blob:sha256:c74dd91102c1295a01b77df6080167fe58d21fc89104f77ff9a823291d7e83fe",
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -24,6 +24,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.CertificatesState
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.CryptoDetector
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import scala.collection.immutable.TreeMap
@@ -73,7 +74,7 @@ class CertificatesStubTests extends FunSuite {
     ByteWrapper("hello goat rodeo".getBytes("UTF-8"), name, None)
 
   private def syntheticItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase1-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase1-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/CertificatesStubTests.scala
+++ b/src/test/scala/strategies/CertificatesStubTests.scala
@@ -74,7 +74,7 @@ class CertificatesStubTests extends FunSuite {
     ByteWrapper("hello goat rodeo".getBytes("UTF-8"), name, None)
 
   private def syntheticItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase1-stub"),
+    identifier = "gitoid:blob:sha256:a5ab2af4d45fb8b97fdfd0b9ae633211884b0f1a765c8bae85b1d5aea257b1e0",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/GenericTestSuite.scala
+++ b/src/test/scala/strategies/GenericTestSuite.scala
@@ -30,7 +30,7 @@ class GenericTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      Gitoid(id),
+      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/strategies/GenericTestSuite.scala
+++ b/src/test/scala/strategies/GenericTestSuite.scala
@@ -21,6 +21,7 @@ import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.omnibor.strategies.GenericFile
 import io.spicelabs.goatrodeo.omnibor.strategies.GenericFileState
 import io.spicelabs.goatrodeo.util.ByteWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -29,7 +30,7 @@ class GenericTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -41,8 +41,7 @@ class MavenTestSuite extends munit.FunSuite {
 </project>"""
 
   def createTestItem(id: String): Item = {
-    Item(
-      Gitoid(id),
+    Item(      io.spicelabs.goatrodeo.test.GitoidFixtures.gitoidFor(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -227,16 +226,15 @@ class MavenTestSuite extends munit.FunSuite {
 
   test("MavenState.postChildProcessing - captures sources for Sources marker") {
     val storage = MemStorage(None)
-    val sourceItem = Item(
-      Gitoid("gitoid:blob:sha256:source123"),
+    val sourceItem = Item(      "gitoid:blob:sha256:66b242a56899be4c47f7825315f721c0401ccaeeb6410c16f8175678b3317459",
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("Source.java"), TreeSet(), 100, TreeMap()))
     )
-    storage.write(sourceItem.identifier(), _ => Some(sourceItem), _ => "")
+    storage.write(sourceItem.identifier, _ => Some(sourceItem), _ => "")
 
     val state = MavenState()
-    val kids = Some(Vector(sourceItem.identifier))
+    val kids: Some[Vector[Gitoid]] = Some(Vector(Gitoid(sourceItem.identifier)))
     val newState =
       state.postChildProcessing(kids, storage, MavenMarkers.Sources)
 

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -22,6 +22,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.MavenState
 import io.spicelabs.goatrodeo.omnibor.strategies.MavenToProcess
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import io.spicelabs.goatrodeo.util.Helpers
 
 import java.io.File
@@ -41,7 +42,7 @@ class MavenTestSuite extends munit.FunSuite {
 
   def createTestItem(id: String): Item = {
     Item(
-      id,
+      Gitoid(id),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(
@@ -227,12 +228,12 @@ class MavenTestSuite extends munit.FunSuite {
   test("MavenState.postChildProcessing - captures sources for Sources marker") {
     val storage = MemStorage(None)
     val sourceItem = Item(
-      "gitoid:blob:sha256:source123",
+      Gitoid("gitoid:blob:sha256:source123"),
       TreeSet(),
       Some(ItemMetaData.mimeType),
       Some(ItemMetaData(TreeSet("Source.java"), TreeSet(), 100, TreeMap()))
     )
-    storage.write(sourceItem.identifier, _ => Some(sourceItem), _ => "")
+    storage.write(sourceItem.identifier(), _ => Some(sourceItem), _ => "")
 
     val state = MavenState()
     val kids = Some(Vector(sourceItem.identifier))

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -196,7 +196,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
     * actually read the Item, but the signature requires one.
     */
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:pgp-property-test"),
+    identifier = "gitoid:blob:sha256:576b69f3080f6cb38372ca5b9e08fce957f5d00b0c1ff9e40029b74cccbac4af",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
@@ -195,7 +196,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
     * actually read the Item, but the signature requires one.
     */
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:pgp-property-test",
+    identifier = Gitoid("gitoid:blob:sha256:pgp-property-test"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -63,7 +63,7 @@ class PrivateKeyLogCaptureTests extends FunSuite {
   }
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase7-log-capture-stub"),
+    identifier = "gitoid:blob:sha256:dc88a2967453fc0e5270985c475b412dbf7f47a24432bb8cf5177441758bb0f5",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.FunSuite
 
 import java.io.File
@@ -62,7 +63,7 @@ class PrivateKeyLogCaptureTests extends FunSuite {
   }
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase7-log-capture-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase7-log-capture-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyPropertyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyPropertyTests.scala
@@ -7,6 +7,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.util.FileWrapper
+import io.spicelabs.goatrodeo.util.Gitoid
 import munit.ScalaCheckSuite
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
@@ -75,7 +76,7 @@ class PrivateKeyPropertyTests extends ScalaCheckSuite {
     FileWrapper(f, f.getName, None)
 
   private def stubItem(): Item = Item(
-    identifier = "gitoid:blob:sha256:phase7-prop-stub",
+    identifier = Gitoid("gitoid:blob:sha256:phase7-prop-stub"),
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyPropertyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyPropertyTests.scala
@@ -76,7 +76,7 @@ class PrivateKeyPropertyTests extends ScalaCheckSuite {
     FileWrapper(f, f.getName, None)
 
   private def stubItem(): Item = Item(
-    identifier = Gitoid("gitoid:blob:sha256:phase7-prop-stub"),
+    identifier = "gitoid:blob:sha256:d589945ab6586fdfdfc7c727c260e7dfe63f6520df3e5de4c1d88b470d9e6f28",
     connections = TreeSet.empty,
     bodyMimeType = Some(ItemMetaData.mimeType),
     body = Some(

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -640,9 +640,10 @@ class PrivateKeyStrategyTests extends FunSuite {
 
   private def stubItem(): io.spicelabs.goatrodeo.omnibor.Item = {
     import io.spicelabs.goatrodeo.omnibor.{Item, ItemMetaData}
+    import io.spicelabs.goatrodeo.util.Gitoid
     import scala.collection.immutable.{TreeMap, TreeSet}
     Item(
-      identifier = "gitoid:blob:sha256:phase7-test-stub",
+      identifier = Gitoid("gitoid:blob:sha256:phase7-test-stub"),
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -643,7 +643,7 @@ class PrivateKeyStrategyTests extends FunSuite {
     import io.spicelabs.goatrodeo.util.Gitoid
     import scala.collection.immutable.{TreeMap, TreeSet}
     Item(
-      identifier = Gitoid("gitoid:blob:sha256:phase7-test-stub"),
+      identifier = "gitoid:blob:sha256:1d8d5fa9ef663970b0e15351ea4a8c5f11a3011c1999dbb0c98c38ab0348acda",
       connections = TreeSet.empty,
       bodyMimeType = Some(ItemMetaData.mimeType),
       body = Some(


### PR DESCRIPTION
## Summary

Introduces opaque types for `Gitoid` and `PackageUrl`, replacing transparent `String` aliases that allowed any `String` to flow into positions expecting a gitoid or pURL. Three commits, in order:

- **Add more typesafety to Gitoids** — introduces `opaque type Gitoid = String`, with extension methods (`apply()`, `length`, `startsWith`, `isBlobSha256`) for the operations that were previously direct `String` calls. Borer codec is `Encoder.forString` / `Decoder.forString`, so the on-disk format is unchanged.
- **Use an efficient internal representation of `Gitoid`s** — switches the internal repr from `String` to `ArraySeq.ofByte` (hex bytes plus a one-byte kind/algo header), making many invalid gitoids unrepresentable and giving ~15% wall-clock on tests. The Borer codec is wrapped to keep emitting/parsing the canonical `gitoid:<type>:<algo>:<hex>` string form — **no wire-format change**, confirmed against the ADGTests corpus.
- **Make `PackageUrl`s typesafe (like `Gitoid`s)** — same treatment for `pkg:...` URLs: `opaque type PackageUrl = String` with construction validated by round-tripping through `com.github.packageurl.PackageURL`. Borer codec stays `Encoder.forString`.

## Provenance

These are exactly commits 7570977, 3e2fe6d, f338719 from the now-rejected `jon/performance-improvements` branch (PR #264), rebased onto the current `main`. The wire-format changes from that branch (Identifier, WireEdge, .gra sidecar v4, sorted .gri, etc.) and the storage/writer perf changes (ConcurrentHashMap, batched writes) are **not** included — only the three internal typesafety commits.

## Verification

- `sbt compile` clean.
- Full `sbt test` passes 1318/1327; the 9 X509 failures reproduce identically on `main` (pre-existing, unrelated to these changes).
- ADGTests output sizes match `main` byte-exactly: `.grd` 866,984,803 B, `.gri` 57,564,695 B, `purls.txt` 470,443 B. `purls.txt` is byte-identical content too. The `.grd`/`.gri` files differ across **any** two ADGTests runs (per-build randomness in goatrodeo itself), so a content-level diff isn't a usable check — file-size + functional-test equivalence is the strongest signal available.

## Test plan

- [ ] CI green on the branch
- [ ] Reviewer confirms scope is "typesafety only" — no behavioural changes to graph output