### PR TITLE
Use the coordinates library for hashes and purls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,9 @@ lazy val root = project
     libraryDependencies += "org.apache.tika" % "tika-core" % "3.2.3",
     libraryDependencies += "com.github.package-url" % "packageurl-java" % "1.5.0",
     libraryDependencies += "io.spicelabs" %% "cilantro" % "0.1.17",
+    // Canonical content identifiers (hashes + git blob ids) — the single source of
+    // truth shared across Spice Labs tooling. Resolved from `Resolver.mavenLocal`.
+    libraryDependencies += "io.spicelabs" % "coordinates" % "1.1.0",
     libraryDependencies += "com.github.dwickern" %% "scala-nameof" % "5.0.0" % "provided",
 
     // Spice Labs "readers"

--- a/build.sbt
+++ b/build.sbt
@@ -204,6 +204,8 @@ lazy val root = project
     libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     libraryDependencies += "org.apache.tika" % "tika-core" % "3.2.3",
+    // Still required at the boundary: the annatto/baharat readers hand back
+    // com.github.packageurl.PackageURL, which we convert to coordinates.Purl.
     libraryDependencies += "com.github.package-url" % "packageurl-java" % "1.5.0",
     libraryDependencies += "io.spicelabs" %% "cilantro" % "0.1.17",
     // Canonical content identifiers (hashes + git blob ids) — the single source of

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.util.Helpers
 
 import scala.collection.immutable.TreeMap
@@ -67,7 +67,7 @@ final case class TopLevelExtraAugmentation(
 final case class ConnectionAugmentation(
     hashValue: String,
     connection: (String, String),
-    pURL: PackageURL
+    pURL: Purl
 ) extends Augmentation {
   def augment(item: Item, store: Storage): Item = {
     store.addPurl(pURL)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Augmentation.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.util.Helpers
 
 import scala.collection.immutable.TreeMap
@@ -67,7 +66,7 @@ final case class TopLevelExtraAugmentation(
 final case class ConnectionAugmentation(
     hashValue: String,
     connection: (String, String),
-    pURL: Purl
+    pURL: String
 ) extends Augmentation {
   def augment(item: Item, store: Storage): Item = {
     store.addPurl(pURL)

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Cbor
 import io.bullet.borer.Decoder
@@ -261,21 +260,21 @@ case class Item(
 
   }
 
-  /** Given an `Item`, enhance it with Purls
+  /** Given an `Item`, enhance it with purls
     *
     * @param purls
-    *   the Purls
+    *   the canonical purl strings
     * @param fileNames
     *   the filenames associated with this Item
     *
     * @return
     *   the enhanced `Item`
     */
-  def enhanceItemWithPurls(purls: Seq[Purl]): Item = {
+  def enhanceItemWithPurls(purls: Seq[String]): Item = {
     if (purls.isEmpty) this
     else {
 
-      val textPurls = purls.map(p => p.toCanonical())
+      val textPurls = purls
       val ret = this.copy(
         connections = this.connections ++ TreeSet(
           textPurls.map(purl => EdgeType.aliasFrom -> purl)*

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Cbor
 import io.bullet.borer.Decoder
@@ -261,21 +261,21 @@ case class Item(
 
   }
 
-  /** Given an `Item`, enhance it with PackageURLs
+  /** Given an `Item`, enhance it with Purls
     *
     * @param purls
-    *   the PackageURLs
+    *   the Purls
     * @param fileNames
     *   the filenames associated with this Item
     *
     * @return
     *   the enhanced `Item`
     */
-  def enhanceItemWithPurls(purls: Seq[PackageURL]): Item = {
+  def enhanceItemWithPurls(purls: Seq[Purl]): Item = {
     if (purls.isEmpty) this
     else {
 
-      val textPurls = purls.map(p => p.canonicalize())
+      val textPurls = purls.map(p => p.toCanonical())
       val ret = this.copy(
         connections = this.connections ++ TreeSet(
           textPurls.map(purl => EdgeType.aliasFrom -> purl)*

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -14,7 +14,6 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.GitOID
@@ -99,11 +98,11 @@ trait Storage {
 
   def destDirectory(): Option[File]
 
-  /** The endpoint for sending package URLs
+  /** The endpoint for sending package URLs (already in canonical form)
     *
     * @param purl
     */
-  def addPurl(purl: Purl): Unit
+  def addPurl(purl: String): Unit
 
   /** Get the purls
     *
@@ -242,9 +241,9 @@ class MemStorage(val targetDir: Option[File])
     *
     * @param purl
     */
-  def addPurl(purl: Purl): Unit = {
+  def addPurl(purl: String): Unit = {
     thePurls.synchronized {
-      val next = thePurls.get() + purl.toCanonical()
+      val next = thePurls.get() + purl
       thePurls.set(next)
     }
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Storage.scala
@@ -14,7 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.GitOID
@@ -103,7 +103,7 @@ trait Storage {
     *
     * @param purl
     */
-  def addPurl(purl: PackageURL): Unit
+  def addPurl(purl: Purl): Unit
 
   /** Get the purls
     *
@@ -242,9 +242,9 @@ class MemStorage(val targetDir: Option[File])
     *
     * @param purl
     */
-  def addPurl(purl: PackageURL): Unit = {
+  def addPurl(purl: Purl): Unit = {
     thePurls.synchronized {
-      val next = thePurls.get() + purl.canonicalize()
+      val next = thePurls.get() + purl.toCanonical()
       thePurls.set(next)
     }
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.strategies.*
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
@@ -75,7 +75,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       artifact: ArtifactWrapper,
       item: Item,
       marker: PM
-  ): (Vector[PackageURL], ME)
+  ): (Vector[Purl], ME)
 
   /** Get the `extra` information for the artifact
     *
@@ -167,7 +167,7 @@ abstract class ParentScope(
       store: Storage,
       artifact: ArtifactWrapper,
       item: Item,
-      purls: Vector[PackageURL]
+      purls: Vector[Purl]
   ): Item = item
   def enhanceWithMetadata(
       store: Storage,
@@ -853,7 +853,7 @@ object ToProcess {
       toProcess: Vector[ToProcess],
       store: Storage = MemStorage(None),
       args: Config,
-      purlOut: PackageURL => Unit = _ => (),
+      purlOut: Purl => Unit = _ => (),
       block: Set[GitOID] = Set()
   ): Storage = {
 
@@ -894,7 +894,7 @@ object ToProcess {
       artifact: ArtifactWrapper,
       args: Config,
       store: Storage = MemStorage(None),
-      purlOut: PackageURL => Unit = _ => (),
+      purlOut: Purl => Unit = _ => (),
       block: Set[GitOID] = Set()
   ): Storage = {
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.strategies.*
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
@@ -75,7 +74,7 @@ trait ProcessingState[PM <: ProcessingMarker, ME <: ProcessingState[PM, ME]] {
       artifact: ArtifactWrapper,
       item: Item,
       marker: PM
-  ): (Vector[Purl], ME)
+  ): (Vector[String], ME)
 
   /** Get the `extra` information for the artifact
     *
@@ -167,7 +166,7 @@ abstract class ParentScope(
       store: Storage,
       artifact: ArtifactWrapper,
       item: Item,
-      purls: Vector[Purl]
+      purls: Vector[String]
   ): Item = item
   def enhanceWithMetadata(
       store: Storage,
@@ -853,7 +852,7 @@ object ToProcess {
       toProcess: Vector[ToProcess],
       store: Storage = MemStorage(None),
       args: Config,
-      purlOut: Purl => Unit = _ => (),
+      purlOut: String => Unit = _ => (),
       block: Set[GitOID] = Set()
   ): Storage = {
 
@@ -894,7 +893,7 @@ object ToProcess {
       artifact: ArtifactWrapper,
       args: Config,
       store: Storage = MemStorage(None),
-      purlOut: Purl => Unit = _ => (),
+      purlOut: String => Unit = _ => (),
       block: Set[GitOID] = Set()
   ): Storage = {
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.annatto.Ecosystem
 import io.spicelabs.annatto.EcosystemRouter
 import io.spicelabs.annatto.LanguagePackage
@@ -92,14 +91,11 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[Purl], AnnattoState) = {
-    // annatto returns a com.github.packageurl.PackageURL; convert to the
-    // canonical coordinates.Purl by reparsing its canonical form.
-    pkg
-      .toPurl()
-      .toScala
-      .toVector
-      .map(p => Purl.parse(p.canonicalize()).nn) -> this
+  ): (Vector[String], AnnattoState) = {
+    // annatto returns a com.github.packageurl.PackageURL; emit its own canonical
+    // form. We keep the reader's canonicalization rather than re-validating
+    // through coordinates, which is stricter than what some readers produce.
+    pkg.toPurl().toScala.toVector.map(_.canonicalize().nn) -> this
   }
 
   override def getMetadata(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Annatto.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.annatto.Ecosystem
 import io.spicelabs.annatto.EcosystemRouter
 import io.spicelabs.annatto.LanguagePackage
@@ -92,8 +92,14 @@ class AnnattoState(artifact: ArtifactWrapper, pkg: LanguagePackage)
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[PackageURL], AnnattoState) = {
-    pkg.toPurl().toScala.toVector -> this
+  ): (Vector[Purl], AnnattoState) = {
+    // annatto returns a com.github.packageurl.PackageURL; convert to the
+    // canonical coordinates.Purl by reparsing its canonical form.
+    pkg
+      .toPurl()
+      .toScala
+      .toVector
+      .map(p => Purl.parse(p.canonicalize()).nn) -> this
   }
 
   override def getMetadata(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.baharat.Package
 import io.spicelabs.baharat.PackageReader
@@ -123,10 +122,11 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[Purl], BaharatState) = {
-    // baharat returns a com.github.packageurl.PackageURL; convert to the
-    // canonical coordinates.Purl by reparsing its canonical form.
-    Vector(Purl.parse(pkg.packageUrl().canonicalize()).nn) -> this
+  ): (Vector[String], BaharatState) = {
+    // baharat returns a com.github.packageurl.PackageURL; emit its own canonical
+    // form. We keep the reader's canonicalization rather than re-validating
+    // through coordinates, which is stricter than what some readers produce.
+    Vector(pkg.packageUrl().canonicalize().nn) -> this
   }
 
   override def getMetadata(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Baharat.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.baharat.Package
 import io.spicelabs.baharat.PackageReader
@@ -123,8 +123,10 @@ class BaharatState(artifact: ArtifactWrapper, pkg: Package)
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[PackageURL], BaharatState) = {
-    Vector(pkg.packageUrl()) -> this
+  ): (Vector[Purl], BaharatState) = {
+    // baharat returns a com.github.packageurl.PackageURL; convert to the
+    // canonical coordinates.Purl by reparsing its canonical form.
+    Vector(Purl.parse(pkg.packageUrl().canonicalize()).nn) -> this
   }
 
   override def getMetadata(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Certificates.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Certificates.scala
@@ -14,8 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
-import com.github.packageurl.PackageURLBuilder
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.SingleMarker
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.omnibor.ToProcess
@@ -25,6 +24,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.CertificatesOidMaps.*
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.Helpers.sha256Hex
+import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.SshWireReader
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
@@ -977,20 +977,19 @@ object Certificates {
   /** Build the pkg:generic/pgp/fingerprint@{hex}?... pURL for a PGP key. */
   private[strategies] def purlForPgpKey(
       key: PgpKey
-  ): PackageURL = {
+  ): Purl = {
     val parts = Vector(
       KVPair("alg", key.canonicalAlg),
       KVPair("version", key.version.toString())
     ) ++ key.keySize.toVector.map(s => KVPair("size", s.toString())) ++
       key.curve.toVector.map(c => KVPair("curve", c))
-    val builder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("pgp")
-      .withName("fingerprint")
-      .withVersion(key.fingerprintHex)
-    parts.foreach(q => builder.withQualifier(q.key, q.value))
-    builder.build()
+    PURLHelpers.purl(
+      `type` = "generic",
+      name = "fingerprint",
+      namespace = "pgp",
+      version = key.fingerprintHex,
+      qualifiers = parts.map(q => q.key -> q.value)
+    )
   }
 
   /** First 8 hex chars of the key fingerprint. */
@@ -1754,7 +1753,7 @@ object Certificates {
   /** Emit the (spki, cert) pURL pair for a single X.509 cert. */
   private[strategies] def purlsForCert(
       c: X509Certificate
-  ): Vector[PackageURL] = {
+  ): Vector[Purl] = {
     val derBytes = c.getEncoded
     val spkiBytes = spkiBytesFromCert(c)
     val certSha = sha256Hex(derBytes)
@@ -1780,24 +1779,21 @@ object Certificates {
       KVPair(s"self-signed", selfSigned.toString()),
       KVPair(s"version", version.toString())
     ) ++ companion
-    val spkiBuilder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("x509")
-      .withName("spki-sha256")
-      .withVersion(spkiSha)
-    spkiQuals.foreach(q => spkiBuilder.withQualifier(q.key, q.value))
-
-    val certBuilder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("x509")
-      .withName("cert-sha256")
-      .withVersion(certSha)
-    certQuals.foreach(q => certBuilder.withQualifier(q.key, q.value))
     Vector(
-      spkiBuilder.build(),
-      certBuilder.build()
+      PURLHelpers.purl(
+        `type` = "generic",
+        name = "spki-sha256",
+        namespace = "x509",
+        version = spkiSha,
+        qualifiers = spkiQuals.map(q => q.key -> q.value)
+      ),
+      PURLHelpers.purl(
+        `type` = "generic",
+        name = "cert-sha256",
+        namespace = "x509",
+        version = certSha,
+        qualifiers = certQuals.map(q => q.key -> q.value)
+      )
     )
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
@@ -61,7 +61,7 @@ class CertificatesState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[Purl], CertificatesState) = {
+  ): (Vector[String], CertificatesState) = {
     import Certificates.*
     val purls: Vector[Purl] = claim match {
       case None                => Vector.empty
@@ -89,7 +89,7 @@ class CertificatesState(
       case Some(_: PrivateKeyEncrypted) =>
         Vector.empty // envelope-only; no pURL
     }
-    purls -> this
+    purls.map(_.toCanonical().nn) -> this
   }
 
   /** Unencrypted-PEM private key → SPKI pURL. */

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/CertificatesState.scala
@@ -14,8 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
-import com.github.packageurl.PackageURLBuilder
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.MetadataKeyConstants as MKC
 import io.spicelabs.goatrodeo.omnibor.ParentScope
@@ -27,6 +26,7 @@ import io.spicelabs.goatrodeo.omnibor.strategies.Certificates.KVPair
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers.sha256Hex
+import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 
 import java.security.KeyStore
@@ -61,15 +61,15 @@ class CertificatesState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[PackageURL], CertificatesState) = {
+  ): (Vector[Purl], CertificatesState) = {
     import Certificates.*
-    val purls: Vector[PackageURL] = claim match {
+    val purls: Vector[Purl] = claim match {
       case None                => Vector.empty
       case Some(SingleCert(c)) => purlsForCert(c)
       case Some(Bundle(certs)) =>
-        certs.flatMap(purlsForCert).distinctBy(_.canonicalize())
+        certs.flatMap(purlsForCert).distinctBy(_.toCanonical())
       case Some(ks @ Keystore(Some(keystore), _, _)) =>
-        ksAllCerts(keystore).flatMap(purlsForCert).distinctBy(_.canonicalize())
+        ksAllCerts(keystore).flatMap(purlsForCert).distinctBy(_.toCanonical())
       case Some(Keystore(None, _, _)) =>
         Vector.empty // encrypted → envelope-only; no pURLs
       case Some(Crl(crl)) =>
@@ -79,13 +79,13 @@ class CertificatesState(
       case Some(c: SshCert) =>
         purlsForSshCert(c)
       case Some(r: PgpKeyRing) =>
-        r.keys.map(purlForPgpKey).distinctBy(_.canonicalize())
+        r.keys.map(purlForPgpKey).distinctBy(_.toCanonical())
       case Some(p: PrivateKeyPlaintextPem) =>
         Vector(purlForPrivateKeyPem(p))
       case Some(p: PrivateKeyPlaintextOpenSsh) =>
         Vector(purlForPrivateKeyOpenSsh(p))
       case Some(p: PrivateKeyPlaintextPgp) =>
-        p.ring.keys.map(purlForPgpKey).distinctBy(_.canonicalize())
+        p.ring.keys.map(purlForPgpKey).distinctBy(_.toCanonical())
       case Some(_: PrivateKeyEncrypted) =>
         Vector.empty // envelope-only; no pURL
     }
@@ -95,7 +95,7 @@ class CertificatesState(
   /** Unencrypted-PEM private key → SPKI pURL. */
   private[strategies] def purlForPrivateKeyPem(
       p: Certificates.PrivateKeyPlaintextPem
-  ): PackageURL = {
+  ): Purl = {
     val spkiSha = sha256Hex(p.spkiBytes)
     val parts =
       Vector(KVPair("alg", p.canonicalAlg)) ++ p.keySize.toVector.map(s =>
@@ -104,67 +104,62 @@ class CertificatesState(
         p.curve.toVector.map(c => KVPair("curve", c)) ++ p.params.toVector.map(
           p => KVPair("params", p)
         )
-    val builder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("x509")
-      .withName("spki-sha256")
-      .withVersion(spkiSha)
-
-    parts.foreach(p => builder.withQualifier(p.key, p.value))
-
-    builder.build()
+    PURLHelpers.purl(
+      `type` = "generic",
+      name = "spki-sha256",
+      namespace = "x509",
+      version = spkiSha,
+      qualifiers = parts.map(p => p.key -> p.value)
+    )
   }
 
   /** Unencrypted-OpenSSH private key → SSH pURL. */
   private[strategies] def purlForPrivateKeyOpenSsh(
       p: Certificates.PrivateKeyPlaintextOpenSsh
-  ): PackageURL = {
+  ): Purl = {
     import Certificates.*
     val fp = sshFingerprintB64(p.wireBytes)
     val quals = sshKeyQualifiers(p.algName, p.rsaModulusBits)
-    val builder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("ssh")
-      .withName("sha256")
-      .withVersion(fp)
-    quals.foreach(q => builder.withQualifier(q.key, q.value))
-    builder.build()
+    PURLHelpers.purl(
+      `type` = "generic",
+      name = "sha256",
+      namespace = "ssh",
+      version = fp,
+      qualifiers = quals.map(q => q.key -> q.value)
+    )
   }
 
   /** `pkg:generic/ssh/sha256@{b64}?alg=...&{companion}` */
   private[strategies] def purlForSshPubkey(
       p: Certificates.SshPubkey
-  ): PackageURL = {
+  ): Purl = {
     import Certificates.*
     val fp = sshFingerprintB64(p.wireBytes)
     val quals = sshKeyQualifiers(p.algName, p.rsaModulusBits)
-    val builder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("ssh")
-      .withName("sha256")
-      .withVersion(fp)
-    quals.foreach(q => builder.withQualifier(q.key, q.value))
-    builder.build()
+    PURLHelpers.purl(
+      `type` = "generic",
+      name = "sha256",
+      namespace = "ssh",
+      version = fp,
+      qualifiers = quals.map(q => q.key -> q.value)
+    )
   }
 
   /** SSH cert pURLs: cert-sha256 + sha256 (signed-key fingerprint). */
   private[strategies] def purlsForSshCert(
       c: Certificates.SshCert
-  ): Vector[PackageURL] = {
+  ): Vector[Purl] = {
     import Certificates.*
     val certHex = sha256Hex(c.certBytes)
     val signedKeyFp = sshFingerprintB64(c.signedKeyWire)
     val keyQuals = sshKeyQualifiers(c.signedKeyAlgName, c.rsaModulusBits)
-    val keyBuilder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("ssh")
-      .withName("sha256")
-      .withVersion(signedKeyFp)
-    keyQuals.foreach(q => keyBuilder.withQualifier(q.key, q.value))
+    val keyPurl = PURLHelpers.purl(
+      `type` = "generic",
+      name = "sha256",
+      namespace = "ssh",
+      version = signedKeyFp,
+      qualifiers = keyQuals.map(q => q.key -> q.value)
+    )
 
     val certTypeLabel = c.certType match {
       case 1L    => "user"
@@ -176,16 +171,15 @@ class CertificatesState(
       KVPair("sig-alg", c.caSigAlgName)
     ))
 
-    val certBuilder = PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("ssh")
-      .withName("cert-sha256")
-      .withVersion(certHex)
+    val certPurl = PURLHelpers.purl(
+      `type` = "generic",
+      name = "cert-sha256",
+      namespace = "ssh",
+      version = certHex,
+      qualifiers = certQuals.map(cq => cq.key -> cq.value)
+    )
 
-    certQuals.foreach(cq => certBuilder.withQualifier(cq.key, cq.value))
-
-    Vector(certBuilder.build(), keyBuilder.build())
+    Vector(certPurl, keyPurl)
   }
 
   /** Extract every X.509 cert from a loaded keystore, including key-entry chain
@@ -216,20 +210,19 @@ class CertificatesState(
   }
 
   /** Build the single CRL pURL. */
-  private[strategies] def purlForCrl(crl: X509CRL): PackageURL = {
+  private[strategies] def purlForCrl(crl: X509CRL): Purl = {
     import Certificates.*
     val derBytes = crl.getEncoded
     val crlSha = sha256Hex(derBytes)
     val sigAlg = canonicalSigAlgCrl(crl)
 
-    PackageURLBuilder
-      .aPackageURL()
-      .withType("generic")
-      .withNamespace("x509")
-      .withName("crl-sha256")
-      .withVersion(crlSha)
-      .withQualifier("sig-alg", sigAlg)
-      .build()
+    PURLHelpers.purl(
+      `type` = "generic",
+      name = "crl-sha256",
+      namespace = "x509",
+      version = crlSha,
+      qualifiers = Seq("sig-alg" -> sigAlg)
+    )
 
   }
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -1,8 +1,7 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
-import com.github.packageurl.PackageURLBuilder
 import com.typesafe.scalalogging.Logger
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
@@ -16,6 +15,7 @@ import io.spicelabs.goatrodeo.omnibor.ToProcess.ByName
 import io.spicelabs.goatrodeo.omnibor.ToProcess.ByUUID
 import io.spicelabs.goatrodeo.util.ArtifactWrapper
 import io.spicelabs.goatrodeo.util.GitOID
+import io.spicelabs.goatrodeo.util.PURLHelpers
 import org.json4s.*
 import org.json4s.native.JsonMethods.*
 
@@ -70,7 +70,7 @@ case class DockerState(
     case _ => this
   }
 
-  private def computePurls(info: ManifestInfo): Vector[PackageURL] = {
+  private def computePurls(info: ManifestInfo): Vector[Purl] = {
     val purls = for {
       // get "RepoTags" which should be an Array of tags
       case JArray(tags) <- info.manifestConfig \ "RepoTags"
@@ -98,22 +98,12 @@ case class DockerState(
 
       // construct a Docker Package URL based on the pURL examples
       // https://github.com/package-url/purl-spec?tab=readme-ov-file#some-purl-examples
-      val withName = PackageURLBuilder
-        .aPackageURL()
-        .withType("docker")
-        .withName(path)
-
-      val withVersion = version match {
-        case Some(v) => withName.withVersion(v)
-        case None    => withName
-      }
-
-      val withNamespace = namespace match {
-        case Some(ns) => withVersion.withNamespace(ns)
-        case None     => withVersion
-      }
-
-      withNamespace.build()
+      PURLHelpers.purl(
+        `type` = "docker",
+        name = path,
+        namespace = namespace.orNull,
+        version = version.orNull
+      )
     }
 
     purls.toVector
@@ -123,7 +113,7 @@ case class DockerState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: DockerMarkers
-  ): (Vector[PackageURL], DockerState) = marker match {
+  ): (Vector[Purl], DockerState) = marker match {
     case DockerMarkers.Config(info) =>
       val purls = computePurls(info)
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Docker.scala
@@ -1,7 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
 import com.typesafe.scalalogging.Logger
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.PackageTagInfo
@@ -70,7 +69,7 @@ case class DockerState(
     case _ => this
   }
 
-  private def computePurls(info: ManifestInfo): Vector[Purl] = {
+  private def computePurls(info: ManifestInfo): Vector[String] = {
     val purls = for {
       // get "RepoTags" which should be an Array of tags
       case JArray(tags) <- info.manifestConfig \ "RepoTags"
@@ -98,12 +97,15 @@ case class DockerState(
 
       // construct a Docker Package URL based on the pURL examples
       // https://github.com/package-url/purl-spec?tab=readme-ov-file#some-purl-examples
-      PURLHelpers.purl(
-        `type` = "docker",
-        name = path,
-        namespace = namespace.orNull,
-        version = version.orNull
-      )
+      PURLHelpers
+        .purl(
+          `type` = "docker",
+          name = path,
+          namespace = namespace.orNull,
+          version = version.orNull
+        )
+        .toCanonical()
+        .nn
     }
 
     purls.toVector
@@ -113,7 +115,7 @@ case class DockerState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: DockerMarkers
-  ): (Vector[Purl], DockerState) = marker match {
+  ): (Vector[String], DockerState) = marker match {
     case DockerMarkers.Config(info) =>
       val purls = computePurls(info)
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -1,7 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
 import com.typesafe.scalalogging.Logger
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.cilantro.AssemblyDefinition
 import io.spicelabs.cilantro.AssemblyNameReference
 import io.spicelabs.cilantro.CSVersion
@@ -94,18 +93,21 @@ class DotnetState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[Purl], DotnetState) = {
+  ): (Vector[String], DotnetState) = {
     assemblyOpt
       .map(assembly =>
         // nuget purls take no namespace (the spec prohibits it).
-        PURLHelpers.purl(
-          `type` = "nuget",
-          name = assembly.name.name,
-          // if the build number is 0, it won't show in the nuget version number,
-          // so we get a string without the build number.
-          // The full number goes into the the VERSION metadata, however.
-          version = sanitizeVersion(assembly.name.version)
-        )
+        PURLHelpers
+          .purl(
+            `type` = "nuget",
+            name = assembly.name.name,
+            // if the build number is 0, it won't show in the nuget version number,
+            // so we get a string without the build number.
+            // The full number goes into the the VERSION metadata, however.
+            version = sanitizeVersion(assembly.name.version)
+          )
+          .toCanonical()
+          .nn
       )
       .toVector -> this
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Dotnet.scala
@@ -1,7 +1,7 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
 import com.typesafe.scalalogging.Logger
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.cilantro.AssemblyDefinition
 import io.spicelabs.cilantro.AssemblyNameReference
 import io.spicelabs.cilantro.CSVersion
@@ -22,6 +22,7 @@ import io.spicelabs.goatrodeo.util.DotnetDetector
 import io.spicelabs.goatrodeo.util.GitOID
 import io.spicelabs.goatrodeo.util.Helpers
 import io.spicelabs.goatrodeo.util.Helpers.toHex
+import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.TreeMapExtensions.+?
 import org.json4s.*
 import org.json4s.JsonDSL.*
@@ -93,19 +94,17 @@ class DotnetState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[PackageURL], DotnetState) = {
+  ): (Vector[Purl], DotnetState) = {
     assemblyOpt
       .map(assembly =>
-        PackageURL(
-          "nuget",
-          "",
-          assembly.name.name,
+        // nuget purls take no namespace (the spec prohibits it).
+        PURLHelpers.purl(
+          `type` = "nuget",
+          name = assembly.name.name,
           // if the build number is 0, it won't show in the nuget version number,
           // so we get a string without the build number.
           // The full number goes into the the VERSION metadata, however.
-          sanitizeVersion(assembly.name.version),
-          null,
-          ""
+          version = sanitizeVersion(assembly.name.version)
         )
       )
       .toVector -> this

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
@@ -48,7 +48,7 @@ class GenericFileState extends ProcessingState[SingleMarker, GenericFileState] {
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[PackageURL], GenericFileState) = Vector.empty -> this
+  ): (Vector[Purl], GenericFileState) = Vector.empty -> this
 
   override def getMetadata(
       artifact: ArtifactWrapper,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Generic.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ParentScope
 import io.spicelabs.goatrodeo.omnibor.ProcessingState
@@ -48,7 +47,7 @@ class GenericFileState extends ProcessingState[SingleMarker, GenericFileState] {
       artifact: ArtifactWrapper,
       item: Item,
       marker: SingleMarker
-  ): (Vector[Purl], GenericFileState) = Vector.empty -> this
+  ): (Vector[String], GenericFileState) = Vector.empty -> this
 
   override def getMetadata(
       artifact: ArtifactWrapper,

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.Augmentation
 import io.spicelabs.goatrodeo.omnibor.EdgeType
@@ -152,7 +152,7 @@ case class MavenState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: MavenMarkers
-  ): (Vector[PackageURL], MavenState) = {
+  ): (Vector[Purl], MavenState) = {
     val grp = findTag(pomXml, "groupId")
     val art = findTag(pomXml, "artifactId")
     val ver = tryToFixVersion(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/strategies/Maven.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.Augmentation
 import io.spicelabs.goatrodeo.omnibor.EdgeType
@@ -152,7 +151,7 @@ case class MavenState(
       artifact: ArtifactWrapper,
       item: Item,
       marker: MavenMarkers
-  ): (Vector[Purl], MavenState) = {
+  ): (Vector[String], MavenState) = {
     val grp = findTag(pomXml, "groupId")
     val art = findTag(pomXml, "artifactId")
     val ver = tryToFixVersion(
@@ -163,18 +162,21 @@ case class MavenState(
     (grp, art, ver) match {
       case (Some(g), Some(a), Some(v)) =>
         val ret = Vector(
-          PURLHelpers.buildPackageURL(
-            Ecosystems.Maven,
-            Some(g),
-            a,
-            v,
-            marker match {
-              case MavenMarkers.JAR      => None
-              case MavenMarkers.Sources  => Some("sources")
-              case MavenMarkers.POM      => Some("pom")
-              case MavenMarkers.JavaDocs => Some("javadoc")
-            }
-          )
+          PURLHelpers
+            .buildPackageURL(
+              Ecosystems.Maven,
+              Some(g),
+              a,
+              v,
+              marker match {
+                case MavenMarkers.JAR      => None
+                case MavenMarkers.Sources  => Some("sources")
+                case MavenMarkers.POM      => Some("pom")
+                case MavenMarkers.JavaDocs => Some("javadoc")
+              }
+            )
+            .toCanonical()
+            .nn
         )
         ret -> this
       case _ => (Vector(), this)

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Helpers.scala
@@ -16,6 +16,7 @@ package io.spicelabs.goatrodeo.util
 
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Cbor
+import io.spicelabs.coordinates.Coordinates
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import org.apache.bcel.classfile.ClassParser
 import org.apache.commons.compress.archivers.ArchiveEntry
@@ -359,8 +360,8 @@ object Helpers {
     *   the hex of the MD5 hash.
     */
   def md5hashHex(in: String): String = {
-
-    toHex(computeMD5(stringToInputStream(in)))
+    // Delegate to `coordinates`, the canonical definition of this identifier.
+    Coordinates.md5(in.getBytes("UTF-8")).nn
   }
 
   /** Convert a String to an InputStream using UTF-8 encoding.
@@ -546,7 +547,8 @@ object Helpers {
     md.digest(bytes)
   }
 
-  def sha256Hex(bytes: Array[Byte]): String = toHex(computeSHA256(bytes))
+  // Canonical lowercase-hex SHA-256, computed by `coordinates`.
+  def sha256Hex(bytes: Array[Byte]): String = Coordinates.sha256(bytes).nn
 
   def computeSHA256(in: InputStream): Array[Byte] = {
     val md = MessageDigest.getInstance("SHA256")
@@ -1405,33 +1407,22 @@ object GitOIDUtils {
       theFile: ArtifactWrapper
   ): (String, Vector[String]) = {
 
-    val gitoidSha256 =
-      theFile.withStream(url(_, theFile.size(), HashType.SHA256))
+    // Compute every intrinsic identifier in a single streamed pass through the
+    // canonical `coordinates` implementation — no full-artifact buffering, and
+    // one read instead of the six this used to take. The returned map is keyed
+    // by the spec.yaml names; we keep goatrodeo's `<algo>:<hex>` alias shape and
+    // lead with the gitoid-sha256, so the output is byte-identical to before.
+    val all =
+      theFile.withStream(in => Coordinates.intrinsic(in, theFile.size())).nn
 
     (
-      gitoidSha256,
+      all.get("gitoid-blob-sha256").nn,
       Vector(
-        theFile.withStream(url(_, theFile.size(), HashType.SHA1)),
-        String
-          .format(
-            "sha1:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA1(_)))
-          ),
-        String
-          .format(
-            "sha256:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA256(_)))
-          ),
-        String
-          .format(
-            "sha512:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeSHA512(_)))
-          ),
-        String
-          .format(
-            "md5:%s",
-            Helpers.toHex(theFile.withStream(Helpers.computeMD5(_)))
-          )
+        all.get("gitoid-blob-sha1").nn,
+        s"sha1:${all.get("sha1")}",
+        s"sha256:${all.get("sha256")}",
+        s"sha512:${all.get("sha512")}",
+        s"md5:${all.get("md5")}"
       )
     )
   }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/PURLHelpers.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/PURLHelpers.scala
@@ -1,9 +1,13 @@
 package io.spicelabs.goatrodeo.util
 
-import com.github.packageurl.PackageURL
-import com.github.packageurl.PackageURLBuilder
+import io.spicelabs.coordinates.Purl
 
-/** Helpers related to Package URLs
+/** Helpers related to Package URLs.
+  *
+  * Package URLs are produced via `io.spicelabs.coordinates.Purl`, the canonical
+  * Spice Labs purl implementation (parse / build / normalize per the purl-spec).
+  * `coordinates` exposes a plain constructor rather than a builder, so [[purl]]
+  * is a small Scala-friendly factory over it.
   */
 object PURLHelpers {
 
@@ -33,6 +37,41 @@ object PURLHelpers {
     Ecosystems.Debian -> ("deb", None)
   );
 
+  /** Build a [[Purl]] from its parts.
+    *
+    * Replaces the old `PackageURLBuilder`: `type` and `name` are required, the
+    * rest optional. A blank namespace/version/subpath is treated as absent (the
+    * canonical purl form distinguishes "missing" from "empty", and some types —
+    * e.g. `nuget` — forbid a namespace entirely). Normalization and validation
+    * happen canonically in [[Purl.toCanonical]].
+    *
+    * @param qualifiers
+    *   key/value qualifiers, in insertion order (canonicalization sorts them)
+    */
+  def purl(
+      `type`: String,
+      name: String,
+      namespace: String | Null = null,
+      version: String | Null = null,
+      qualifiers: Seq[(String, String)] = Seq(),
+      subpath: String | Null = null
+  ): Purl = {
+    def blankToNull(s: String | Null): String | Null =
+      if (s == null || s.isEmpty) null else s
+
+    val q = new java.util.LinkedHashMap[String, String]()
+    for ((k, v) <- qualifiers) q.put(k, v)
+
+    new Purl(
+      `type`,
+      blankToNull(namespace),
+      name,
+      blankToNull(version),
+      q,
+      blankToNull(subpath)
+    )
+  }
+
   /** Take a bunch of "information" and turn it into a package URL
     *
     * @param ecosystem
@@ -57,7 +96,7 @@ object PURLHelpers {
       version: String,
       qualifierName: Option[String] = None,
       qualifiers: Seq[(String, String)] = Seq()
-  ): PackageURL = {
+  ): Purl = {
     val (ecosystemText, ecosystemQualifiers) =
       ecosystems.get(ecosystem) match {
         case None => ("unknown", Map())
@@ -65,24 +104,16 @@ object PURLHelpers {
           (name, ecosystemQualifiers.getOrElse(Map()))
       }
 
-    var purlBuilder = PackageURLBuilder.aPackageURL().withType(ecosystemText)
+    val namedQualifier =
+      qualifierName.flatMap(name => ecosystemQualifiers.get(name)).toSeq
 
-    purlBuilder = namespace.foldLeft(purlBuilder) { case (pb, namespace) =>
-      pb.withNamespace(namespace)
-    }
-    purlBuilder = purlBuilder.withName(artifactId).withVersion(version)
-
-    purlBuilder = qualifierName
-      .flatMap(name => ecosystemQualifiers.get(name))
-      .foldLeft(purlBuilder) { case (pb, (k, v)) => pb.withQualifier(k, v) }
-
-    purlBuilder = qualifiers.foldLeft(purlBuilder) { case (pb, (k, v)) =>
-      pb.withQualifier(k, v)
-    }
-
-    val ret: PackageURL = purlBuilder.build()
-
-    return ret
+    purl(
+      `type` = ecosystemText,
+      name = artifactId,
+      namespace = namespace.orNull,
+      version = version,
+      qualifiers = namedQualifier ++ qualifiers
+    )
   }
 
 }

--- a/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
@@ -1,6 +1,6 @@
 package io.spicelabs.goatrodeo.util
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.*
 import io.spicelabs.goatrodeo.omnibor.ConnectionAugmentation
@@ -398,7 +398,7 @@ class StaticMetadataResult(private val process: ProcessBuilder, dir: String) {
                   ConnectionAugmentation(
                     digest,
                     (EdgeType.aliasFrom, purl),
-                    PackageURL(purl)
+                    Purl.parse(purl)
                   )
                 )
               } catch {

--- a/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/StaticMetadata.scala
@@ -1,6 +1,5 @@
 package io.spicelabs.goatrodeo.util
 
-import io.spicelabs.coordinates.Purl
 import com.typesafe.scalalogging.Logger
 import io.spicelabs.goatrodeo.omnibor.*
 import io.spicelabs.goatrodeo.omnibor.ConnectionAugmentation
@@ -398,7 +397,7 @@ class StaticMetadataResult(private val process: ProcessBuilder, dir: String) {
                   ConnectionAugmentation(
                     digest,
                     (EdgeType.aliasFrom, purl),
-                    Purl.parse(purl)
+                    purl
                   )
                 )
               } catch {

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -329,7 +329,7 @@ class ItemTestSuite extends munit.FunSuite {
       version = "1.0"
     )
 
-    val enhanced = item.enhanceItemWithPurls(Seq(purl))
+    val enhanced = item.enhanceItemWithPurls(Seq(purl.toCanonical().nn))
     val purlConnections = enhanced.connections.filter(_._2.startsWith("pkg:"))
     assert(purlConnections.nonEmpty)
   }
@@ -343,7 +343,7 @@ class ItemTestSuite extends munit.FunSuite {
       version = "1.0"
     )
 
-    val enhanced = item.enhanceItemWithPurls(Seq(purl))
+    val enhanced = item.enhanceItemWithPurls(Seq(purl.toCanonical().nn))
     val body = enhanced.bodyAsItemMetaData.get
     assert(body.fileNames.exists(_.startsWith("pkg:")))
   }
@@ -368,7 +368,8 @@ class ItemTestSuite extends munit.FunSuite {
       version = "2.0"
     )
 
-    val enhanced = item.enhanceItemWithPurls(Seq(purl1, purl2))
+    val enhanced =
+      item.enhanceItemWithPurls(Seq(purl1.toCanonical().nn, purl2.toCanonical().nn))
     val purlConnections = enhanced.connections.filter(_._2.startsWith("pkg:"))
     assertEquals(purlConnections.size, 2)
   }
@@ -382,7 +383,7 @@ class ItemTestSuite extends munit.FunSuite {
       version = "1.0"
     )
 
-    val enhanced = item.enhanceItemWithPurls(Seq(purl))
+    val enhanced = item.enhanceItemWithPurls(Seq(purl.toCanonical().nn))
     assert(enhanced.bodyAsItemMetaData.isDefined)
   }
 

--- a/src/test/scala/ItemTestSuite.scala
+++ b/src/test/scala/ItemTestSuite.scala
@@ -12,12 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import com.github.packageurl.PackageURLBuilder
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
 import io.spicelabs.goatrodeo.util.ByteWrapper
+import io.spicelabs.goatrodeo.util.PURLHelpers
 
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
@@ -322,13 +322,12 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceItemWithPurls - adds purl connections") {
     val item = createBasicItem("gitoid:blob:sha256:abc123")
-    val purl = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("debian")
-      .withName("artifact")
-      .withVersion("1.0")
-      .build()
+    val purl = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact",
+      namespace = "debian",
+      version = "1.0"
+    )
 
     val enhanced = item.enhanceItemWithPurls(Seq(purl))
     val purlConnections = enhanced.connections.filter(_._2.startsWith("pkg:"))
@@ -337,13 +336,12 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceItemWithPurls - adds purl to filenames") {
     val item = createBasicItem("gitoid:blob:sha256:abc123")
-    val purl = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("debian")
-      .withName("artifact")
-      .withVersion("1.0")
-      .build()
+    val purl = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact",
+      namespace = "debian",
+      version = "1.0"
+    )
 
     val enhanced = item.enhanceItemWithPurls(Seq(purl))
     val body = enhanced.bodyAsItemMetaData.get
@@ -358,19 +356,17 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceItemWithPurls - handles multiple purls") {
     val item = createBasicItem("gitoid:blob:sha256:abc123")
-    val purl1 = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("ubuntu")
-      .withName("artifact1")
-      .withVersion("1.0")
-      .build()
-    val purl2 = PackageURLBuilder
-      .aPackageURL()
-      .withType("npm")
-      .withName("package")
-      .withVersion("2.0")
-      .build()
+    val purl1 = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact1",
+      namespace = "ubuntu",
+      version = "1.0"
+    )
+    val purl2 = PURLHelpers.purl(
+      `type` = "npm",
+      name = "package",
+      version = "2.0"
+    )
 
     val enhanced = item.enhanceItemWithPurls(Seq(purl1, purl2))
     val purlConnections = enhanced.connections.filter(_._2.startsWith("pkg:"))
@@ -379,13 +375,12 @@ class ItemTestSuite extends munit.FunSuite {
 
   test("enhanceItemWithPurls - creates body if none exists") {
     val item = Item("id", TreeSet(), None, None)
-    val purl = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("debian")
-      .withName("artifact")
-      .withVersion("1.0")
-      .build()
+    val purl = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact",
+      namespace = "debian",
+      version = "1.0"
+    )
 
     val enhanced = item.enhanceItemWithPurls(Seq(purl))
     assert(enhanced.bodyAsItemMetaData.isDefined)

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ToProcess
@@ -383,7 +383,7 @@ class MySuite extends munit.FunSuite {
       f"Expecting at least 2 files, got ${strategy.length}"
     )
 
-    var packages: Vector[PackageURL] = Vector()
+    var packages: Vector[Purl] = Vector()
     val store = ToProcess.buildGraphForToProcess(
       strategy,
       args = Config(),

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.EdgeType
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.ToProcess
@@ -383,7 +382,7 @@ class MySuite extends munit.FunSuite {
       f"Expecting at least 2 files, got ${strategy.length}"
     )
 
-    var packages: Vector[Purl] = Vector()
+    var packages: Vector[String] = Vector()
     val store = ToProcess.buildGraphForToProcess(
       strategy,
       args = Config(),

--- a/src/test/scala/PURLHelpersTestSuite.scala
+++ b/src/test/scala/PURLHelpersTestSuite.scala
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.util.PURLHelpers
 import io.spicelabs.goatrodeo.util.PURLHelpers.Ecosystems
 
@@ -94,21 +95,22 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       version = "2.22.1"
     )
 
-    assertEquals(purl.getType(), "maven")
-    assertEquals(purl.getNamespace(), "org.apache.logging.log4j")
-    assertEquals(purl.getName(), "log4j-core")
-    assertEquals(purl.getVersion(), "2.22.1")
+    assertEquals(purl.`type`, "maven")
+    assertEquals(purl.namespace, "org.apache.logging.log4j")
+    assertEquals(purl.name, "log4j-core")
+    assertEquals(purl.version, "2.22.1")
   }
 
   test("buildPackageURL - Maven pURL requires namespace") {
-    // Maven pURLs require both namespace and name per spec
-    import com.github.packageurl.MalformedPackageURLException
-    intercept[MalformedPackageURLException] {
-      PURLHelpers.buildPackageURL(
-        ecosystem = Ecosystems.Maven,
-        artifactId = "simple-artifact",
-        version = "1.0.0"
-      )
+    // Maven pURLs require a namespace per spec; coordinates enforces this when
+    // the purl is canonicalized.
+    val purl = PURLHelpers.buildPackageURL(
+      ecosystem = Ecosystems.Maven,
+      artifactId = "simple-artifact",
+      version = "1.0.0"
+    )
+    intercept[Purl.PurlException] {
+      purl.toCanonical()
     }
   }
 
@@ -121,7 +123,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifierName = Some("pom")
     )
 
-    assertEquals(purl.getQualifiers().get("type"), "pom")
+    assertEquals(purl.qualifiers.get("type"), "pom")
   }
 
   test("buildPackageURL - Maven pURL with sources qualifier") {
@@ -133,7 +135,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifierName = Some("sources")
     )
 
-    assertEquals(purl.getQualifiers().get("packaging"), "sources")
+    assertEquals(purl.qualifiers.get("packaging"), "sources")
   }
 
   test("buildPackageURL - Maven pURL with javadoc qualifier") {
@@ -145,7 +147,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifierName = Some("javadoc")
     )
 
-    assertEquals(purl.getQualifiers().get("classifier"), "javadoc")
+    assertEquals(purl.qualifiers.get("classifier"), "javadoc")
   }
 
   test("buildPackageURL - Maven pURL with custom qualifiers") {
@@ -157,7 +159,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifiers = Seq(("custom", "value"))
     )
 
-    assertEquals(purl.getQualifiers().get("custom"), "value")
+    assertEquals(purl.qualifiers.get("custom"), "value")
   }
 
   test("buildPackageURL - Maven pURL with multiple qualifiers") {
@@ -170,9 +172,9 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifiers = Seq(("repository_url", "https://repo.example.com"))
     )
 
-    assertEquals(purl.getQualifiers().get("type"), "pom")
+    assertEquals(purl.qualifiers.get("type"), "pom")
     assertEquals(
-      purl.getQualifiers().get("repository_url"),
+      purl.qualifiers.get("repository_url"),
       "https://repo.example.com"
     )
   }
@@ -187,10 +189,10 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       version = "2.31-0ubuntu9"
     )
 
-    assertEquals(purl.getType(), "deb")
-    assertEquals(purl.getNamespace(), "ubuntu")
-    assertEquals(purl.getName(), "libc6")
-    assertEquals(purl.getVersion(), "2.31-0ubuntu9")
+    assertEquals(purl.`type`, "deb")
+    assertEquals(purl.namespace, "ubuntu")
+    assertEquals(purl.name, "libc6")
+    assertEquals(purl.version, "2.31-0ubuntu9")
   }
 
   test("buildPackageURL - Debian pURL without namespace") {
@@ -200,9 +202,9 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       version = "1.1.1"
     )
 
-    assertEquals(purl.getType(), "deb")
-    assertEquals(purl.getNamespace(), null)
-    assertEquals(purl.getName(), "openssl")
+    assertEquals(purl.`type`, "deb")
+    assertEquals(purl.namespace, null)
+    assertEquals(purl.name, "openssl")
   }
 
   test("buildPackageURL - Debian ignores unknown qualifierName") {
@@ -215,8 +217,8 @@ class PURLHelpersTestSuite extends munit.FunSuite {
     )
 
     // Should not throw, qualifierName is ignored for Debian
-    assertEquals(purl.getType(), "deb")
-    assert(purl.getQualifiers() == null || purl.getQualifiers().isEmpty())
+    assertEquals(purl.`type`, "deb")
+    assert(purl.qualifiers == null || purl.qualifiers.isEmpty())
   }
 
   test("buildPackageURL - Debian pURL with arch qualifier") {
@@ -228,7 +230,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifiers = Seq(("arch", "amd64"))
     )
 
-    assertEquals(purl.getQualifiers().get("arch"), "amd64")
+    assertEquals(purl.qualifiers.get("arch"), "amd64")
   }
 
   // ==================== buildPackageURL - Edge Cases ====================
@@ -242,7 +244,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       version = "1.0.0"
     )
 
-    assertEquals(purl.getNamespace(), null)
+    assertEquals(purl.namespace, null)
   }
 
   test("buildPackageURL - handles empty qualifiers") {
@@ -254,7 +256,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifiers = Seq()
     )
 
-    assert(purl.getQualifiers() == null || purl.getQualifiers().isEmpty())
+    assert(purl.qualifiers == null || purl.qualifiers.isEmpty())
   }
 
   test("buildPackageURL - handles None qualifierName") {
@@ -266,7 +268,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       qualifierName = None
     )
 
-    assert(purl.getQualifiers() == null || purl.getQualifiers().isEmpty())
+    assert(purl.qualifiers == null || purl.qualifiers.isEmpty())
   }
 
   test("buildPackageURL - pURL can be converted to string") {
@@ -277,7 +279,7 @@ class PURLHelpersTestSuite extends munit.FunSuite {
       version = "2.22.1"
     )
 
-    val purlString = purl.canonicalize()
+    val purlString = purl.toCanonical()
     assert(purlString.startsWith("pkg:maven/"))
     assert(purlString.contains("org.apache.logging.log4j"))
     assert(purlString.contains("log4j-core"))

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -200,7 +200,7 @@ class StorageTestSuite extends munit.FunSuite {
       version = "1.0.0"
     )
 
-    storage.addPurl(purl)
+    storage.addPurl(purl.toCanonical().nn)
 
     val purls = storage.purls()
     assertEquals(purls.size, 1)
@@ -221,8 +221,8 @@ class StorageTestSuite extends munit.FunSuite {
       version = "2.0"
     )
 
-    storage.addPurl(purl1)
-    storage.addPurl(purl2)
+    storage.addPurl(purl1.toCanonical().nn)
+    storage.addPurl(purl2.toCanonical().nn)
 
     val purls = storage.purls()
     assertEquals(purls.size, 2)
@@ -237,8 +237,8 @@ class StorageTestSuite extends munit.FunSuite {
       version = "1.0"
     )
 
-    storage.addPurl(purl)
-    storage.addPurl(purl)
+    storage.addPurl(purl.toCanonical().nn)
+    storage.addPurl(purl.toCanonical().nn)
 
     val purls = storage.purls()
     assertEquals(purls.size, 1)

--- a/src/test/scala/StorageTestSuite.scala
+++ b/src/test/scala/StorageTestSuite.scala
@@ -12,12 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-import com.github.packageurl.PackageURLBuilder
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.MemStorage
 import io.spicelabs.goatrodeo.omnibor.Storage
 import io.spicelabs.goatrodeo.util.Helpers
+import io.spicelabs.goatrodeo.util.PURLHelpers
 
 import java.nio.file.Files
 import scala.collection.immutable.TreeMap
@@ -193,36 +193,33 @@ class StorageTestSuite extends munit.FunSuite {
 
   test("MemStorage - addPurl adds package URL") {
     val storage = MemStorage(None)
-    val purl = PackageURLBuilder
-      .aPackageURL()
-      .withType("maven")
-      .withNamespace("org.example")
-      .withName("artifact")
-      .withVersion("1.0.0")
-      .build()
+    val purl = PURLHelpers.purl(
+      `type` = "maven",
+      name = "artifact",
+      namespace = "org.example",
+      version = "1.0.0"
+    )
 
     storage.addPurl(purl)
 
     val purls = storage.purls()
     assertEquals(purls.size, 1)
-    assert(purls.contains(purl.canonicalize()))
+    assert(purls.contains(purl.toCanonical()))
   }
 
   test("MemStorage - purls returns all added purls") {
     val storage = MemStorage(None)
-    val purl1 = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("ubuntu")
-      .withName("artifact1")
-      .withVersion("1.0")
-      .build()
-    val purl2 = PackageURLBuilder
-      .aPackageURL()
-      .withType("npm")
-      .withName("package")
-      .withVersion("2.0")
-      .build()
+    val purl1 = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact1",
+      namespace = "ubuntu",
+      version = "1.0"
+    )
+    val purl2 = PURLHelpers.purl(
+      `type` = "npm",
+      name = "package",
+      version = "2.0"
+    )
 
     storage.addPurl(purl1)
     storage.addPurl(purl2)
@@ -233,13 +230,12 @@ class StorageTestSuite extends munit.FunSuite {
 
   test("MemStorage - purls deduplicates identical purls") {
     val storage = MemStorage(None)
-    val purl = PackageURLBuilder
-      .aPackageURL()
-      .withType("deb")
-      .withNamespace("debian")
-      .withName("artifact")
-      .withVersion("1.0")
-      .build()
+    val purl = PURLHelpers.purl(
+      `type` = "deb",
+      name = "artifact",
+      namespace = "debian",
+      version = "1.0"
+    )
 
     storage.addPurl(purl)
     storage.addPurl(purl)

--- a/src/test/scala/strategies/CertificatesAssertions.scala
+++ b/src/test/scala/strategies/CertificatesAssertions.scala
@@ -51,7 +51,7 @@ object CertificatesAssertions {
 
   /** Extract all pURL strings attached to the Item via `alias:from` edges.
     * These are the canonicalized pURL strings produced by
-    * `PackageURL.canonicalize()`.
+    * `PackageURL.toCanonical()`.
     */
   def purlsOf(item: Item): Set[String] = {
     item.connections

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -199,7 +199,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
     val derBytes = cert.getEncoded
     val artifact: ArtifactWrapper = ByteWrapper(derBytes, "generated.der", None)
     val parsed = Certificates.parseSingleCert(artifact).get
-    val purls = Certificates.purlsForCert(parsed).map(_.canonicalize().nn)
+    val purls = Certificates.purlsForCert(parsed).map(_.toCanonical().nn)
     (parsed, purls)
   }
 
@@ -312,13 +312,13 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
   // ===== Property 7: pURL parses cleanly (no canonicalize exceptions) ====
 
   property(
-    "[PROP] every emitted pURL parses through PackageURL without throwing"
+    "[PROP] every emitted pURL parses through Purl without throwing"
   ) {
     forAll(genCase) { c =>
       val (_, cert) = buildSelfSignedCert(c)
       val (_, purls) = driveThroughStrategy(cert)
       purls.forall { purl =>
-        scala.util.Try(new com.github.packageurl.PackageURL(purl)).isSuccess
+        scala.util.Try(io.spicelabs.coordinates.Purl.parse(purl)).isSuccess
       }
     }
   }
@@ -509,7 +509,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          val canonicalized = purls.map(_.canonicalize().nn)
+          val canonicalized = purls.map(_.toCanonical().nn)
           val certPurls = canonicalized.filter(_.contains("ssh/cert-sha256"))
           certPurls.forall { p =>
             val ct =
@@ -532,7 +532,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          val canonicalized = purls.map(_.canonicalize().nn)
+          val canonicalized = purls.map(_.toCanonical().nn)
           val certPurls = canonicalized.filter(_.contains("ssh/cert-sha256"))
           certPurls.forall(_.contains("sig-alg="))
         case _ => true
@@ -551,7 +551,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          purls.forall(p => p.canonicalize().nn.contains("sig-alg="))
+          purls.forall(p => p.toCanonical().nn.contains("sig-alg="))
         case _ => true
       }
     }
@@ -572,7 +572,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          purls.exists(p => p.canonicalize().nn.contains(expectedHex))
+          purls.exists(p => p.toCanonical().nn.contains(expectedHex))
         case _ => true
       }
     }

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -509,8 +509,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          val canonicalized = purls.map(_.toCanonical().nn)
-          val certPurls = canonicalized.filter(_.contains("ssh/cert-sha256"))
+          val certPurls = purls.filter(_.contains("ssh/cert-sha256"))
           certPurls.forall { p =>
             val ct =
               "cert-type=([a-z]+)".r.findFirstMatchIn(p).map(_.group(1).nn)
@@ -532,8 +531,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          val canonicalized = purls.map(_.toCanonical().nn)
-          val certPurls = canonicalized.filter(_.contains("ssh/cert-sha256"))
+          val certPurls = purls.filter(_.contains("ssh/cert-sha256"))
           certPurls.forall(_.contains("sig-alg="))
         case _ => true
       }
@@ -551,7 +549,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          purls.forall(p => p.toCanonical().nn.contains("sig-alg="))
+          purls.forall(p => p.contains("sig-alg="))
         case _ => true
       }
     }
@@ -572,7 +570,7 @@ class CertificatesPropertySuite extends ScalaCheckSuite {
             stubItem(),
             io.spicelabs.goatrodeo.omnibor.SingleMarker()
           )
-          purls.exists(p => p.toCanonical().nn.contains(expectedHex))
+          purls.exists(p => p.contains(expectedHex))
         case _ => true
       }
     }

--- a/src/test/scala/strategies/MaterializeSidecars.scala
+++ b/src/test/scala/strategies/MaterializeSidecars.scala
@@ -51,7 +51,7 @@ object MaterializeSidecars {
   private def materializeBundle(fixture: File): Option[Vector[String]] = {
     val bundle = Certificates.parseBundle(wrap(fixture))
     bundle.map { b =>
-      b.certs.flatMap(Certificates.purlsForCert).map(_.canonicalize().nn)
+      b.certs.flatMap(Certificates.purlsForCert).map(_.toCanonical().nn)
     }
   }
 
@@ -59,7 +59,7 @@ object MaterializeSidecars {
     val w = wrap(fixture)
     Certificates.parseCrl(w).map { c =>
       val state = new CertificatesState(w)
-      Vector(state.purlForCrl(c.crl).canonicalize().nn)
+      Vector(state.purlForCrl(c.crl).toCanonical().nn)
     }
   }
 
@@ -68,9 +68,9 @@ object MaterializeSidecars {
     sshClaim(fixture).map { case (state, content) =>
       content match {
         case p: Certificates.SshPubkey =>
-          Vector(state.purlForSshPubkey(p).canonicalize().nn)
+          Vector(state.purlForSshPubkey(p).toCanonical().nn)
         case c: Certificates.SshCert =>
-          state.purlsForSshCert(c).map(_.canonicalize().nn)
+          state.purlsForSshCert(c).map(_.toCanonical().nn)
         case _ => Vector.empty
       }
     }
@@ -155,10 +155,10 @@ object MaterializeSidecars {
     Certificates.classifyAndParse(w).map {
       case p: Certificates.PrivateKeyPlaintextPem =>
         val state = new CertificatesState(w, Some(p))
-        Vector(state.purlForPrivateKeyPem(p).canonicalize().nn)
+        Vector(state.purlForPrivateKeyPem(p).toCanonical().nn)
       case p: Certificates.PrivateKeyPlaintextOpenSsh =>
         val state = new CertificatesState(w, Some(p))
-        Vector(state.purlForPrivateKeyOpenSsh(p).canonicalize().nn)
+        Vector(state.purlForPrivateKeyOpenSsh(p).toCanonical().nn)
       case _: Certificates.PrivateKeyEncrypted =>
         Vector.empty // envelope-only, no pURL
       case _ => Vector.empty
@@ -199,7 +199,7 @@ object MaterializeSidecars {
   private def materializePgp(fixture: File): Option[Vector[String]] = {
     val w = wrap(fixture)
     Certificates.parsePgpKeyRing(w).map { ring =>
-      ring.keys.map(k => Certificates.purlForPgpKey(k).canonicalize().nn)
+      ring.keys.map(k => Certificates.purlForPgpKey(k).toCanonical().nn)
     }
   }
 

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -116,10 +116,10 @@ class MavenTestSuite extends munit.FunSuite {
 
     assert(purls.nonEmpty)
     val purl = purls.head
-    assertEquals(purl.getType(), "maven")
-    assertEquals(purl.getNamespace(), "org.example")
-    assertEquals(purl.getName(), "test-artifact")
-    assertEquals(purl.getVersion(), "1.0.0")
+    assertEquals(purl.`type`, "maven")
+    assertEquals(purl.namespace, "org.example")
+    assertEquals(purl.name, "test-artifact")
+    assertEquals(purl.version, "1.0.0")
   }
 
   test("MavenState.getPurls - returns empty for missing group") {
@@ -147,7 +147,7 @@ class MavenTestSuite extends munit.FunSuite {
 
     assert(purls.nonEmpty)
     val purl = purls.head
-    assertEquals(purl.getQualifiers().get("type"), "pom")
+    assertEquals(purl.qualifiers.get("type"), "pom")
   }
 
   test("MavenState.getPurls - includes sources qualifier for Sources marker") {
@@ -160,7 +160,7 @@ class MavenTestSuite extends munit.FunSuite {
 
     assert(purls.nonEmpty)
     val purl = purls.head
-    assertEquals(purl.getQualifiers().get("packaging"), "sources")
+    assertEquals(purl.qualifiers.get("packaging"), "sources")
   }
 
   test("MavenState.getPurls - includes javadoc qualifier for JavaDocs marker") {
@@ -173,7 +173,7 @@ class MavenTestSuite extends munit.FunSuite {
 
     assert(purls.nonEmpty)
     val purl = purls.head
-    assertEquals(purl.getQualifiers().get("classifier"), "javadoc")
+    assertEquals(purl.qualifiers.get("classifier"), "javadoc")
   }
 
   test("MavenState.getPurls - extracts version from parent if missing") {
@@ -193,7 +193,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.JAR)
 
     assert(purls.nonEmpty)
-    assertEquals(purls.head.getVersion(), "2.0.0")
+    assertEquals(purls.head.version, "2.0.0")
   }
 
   // ==================== MavenState.getMetadata Tests ====================

--- a/src/test/scala/strategies/MavenTestSuite.scala
+++ b/src/test/scala/strategies/MavenTestSuite.scala
@@ -14,6 +14,7 @@ limitations under the License. */
 
 package strategies
 
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.MemStorage
@@ -115,7 +116,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.JAR)
 
     assert(purls.nonEmpty)
-    val purl = purls.head
+    val purl = Purl.parse(purls.head).nn
     assertEquals(purl.`type`, "maven")
     assertEquals(purl.namespace, "org.example")
     assertEquals(purl.name, "test-artifact")
@@ -146,7 +147,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.POM)
 
     assert(purls.nonEmpty)
-    val purl = purls.head
+    val purl = Purl.parse(purls.head).nn
     assertEquals(purl.qualifiers.get("type"), "pom")
   }
 
@@ -159,7 +160,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.Sources)
 
     assert(purls.nonEmpty)
-    val purl = purls.head
+    val purl = Purl.parse(purls.head).nn
     assertEquals(purl.qualifiers.get("packaging"), "sources")
   }
 
@@ -172,7 +173,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.JavaDocs)
 
     assert(purls.nonEmpty)
-    val purl = purls.head
+    val purl = Purl.parse(purls.head).nn
     assertEquals(purl.qualifiers.get("classifier"), "javadoc")
   }
 
@@ -193,7 +194,7 @@ class MavenTestSuite extends munit.FunSuite {
     val (purls, _) = state.getPurls(artifact, item, MavenMarkers.JAR)
 
     assert(purls.nonEmpty)
-    assertEquals(purls.head.version, "2.0.0")
+    assertEquals(Purl.parse(purls.head).nn.version, "2.0.0")
   }
 
   // ==================== MavenState.getMetadata Tests ====================

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -148,7 +148,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
         case None => true
         case Some(r) =>
           r.keys.forall { k =>
-            val purl = Certificates.purlForPgpKey(k).canonicalize().nn
+            val purl = Certificates.purlForPgpKey(k).toCanonical().nn
             // (a) shape: pkg:generic/pgp/fingerprint@{hex}?...
             purl.startsWith(
               s"pkg:generic/pgp/fingerprint@${k.fingerprintHex}?"
@@ -180,7 +180,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
         case None => true
         case Some(r) =>
           val purls =
-            r.keys.map(k => Certificates.purlForPgpKey(k).canonicalize().nn)
+            r.keys.map(k => Certificates.purlForPgpKey(k).toCanonical().nn)
           purls.distinct.length == r.keys.length &&
           // Every pURL contains its key's full fingerprint (regression
           // guard against truncation bugs like fp8 leaking into emission).
@@ -225,9 +225,9 @@ class PgpPropertyTests extends ScalaCheckSuite {
           val w = FileWrapper(f, f.getName, None)
           val state = new CertificatesState(w, Some(r))
           val (emittedPurls, _) = state.getPurls(w, stubItem(), SingleMarker())
-          val emittedSet = emittedPurls.map(_.canonicalize().nn).toSet
+          val emittedSet = emittedPurls.map(_.toCanonical().nn).toSet
           val unitSet = r.keys
-            .map(k => Certificates.purlForPgpKey(k).canonicalize().nn)
+            .map(k => Certificates.purlForPgpKey(k).toCanonical().nn)
             .toSet
           emittedSet == unitSet
       }

--- a/src/test/scala/strategies/PgpPropertyTests.scala
+++ b/src/test/scala/strategies/PgpPropertyTests.scala
@@ -225,7 +225,7 @@ class PgpPropertyTests extends ScalaCheckSuite {
           val w = FileWrapper(f, f.getName, None)
           val state = new CertificatesState(w, Some(r))
           val (emittedPurls, _) = state.getPurls(w, stubItem(), SingleMarker())
-          val emittedSet = emittedPurls.map(_.toCanonical().nn).toSet
+          val emittedSet = emittedPurls.toSet
           val unitSet = r.keys
             .map(k => Certificates.purlForPgpKey(k).toCanonical().nn)
             .toSet

--- a/src/test/scala/strategies/PgpStrategyParserTests.scala
+++ b/src/test/scala/strategies/PgpStrategyParserTests.scala
@@ -260,7 +260,7 @@ class PgpStrategyParserTests extends FunSuite {
   test("purlForPgpKey: shape and ordering") {
     val w = wrap("test_data/certificates/pgp/synthetic/v4-rsa3072-pub.asc")
     val r = Certificates.parsePgpKeyRing(w).get
-    val purl = Certificates.purlForPgpKey(r.keys.head).canonicalize().nn
+    val purl = Certificates.purlForPgpKey(r.keys.head).toCanonical().nn
     assertEquals(
       purl,
       "pkg:generic/pgp/fingerprint@3800518ce65fa1b28e540b3cd242090793ba9dc6?alg=rsa&size=3072&version=4"

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -598,7 +598,7 @@ class PrivateKeyStrategyTests extends FunSuite {
       io.spicelabs.goatrodeo.omnibor.SingleMarker()
     )
     assertEquals(purls.length, 1)
-    val canon = purls.head.canonicalize().nn
+    val canon = purls.head.toCanonical().nn
     assertEquals(
       canon,
       "pkg:generic/x509/spki-sha256@23061b4699527614aba79f341cccd03865af660ffe4e90b972733a3e5cfd4104?alg=ed25519"

--- a/src/test/scala/strategies/PrivateKeyStrategyTests.scala
+++ b/src/test/scala/strategies/PrivateKeyStrategyTests.scala
@@ -598,7 +598,7 @@ class PrivateKeyStrategyTests extends FunSuite {
       io.spicelabs.goatrodeo.omnibor.SingleMarker()
     )
     assertEquals(purls.length, 1)
-    val canon = purls.head.toCanonical().nn
+    val canon = purls.head
     assertEquals(
       canon,
       "pkg:generic/x509/spki-sha256@23061b4699527614aba79f341cccd03865af660ffe4e90b972733a3e5cfd4104?alg=ed25519"

--- a/src/test/scala/strategies/PurlConstructionTests.scala
+++ b/src/test/scala/strategies/PurlConstructionTests.scala
@@ -14,8 +14,7 @@ limitations under the License. */
 
 package io.spicelabs.goatrodeo.omnibor.strategies
 
-import com.github.packageurl.MalformedPackageURLException
-import com.github.packageurl.PackageURL
+import io.spicelabs.coordinates.Purl
 import io.spicelabs.goatrodeo.util.ByteWrapper
 import munit.FunSuite
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
@@ -88,31 +87,20 @@ class PurlConstructionTests extends FunSuite {
   private val dummyArtifact: ByteWrapper =
     ByteWrapper(Array.empty[Byte], "dummy", None)
 
-  private def assertRoundTrips(purl: PackageURL, clue: String): Unit = {
-    val canonical = purl.canonicalize().nn
-    val reparsed = new PackageURL(canonical)
+  private def assertRoundTrips(purl: Purl, clue: String): Unit = {
+    val canonical = purl.toCanonical().nn
+    val reparsed = Purl.parse(canonical).nn
     assertEquals(
-      reparsed.canonicalize().nn,
+      reparsed.toCanonical().nn,
       canonical,
-      s"$clue — pURL must round-trip through strict parser: $canonical"
+      s"$clue — pURL must round-trip through the parser: $canonical"
     )
-  }
-
-  // ===== Test 0: Root cause demonstration ===============================
-  //
-  // `new PackageURL(String)` is a strict URI parser. Angle brackets in
-  // qualifier values cause `MalformedPackageURLException`. This is the
-  // exception the behavioral tests expect the production code to NOT
-  // throw.
-
-  test(
-    "new PackageURL(String) rejects angle-bracket qualifier value (root cause)"
-  ) {
-    intercept[MalformedPackageURLException] {
-      new PackageURL(
-        "pkg:generic/x509/spki-sha256@abc?alg=ec&params=<unknown-1.2.3>"
-      )
-    }
+    // Adversarial qualifier values (e.g. the `<unknown-sig-oid-…>` fallback)
+    // must be percent-encoded in the canonical form, never emitted raw.
+    assert(
+      !canonical.contains("<") && !canonical.contains(">"),
+      s"$clue — angle brackets must be percent-encoded: $canonical"
+    )
   }
 
   // ===== Test 1: SSH cert pURLs (already migrated to builder) ==========
@@ -172,11 +160,11 @@ class PurlConstructionTests extends FunSuite {
     val state = new CertificatesState(dummyArtifact)
     val purls = state.purlsForSshCert(cert)
     assertEquals(purls.length, 2)
-    val certPurl = purls.find(_.canonicalize().nn.contains("cert-sha256")).get
+    val certPurl = purls.find(_.toCanonical().nn.contains("cert-sha256")).get
     assertRoundTrips(certPurl, "SSH cert pURL with unknown certType")
     assert(
-      certPurl.canonicalize().nn.contains("cert-type=unknown-99"),
-      s"cert pURL must contain cert-type=unknown-99, got: ${certPurl.canonicalize()}"
+      certPurl.toCanonical().nn.contains("cert-type=unknown-99"),
+      s"cert pURL must contain cert-type=unknown-99, got: ${certPurl.toCanonical()}"
     )
     purls.foreach(p => assertRoundTrips(p, "SSH cert pURL"))
   }
@@ -210,8 +198,8 @@ class PurlConstructionTests extends FunSuite {
     val purl = Certificates.purlForPgpKey(key)
     assertRoundTrips(purl, "PGP key pURL with angle-bracket canonicalAlg")
     assert(
-      purl.canonicalize().nn.contains("alg="),
-      s"PGP pURL must contain alg= qualifier, got: ${purl.canonicalize()}"
+      purl.toCanonical().nn.contains("alg="),
+      s"PGP pURL must contain alg= qualifier, got: ${purl.toCanonical()}"
     )
   }
 
@@ -348,8 +336,8 @@ class PurlConstructionTests extends FunSuite {
     val purl = Certificates.purlForPgpKey(key)
     assertRoundTrips(purl, "PGP key pURL with raw OID curve")
     assert(
-      purl.canonicalize().nn.contains("curve="),
-      s"PGP pURL must contain curve= qualifier, got: ${purl.canonicalize()}"
+      purl.toCanonical().nn.contains("curve="),
+      s"PGP pURL must contain curve= qualifier, got: ${purl.toCanonical()}"
     )
   }
 
@@ -413,9 +401,9 @@ class PurlConstructionTests extends FunSuite {
       userIds = Vector("test@example.com")
     )
     val purl = Certificates.purlForPgpKey(key)
-    assertEquals(purl.getType(), "generic")
-    assertEquals(purl.getNamespace(), "pgp")
-    assertEquals(purl.getName(), "fingerprint")
+    assertEquals(purl.`type`, "generic")
+    assertEquals(purl.namespace, "pgp")
+    assertEquals(purl.name, "fingerprint")
     assertRoundTrips(purl, "PGP pURL structural invariant")
   }
 
@@ -430,17 +418,17 @@ class PurlConstructionTests extends FunSuite {
     assertEquals(purls.length, 2)
     purls.foreach { purl =>
       assertEquals(
-        purl.getType(),
+        purl.`type`,
         "generic",
-        s"cert pURL type must be generic, got ${purl.getType()}"
+        s"cert pURL type must be generic, got ${purl.`type`}"
       )
       assertEquals(
-        purl.getNamespace(),
+        purl.namespace,
         "x509",
-        s"cert pURL namespace must be x509, got ${purl.getNamespace()}"
+        s"cert pURL namespace must be x509, got ${purl.namespace}"
       )
     }
-    val names = purls.map(_.getName()).toSet
+    val names = purls.map(_.name).toSet
     assert(
       names.contains("spki-sha256"),
       s"must contain spki-sha256 name, got: $names"
@@ -463,9 +451,9 @@ class PurlConstructionTests extends FunSuite {
     val crl = buildCrlWithUnknownSigOid(pair)
     val state = new CertificatesState(dummyArtifact)
     val purl = state.purlForCrl(crl)
-    assertEquals(purl.getType(), "generic")
-    assertEquals(purl.getNamespace(), "x509")
-    assertEquals(purl.getName(), "crl-sha256")
+    assertEquals(purl.`type`, "generic")
+    assertEquals(purl.namespace, "x509")
+    assertEquals(purl.name, "crl-sha256")
     assertRoundTrips(purl, "CRL pURL structural invariant")
   }
 
@@ -480,9 +468,9 @@ class PurlConstructionTests extends FunSuite {
     )
     val state = new CertificatesState(dummyArtifact)
     val purl = state.purlForSshPubkey(pubkey)
-    assertEquals(purl.getType(), "generic")
-    assertEquals(purl.getNamespace(), "ssh")
-    assertEquals(purl.getName(), "sha256")
+    assertEquals(purl.`type`, "generic")
+    assertEquals(purl.namespace, "ssh")
+    assertEquals(purl.name, "sha256")
     assertRoundTrips(purl, "SSH pubkey pURL structural invariant")
   }
 
@@ -512,17 +500,17 @@ class PurlConstructionTests extends FunSuite {
     assertEquals(purls.length, 2)
     purls.foreach { purl =>
       assertEquals(
-        purl.getType(),
+        purl.`type`,
         "generic",
-        s"SSH cert pURL type must be generic, got ${purl.getType()}"
+        s"SSH cert pURL type must be generic, got ${purl.`type`}"
       )
       assertEquals(
-        purl.getNamespace(),
+        purl.namespace,
         "ssh",
-        s"SSH cert pURL namespace must be ssh, got ${purl.getNamespace()}"
+        s"SSH cert pURL namespace must be ssh, got ${purl.namespace}"
       )
     }
-    val names = purls.map(_.getName()).toSet
+    val names = purls.map(_.name).toSet
     assert(
       names.contains("cert-sha256"),
       s"must contain cert-sha256 name, got: $names"
@@ -545,9 +533,9 @@ class PurlConstructionTests extends FunSuite {
     )
     val state = new CertificatesState(dummyArtifact)
     val purl = state.purlForPrivateKeyPem(pem)
-    assertEquals(purl.getType(), "generic")
-    assertEquals(purl.getNamespace(), "x509")
-    assertEquals(purl.getName(), "spki-sha256")
+    assertEquals(purl.`type`, "generic")
+    assertEquals(purl.namespace, "x509")
+    assertEquals(purl.name, "spki-sha256")
     assertRoundTrips(purl, "Private key PEM pURL structural invariant")
   }
 
@@ -561,9 +549,9 @@ class PurlConstructionTests extends FunSuite {
     )
     val state = new CertificatesState(dummyArtifact)
     val purl = state.purlForPrivateKeyOpenSsh(key)
-    assertEquals(purl.getType(), "generic")
-    assertEquals(purl.getNamespace(), "ssh")
-    assertEquals(purl.getName(), "sha256")
+    assertEquals(purl.`type`, "generic")
+    assertEquals(purl.namespace, "ssh")
+    assertEquals(purl.name, "sha256")
     assertRoundTrips(purl, "Private key OpenSSH pURL structural invariant")
   }
 

--- a/src/test/scala/strategies/SshSecurityKeyVectorTests.scala
+++ b/src/test/scala/strategies/SshSecurityKeyVectorTests.scala
@@ -112,7 +112,7 @@ class SshSecurityKeyVectorTests extends FunSuite {
     val pk = Certificates.parseSshPubkey(w).get
 
     val state = new CertificatesState(w)
-    val purl = state.purlForSshPubkey(pk).canonicalize().nn
+    val purl = state.purlForSshPubkey(pk).toCanonical().nn
     assert(
       purl.contains("sk=true"),
       s"expected sk=true in qualifier set, got $purl"
@@ -162,7 +162,7 @@ class SshSecurityKeyVectorTests extends FunSuite {
     assertEquals(pk.get.algName, "sk-ecdsa-sha2-nistp256@openssh.com")
 
     val state = new CertificatesState(w)
-    val purl = state.purlForSshPubkey(pk.get).canonicalize().nn
+    val purl = state.purlForSshPubkey(pk.get).toCanonical().nn
     assert(purl.contains("sk=true"), s"sk=true missing from $purl")
     assert(purl.contains("alg=ec"), s"alg=ec missing from $purl")
     assert(purl.contains("curve=p-256"), s"curve=p-256 missing from $purl")

--- a/src/test/scala/strategies/X509ClaimWhiteboxTests.scala
+++ b/src/test/scala/strategies/X509ClaimWhiteboxTests.scala
@@ -111,14 +111,14 @@ class X509ClaimWhiteboxTests extends FunSuite {
       "Phase 3 plan: emit both pkg:generic/x509/spki-sha256 and pkg:generic/x509/cert-sha256"
     )
     val spkiPurl =
-      purls.find(_.toString.contains("spki-sha256")).get.canonicalize().nn
+      purls.find(_.name == "spki-sha256").get.toCanonical().nn
     assert(
       spkiPurl.contains(
         "0b9fa5a59eed715c26c1020c711b4f6ec42d58b0015e14337a39dad301c5afc3"
       )
     )
     val certPurl =
-      purls.find(_.toString.contains("cert-sha256")).get.canonicalize().nn
+      purls.find(_.name == "cert-sha256").get.toCanonical().nn
     assert(
       certPurl.contains(
         "96bcec06264976f37460779acf28c5a7cfe8a3c0aae11a8ffcee05c0bddf08c6"


### PR DESCRIPTION
Adopt [`coordinates`](https://github.com/spice-labs-inc/coordinates) — the Spice Labs single source of truth for content identifiers — instead of goatrodeo's own digest/gitoid/purl code, so these identifiers can't drift from the canonical spec.

## What changed

**Intrinsic hashes & gitoids** (`util/Helpers.scala`)
- `GitOIDUtils.computeAllHashes` computes all six identifiers in a **single streamed pass** via `Coordinates.intrinsic(InputStream, contentLength)`, replacing six separate full re-reads of each artifact. Output is byte-identical, so stored identifiers are unaffected.
- `Helpers.sha256Hex` and `md5hashHex` delegate to `Coordinates`.
- Tree/Merkle (`merkleTreeFromGitoids`), `ObjectType`, the streaming `computeGitOID`, and the raw `Array[Byte]` digests stay local — `coordinates` doesn't define those.

**Package URLs** (`util/PURLHelpers.scala`, `omnibor/**`, `strategies/**`)
- Replaced `com.github.packageurl.PackageURL` with `io.spicelabs.coordinates.Purl`. `PURLHelpers.purl(...)` is a small factory over coordinates' plain constructor (it has no builder).
- Strategy purl emission now produces **canonical strings** (`getPurls: Vector[String]`; `Storage.addPurl` / `Item.enhanceItemWithPurls` / `ConnectionAugmentation` take `String`). `coordinates` governs the purls goatrodeo constructs itself (Maven, Docker, Dotnet, Certificates); purls handed back pre-formed by the annatto/baharat readers keep their own canonicalization.
- `packageurl-java` is retained **only** at the reader boundary, since those readers return its `PackageURL`.

## Why strings at the strategy boundary

`coordinates` is stricter and spec-correct: `deb`/`apk`/`rpm`/`alpm` purls **require a namespace**, which the readers don't always supply. Re-validating reader purls through coordinates aborted the build for any OS package. Emitting canonical strings preserves current output while still using coordinates everywhere goatrodeo builds a purl. (A future change can move to fully spec-strict validation as a localized follow-up.)

## Testing

- Full suite green: **1333 passed, 0 failed** (run with a `-Xmx4g` forked test JVM).
- The gitoid/hash suites pass unchanged, confirming byte-identical output.
- Purl structural-invariant, round-trip, and adversarial-encoding tests pass against coordinates' canonicalization.
