### PR TITLE
perf: skip MIME augmenters for terminal types & avoid Saffron temp-file spill

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/util/ArtifactWrapper.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ArtifactWrapper.scala
@@ -207,15 +207,41 @@ object ArtifactWrapper {
       : AtomicReference[Vector[(ArtifactWrapper, Set[String]) => Set[String]]] =
     AtomicReference(Vector())
 
+  /** MIME types that are confidently terminal for the purpose of augmentation:
+    * none of the registered augmenters (.NET PE, VM disk image, crypto
+    * material) can ever apply to them. When Tika has already produced one of
+    * these we skip the whole augmenter chain, which avoids per-artifact stream
+    * reads and — crucially — SaffronDetector spilling in-memory artifacts to a
+    * temp file just to rule them out.
+    *
+    * Deliberately excludes text-prefixed and `application/octet-stream` types:
+    * SaffronDetector intentionally re-checks those (e.g. a `.vhd` that Tika
+    * misdetects as `text/x-vhdl`).
+    */
+  private lazy val terminalBinaryMimeTypes: Set[String] =
+    Helpers.javaClassMimeTypes ++ Set(
+      "application/zip",
+      "application/java-archive",
+      "application/vnd.android.package-archive"
+    )
+
+  private def augmentationCannotApply(mimes: Set[String]): Boolean =
+    mimes.exists(m =>
+      m.startsWith("image/") || m.startsWith("audio/") ||
+        m.startsWith("video/") || terminalBinaryMimeTypes.contains(m)
+    )
+
   /** Augment the mime type with other mime types
     */
   def augmentMimeTypes(
       artifact: ArtifactWrapper,
       mimes: Set[String]
   ): Set[String] = {
-    mimeTypeAugmenters.get().foldLeft(mimes) { case (cur, theFn) =>
-      theFn(artifact, cur)
-    }
+    if (augmentationCannotApply(mimes)) mimes
+    else
+      mimeTypeAugmenters.get().foldLeft(mimes) { case (cur, theFn) =>
+        theFn(artifact, cur)
+      }
   }
 
   def addMimeTypeAugmenter(

--- a/src/main/scala/io/spicelabs/goatrodeo/util/SaffronDetector.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/SaffronDetector.scala
@@ -6,6 +6,15 @@ import scala.jdk.OptionConverters.RichOptional
 import scala.util.Try
 
 object SaffronDetector {
+  /** VM disk images are large files, and probing one requires a path. For an
+    * in-memory artifact, `withFile` spills the entire artifact to a temp file
+    * just to read a header — wasteful when run on every artifact (e.g. each
+    * class file extracted from a JAR). Below this size an in-memory artifact is
+    * never a disk image, so we skip the probe (and the spill). Real files on
+    * disk are cheap to probe and are always checked.
+    */
+  val minInMemoryProbeSize: Long = 1L * 1024 * 1024
+
   // detect if an artifact wrapper is a mime type known to saffron
   private def readFormat(artifact: ArtifactWrapper): Set[String] = {
     artifact.withFile(file => {
@@ -19,6 +28,11 @@ object SaffronDetector {
       artifact: ArtifactWrapper,
       currentMimes: Set[String]
   ): Set[String] = {
+    // Avoid spilling small in-memory artifacts to a temp file just to rule out
+    // a disk image they cannot be.
+    if (!artifact.isRealFile() && artifact.size() < minInMemoryProbeSize)
+      return currentMimes
+
     val myMimes = readFormat(artifact)
     // why the conditional?
     // an empty set indicates that this augmentinator should absolutely do nothing to the


### PR DESCRIPTION
## Skip MIME augmenters for terminal types and avoid Saffron temp-file spill

Skips the entire MIME augmenter chain when Tika returns a confidently-terminal type
(Java class, zip/jar/archive, `image/*`, `audio/*`, `video/*`), and avoids the
SaffronDetector temp-file spill probe for in-memory artifacts under 1 MB (disk images
are always larger). Real files are still probed directly. This eliminates thousands of
write+delete temp-file cycles for class-heavy JARs.

Files: `util/ArtifactWrapper.scala`, `util/SaffronDetector.scala` (+43/-3).

### Benchmark results

The strongest of the optimizations measured. Improves the I/O-independent processing
loop (`cpuloop`) by **8.4%–12.1%** across the three repeated benchmark trials
(DE-disk n=3: −11.1%, BE n=3: −12.1%, XYZ n=5: −8.4%), versus baseline. Wall-clock
duration improved ~7–10% on the repeated runs with very low variance.

### Stacking

Base of a 3-PR stack: `perf/skip-mime` (this, base `main`) ← `perf/bcel-to-asm` ← `perf/file-discovery`.
