### PR TITLE
perf: speed up file discovery/dispatch for very large top-level file sets

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -713,15 +713,9 @@ object ToProcess {
     }*)
 
     if (infoMsgs_?) logger.debug("Built UUID map")
-    // and by name for lookup
-    val byName: ByName =
-      artifacts.foldLeft(Map()) { case (map, wrapper) =>
-        val v = map.get(wrapper.filenameWithNoPath) match {
-          case None    => Vector()
-          case Some(v) => v
-        }
-        map + (wrapper.filenameWithNoPath -> (v :+ wrapper))
-      }
+    // and by name for lookup. groupBy preserves per-key insertion order and
+    // avoids the O(n) immutable-map/vector rebuilds of a foldLeft + `:+`.
+    val byName: ByName = artifacts.groupBy(_.filenameWithNoPath)
 
     if (infoMsgs_?)
       logger.debug("Finished setting up files for per-ecosystem specialization")
@@ -772,9 +766,16 @@ object ToProcess {
         val allFiles: Vector[ArtifactWrapper] =
           (for {
             (root, fl) <- fileListers
-            basePath = root.getCanonicalPath()
+            // Use absolute + lexically-normalized paths rather than
+            // getCanonicalPath(): canonicalization resolves symlinks against the
+            // filesystem (a syscall per file, costly across very large file
+            // sets), whereas toAbsolutePath()/normalize() are pure path ops.
+            // Symlinks are intentionally not resolved.
+            basePath = root.toPath().toAbsolutePath().normalize().toString()
             basePathLen = basePath.length()
-            file <- fl().par if file.exists() && file.isFile() && !file
+            // isFile() already implies exists() (it is true only for an existing
+            // regular file), so a separate exists() stat is redundant.
+            file <- fl().par if file.isFile() && !file
               .getName()
               .startsWith(".") && !ignorePathList.contains(file.getPath()) && {
               val name = file.getName()
@@ -784,9 +785,9 @@ object ToProcess {
           } yield FileWrapper(
             file,
             if (fsFilePaths) {
-              val cp = file.getCanonicalPath()
-              if (cp.startsWith(basePath)) cp.substring(basePathLen + 1)
-              else cp.substring(1)
+              val ap = file.toPath().toAbsolutePath().normalize().toString()
+              if (ap.startsWith(basePath)) ap.substring(basePathLen + 1)
+              else ap.substring(1)
             } else file.getName(),
             tempDir,
             finishedFile


### PR DESCRIPTION
## Speed up file discovery/dispatch for very large top-level file sets

Optimizes the top-level file walk in `ToProcess`: drops the redundant `file.exists()`
check (`isFile()` already implies it), replaces `getCanonicalPath()` (which resolves
symlinks via syscalls) with pure `toAbsolutePath()/normalize()` path operations, and
builds the by-name map with `groupBy()` instead of repeated `foldLeft` map/vector rebuilds.

Files: `omnibor/ToProcess.scala` (+15/-14).

### Benchmark results

A small, low-risk improvement. Improves the processing loop (`cpuloop`) by **1.0%–5.7%**
across the three repeated benchmark trials (DE-disk n=3: −5.7%, BE n=3: −1.0%,
XYZ n=5: −2.3%), versus baseline. Caveat: the gain is the most modest and least
consistent of the three — on the BE dataset wall-clock duration was roughly flat to
slightly slower (~+1.7%), so the benefit is concentrated on the larger corpora.

### Stacking

Top of a 3-PR stack — **base branch: `perf/bcel-to-asm`**. Review/merge after the other two.
