### PR TITLE
Replace sbt-git-versioning with hand-rolled version derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,38 @@ val projectName = "goatrodeo"
 val scala3Version = "3.8.3"
 
 ThisBuild / organization := "io.spicelabs"
-ThisBuild / version := "0.0.1-SNAPSHOT" // Don't change this, it is overridden by the GitHub Actions workflow
+
+// Derive `version` from git. Format follows what sbt-git-versioning used to
+// produce, since `BuildInfo.version` is consumed at runtime:
+//   - HEAD is on a release tag       → "0.15.5"            (or "0.15.5-dirty-SNAPSHOT")
+//   - HEAD is N commits past a tag   → "0.15.5-3-abc1234-SNAPSHOT" (+"-dirty" if dirty)
+//   - No tags / not in a git repo    → "0.0.0-SNAPSHOT"
+// Release builds in CI override this entirely via `sbt "set ThisBuild / version := ..."`.
+ThisBuild / version := {
+  val SemVer = """^v?(\d+)\.(\d+)\.(\d+)$""".r
+  def run(cmd: String): Vector[String] =
+    scala.util.Try(Process(cmd).lineStream.toVector).getOrElse(Vector.empty)
+
+  val dirty = run("git status --porcelain").nonEmpty
+  val headTags = run("git tag --points-at HEAD").collect {
+    case t @ SemVer(ma, mi, pa) => (t, ma.toInt, mi.toInt, pa.toInt)
+  }
+  if (headTags.nonEmpty) {
+    // HEAD is tagged. When multiple semver tags decorate it, pick the largest.
+    val chosen = headTags.maxBy { case (_, ma, mi, pa) => (ma, mi, pa) }._1.stripPrefix("v")
+    if (dirty) s"$chosen-dirty-SNAPSHOT" else chosen
+  } else {
+    val baseTag = run("git describe --tags --abbrev=0 --match=v[0-9]*").headOption
+      .orElse(run("git describe --tags --abbrev=0").headOption)
+      .getOrElse("v0.0.0")
+    val base = baseTag.stripPrefix("v")
+    val sha = run("git rev-parse --short HEAD").headOption.getOrElse("unknown")
+    val commits = run(s"git rev-list --count $baseTag..HEAD").headOption.getOrElse("0")
+    val dirtyTag = if (dirty) "-dirty" else ""
+    s"$base-$commits-$sha$dirtyTag-SNAPSHOT"
+  }
+}
+
 ThisBuild / licenses := Seq(
   "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")
 )
@@ -151,7 +182,6 @@ lazy val root = project
   .enablePlugins(
     BuildInfoPlugin,
     JavaAppPackaging,
-    GitVersioningPlugin,
     AssemblyPlugin
   )
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
-resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.8")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
-addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.6.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")

--- a/src/test/scala/FatJarContentsTest.scala
+++ b/src/test/scala/FatJarContentsTest.scala
@@ -20,7 +20,7 @@ class FatJarContentsTest extends munit.FunSuite {
 
   test("fat JAR must not contain signature files") {
     val fatJarFile =
-      new File(s"target/scala-3.8.3/goatrodeo-0.0.1-SNAPSHOT-fat.jar")
+      new File(s"target/scala-3.8.3/${hellogoat.BuildInfo.name}-${hellogoat.BuildInfo.version}-fat.jar")
     assert(
       fatJarFile.exists(),
       s"Fat JAR not found at ${fatJarFile.getAbsolutePath}"

--- a/src/test/scala/FatJarExecutionTest.scala
+++ b/src/test/scala/FatJarExecutionTest.scala
@@ -19,7 +19,7 @@ class FatJarExecutionTest extends munit.FunSuite {
 
   test("fat JAR must execute without SecurityException") {
     val fatJarFile =
-      new File(s"target/scala-3.8.3/goatrodeo-0.0.1-SNAPSHOT-fat.jar")
+      new File(s"target/scala-3.8.3/${hellogoat.BuildInfo.name}-${hellogoat.BuildInfo.version}-fat.jar")
     assert(
       fatJarFile.exists(),
       s"Fat JAR not found at ${fatJarFile.getAbsolutePath}"


### PR DESCRIPTION
## Summary

Goat Rodeo was refusing to build because it wanted to read a tag for the current commit to use as the local version number, but had a choice of three. This will happen whenever the same commit is tagged more than once, which is often going to happen during complex deployments of multiple components.

This drops the `sbt-git-versioning` plugin (and its bintray resolver) in favour of a manual `ThisBuild / version` block in `build.sbt` that reads tags directly from git.

## Why

The plugin's `branchState` asserts that the two most-recent release-tagged commits are distinct, and **throws on project load** when one commit carries more than one release tag. We hit that on `main` when commit `6a8d38f` was simultaneously tagged `v0.15.3`, `v0.15.4`, and `v0.15.5` — sbt couldn't even reach `compile`.

The plugin's only contribution to this build was a more informative *local* SNAPSHOT version string (`0.15.5-N-sha-SNAPSHOT` vs the static `0.0.1-SNAPSHOT` that was on line 8). Release builds set the version explicitly in CI via `sbt "set ThisBuild / version := \"<tag>\""` (see `.github/workflows/publish.yml:62-66`) — the plugin never participated in those.

## What

- `project/plugins.sbt`: drop `sbt-git-versioning` and the `rallyhealth` bintray resolver it required.
- `build.sbt`: remove `GitVersioningPlugin` from `.enablePlugins(...)`, replace the hardcoded `"0.0.1-SNAPSHOT"` with a derivation that:
  - When HEAD is on one or more semver tags, picks the **largest** as the release version (e.g. `0.15.5`).
  - When HEAD is N commits past the last reachable tag, produces `<base>-<N>-<sha>-SNAPSHOT`.
  - Appends `-dirty` when the working tree has uncommitted changes.
  - Falls back to `0.0.0-SNAPSHOT` if not in a git checkout (e.g. release tarball builds).

## Behaviour verified locally

| State                              | Computed version                          |
| ---------------------------------- | ----------------------------------------- |
| HEAD has 3 release tags (the bug)  | `99.0.2-dirty-SNAPSHOT` (largest picked)  |
| HEAD has one tag                   | `0.15.5-dirty-SNAPSHOT`                   |
| HEAD has no tag                    | `0.15.2-2-6a8d38f-dirty-SNAPSHOT`         |
| CI's explicit `set ThisBuild / version := "1.2.3"` | `1.2.3` (override path intact) |

(The `-dirty` shown above is from local working-tree changes during testing; format is correct.)

## Test plan

- [ ] CI green on the branch
- [ ] Confirm `BuildInfo.version` (consumed at runtime in `Main.scala`, `Config.scala`, `GraphManager.scala`) still reads as expected
- [ ] After merge: confirm the next release build sets the right `pkg:maven/io.spicelabs/goatrodeo@<version>` coordinates