### PR TITLE
Upgrade actions/checkout and pin runner for Node.js 24 Compatibility

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout with LFS
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         lfs: true
     - name: Free up disk space on the runner

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Checkout with LFS
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -84,7 +84,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -179,7 +179,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Fat JAR from GitHub Packages
         env:
@@ -235,7 +235,7 @@ jobs:
   notify:
     needs: [publish-jars, publish-to-central, docker-image]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Summary

Updates both CI workflows to resolve Node.js 20 deprecation warnings on GitHub
Actions runners. `actions/checkout` has been updated to v5 across all jobs in
both files, and the unpinned `ubuntu-latest` runner in the `notify` job has
been locked to `ubuntu-24.04`, ahead of the June 16th enforcement date.

### Changes

- Updated `actions/checkout` from `@v4` to `@v5` in `build_test.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in the `publish-jars` job
  in `publish.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in the `publish-to-central`
  job in `publish.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in the `docker-image` job
  in `publish.yml`
- Pinned `runs-on` from `ubuntu-latest` to `ubuntu-24.04` on the `notify` job
  in `publish.yml`

### Tests

- Push to any branch and confirm the `Scala Build & Test` job completes
  successfully, including the disk space cleanup, JDK 21 setup, and `sbt test`
- Publish a release with a semver tag (e.g. `v1.2.3`) and confirm all four
  jobs complete successfully:
  - `publish-jars`: SBT JAR publish to GitHub Packages and ADG upload
  - `publish-to-central`: artifact download, pom injection, and Maven Central
    staging deploy
  - `docker-image`: multi-platform Docker build and push to Docker Hub with
    SBOM and ADG upload
  - `notify`: correct Slack thread reply on both success and failure

### Impact

No change to build, test, or publish behaviour. All runners in `build_test.yml`
and `publish.yml` (except `notify`) were already correctly pinned to
`ubuntu-24.04`. All other actions (`actions/setup-java@v4`, `sbt/setup-sbt@v1`,
`docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`,
`docker/metadata-action@v5`, `docker/login-action@v3`,
`docker/build-push-action@v6`) required no changes.

### Ticket

- https://github.com/spice-labs-inc/internal-docs/issues/509