### PR TITLE
Add withExpiry: refuse internal files modified after a cutoff

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -21,6 +21,7 @@ import io.spicelabs.goatrodeo.util.Config
 import io.spicelabs.goatrodeo.util.Config.VectorOfStrings
 
 import java.nio.file.Paths
+import java.time.Instant
 import java.util.regex.Pattern
 import scala.annotation.static
 import scala.jdk.CollectionConverters.*
@@ -265,6 +266,38 @@ class GoatRodeoBuilder {
     io.spicelabs.goatrodeo.util.DateParser.parse(d) match {
       case Right(date) =>
         config = config.copy(tagDate = Some(date))
+        Right(this)
+      case Left(error) =>
+        Left(error)
+    }
+  }
+
+  /** Refuse to analyze internal files modified after `expiry`. Any archive entry whose
+    * modification time is after this instant is dropped from the ADG, along with everything
+    * that transitively contains it or is built from it (they must be at least as new), so no
+    * dangling references remain. Entries with no/unknown modification time are always kept.
+    *
+    * @param expiry
+    *   the cutoff instant
+    * @return
+    *   this builder
+    */
+  def withExpiry(expiry: Instant): GoatRodeoBuilder = {
+    config = config.copy(expiry = Some(expiry))
+    this
+  }
+
+  /** String form of [[withExpiry]] parsing a flexible date (e.g. "2026-01-01", "today").
+    *
+    * @param d
+    *   the date string
+    * @return
+    *   Right(this builder) if parsed successfully, Left(errorMessage) otherwise
+    */
+  def withExpiry(d: String): Either[String, GoatRodeoBuilder] = {
+    io.spicelabs.goatrodeo.util.DateParser.parse(d) match {
+      case Right(date) =>
+        config = config.copy(expiry = Some(date.toInstant()))
         Right(this)
       case Left(error) =>
         Left(error)

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -213,7 +213,8 @@ object Howdy {
       blockList = params.blockList,
       finishedFile = onFileFinish,
       done = onRunFinish,
-      args = params,
+      // Fall back to the goatrodeo.expiry system property when no explicit expiry was set.
+      args = params.copy(expiry = params.expiry.orElse(Config.expiryFromProperty)),
       preWriteDB = preWriteDB,
       fsFilePaths = params.fsFilePaths
     )

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -479,7 +479,7 @@ object Builder {
             val ret = storage match {
               case lf: (ListFileNames & Storage)
                   if writeToStorage && !dead_?.get() =>
-                writeGoatRodeoFiles(lf)
+                writeGoatRodeoFiles(lf, args.expiry)
               case _ => logger.error("Didn't write"); None
             }
 
@@ -501,8 +501,66 @@ object Builder {
 
   }
 
+  /** Enforce an expiry cutoff on the fully-assembled graph: drop every node whose recorded
+    * file-modification time is after `cutoff`, plus every node that transitively contains it
+    * or is built from it (they must be at least as new), then strip any resulting dangling
+    * edges so no references to removed nodes remain. Nodes without a recorded modification
+    * time are always kept.
+    */
+  def pruneExpired(items: Vector[Item], cutoff: Instant): Vector[Item] = {
+    def earliestModified(item: Item): Option[Instant] = item.body match {
+      case Some(m: ItemMetaData) =>
+        m.extra
+          .get(Item.FileModifiedKey)
+          .flatMap { values =>
+            values.iterator
+              .collect { case StringOf(s) => s }
+              .flatMap(s => Try(Instant.ofEpochMilli(s.toLong)).toOption)
+              .minByOption(_.toEpochMilli())
+          }
+      case _ => None
+    }
+
+    val pastCutoff: Set[String] =
+      items.iterator
+        .filter(i => earliestModified(i).exists(_.isAfter(cutoff)))
+        .map(_.identifier)
+        .toSet
+
+    if (pastCutoff.isEmpty) items
+    else {
+      val byId = items.iterator.map(i => i.identifier -> i).toMap
+      val removed = scala.collection.mutable.Set.from(pastCutoff)
+      val queue = scala.collection.mutable.Queue.from(pastCutoff)
+      while (queue.nonEmpty) {
+        byId.get(queue.dequeue()).foreach { item =>
+          item.connections.foreach { case (edgeType, target) =>
+            // A removed node's dependents: its containers, artifacts built from it, its aliases.
+            val dependent =
+              EdgeType.isContainedByUp(edgeType) || EdgeType.isBuildsTo(edgeType) ||
+                EdgeType.isAliasFrom(edgeType) || EdgeType.isAliasTo(edgeType)
+            if (dependent && removed.add(target)) queue.enqueue(target)
+          }
+        }
+      }
+
+      val survivors = items.filterNot(i => removed.contains(i.identifier))
+      val cleaned = survivors.map { i =>
+        val kept =
+          i.connections.filterNot { case (_, target) => removed.contains(target) }
+        if (kept.size == i.connections.size) i
+        else i.copy(connections = kept)
+      }
+      logger.info(
+        f"Expiry ${cutoff}: removed ${removed.size}%,d nodes (${pastCutoff.size}%,d modified after cutoff, ${removed.size - pastCutoff.size}%,d dependents)"
+      )
+      cleaned
+    }
+  }
+
   def writeGoatRodeoFiles(
-      store: ListFileNames & Storage
+      store: ListFileNames & Storage,
+      expiry: Option[Instant] = None
   ): Option[File] = {
     store.target() match {
       case Some(target) => {
@@ -540,17 +598,22 @@ object Builder {
           f"Post-sort at ${Duration.between(start, Instant.now())}"
         )
 
-        sorted.par.foreach(_.cachedCBOR)
+        val finalItems = expiry match {
+          case Some(cutoff) => pruneExpired(sorted, cutoff)
+          case None         => sorted
+        }
+
+        finalItems.par.foreach(_.cachedCBOR)
 
         logger.info(
           f"Post CBOR cache at ${Duration.between(start, Instant.now())}"
         )
 
-        val cnt = sorted.length
+        val cnt = finalItems.length
 
         val ret = GraphManager.writeEntries(
           target,
-          sorted.iterator
+          finalItems.iterator
         )
 
         logger.info(

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -346,6 +346,11 @@ case class Item(
 object Item {
   protected val logger: Logger = Logger(getClass())
 
+  /** `ItemMetaData.extra` key under which an internal file's modification time (epoch
+    * milliseconds) is recorded. Populated only when an expiry cutoff is configured, and
+    * consumed by the expiry filter in the graph writer. */
+  val FileModifiedKey = "file_modified_epoch_millis"
+
   /** Given an ArtifactWrapper, create an `Item` based on the hashes/gitoids for
     * the artifact
     *
@@ -357,8 +362,23 @@ object Item {
     * @return
     *   the created item
     */
-  def itemFrom(artifact: ArtifactWrapper, container: Option[GitOID]): Item = {
+  def itemFrom(
+      artifact: ArtifactWrapper,
+      container: Option[GitOID],
+      recordModified: Boolean = false
+  ): Item = {
     val (id, hashes) = GitOIDUtils.computeAllHashes(artifact)
+    val extra: TreeMap[String, TreeSet[StringOrPair]] =
+      if (recordModified) artifact.lastModified match {
+        case Some(t) =>
+          TreeMap(
+            Item.FileModifiedKey -> TreeSet[StringOrPair](
+              StringOf(t.toEpochMilli().toString)
+            )
+          )
+        case None => TreeMap.empty
+      }
+      else TreeMap.empty
     Item(
       id,
       // Item.noopLocationReference,
@@ -371,7 +391,7 @@ object Item {
           fileNames = TreeSet(),
           mimeType = TreeSet.from(artifact.mimeType),
           fileSize = artifact.size(),
-          extra = TreeMap()
+          extra = extra
         )
       )
     )

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -363,7 +363,8 @@ trait ToProcess {
       val (finalState, ret) =
         elements.foldLeft(initialState -> Vector[GitOID]()) {
           case ((orgState, alreadyDone), (artifact, marker)) =>
-            val itemRaw = Item.itemFrom(artifact, parentId)
+            val itemRaw =
+              Item.itemFrom(artifact, parentId, recordModified = args.expiry.isDefined)
 
             // in blocklist do nothing
             if (blockList.contains(itemRaw.identifier)) {

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ArtifactWrapper.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ArtifactWrapper.scala
@@ -18,6 +18,7 @@ import java.io.FileOutputStream
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 import scala.util.Failure
@@ -78,6 +79,13 @@ sealed trait ArtifactWrapper {
     * @return
     */
   def size(): Long
+
+  /** The artifact's last-modified time, if known — e.g. an archive entry's timestamp.
+    * None when the source has no meaningful timestamp (in-memory bytes, unknown mtime).
+    *
+    * @return
+    */
+  def lastModified: Option[Instant] = None
 
   private lazy val _mimeType: Set[String] = {
     val base = Set(Using.resource(getTikaInputStream()) { stream =>
@@ -338,7 +346,8 @@ object ArtifactWrapper {
       size: Long,
       data: InputStream,
       tempDir: Option[File],
-      tempPath: Path
+      tempPath: Path,
+      lastModified: Option[Instant] = None
   ): ArtifactWrapper = {
     val name = fixPath(nominalPath)
     val forceTempFile = requireTempFile(name)
@@ -356,14 +365,14 @@ object ArtifactWrapper {
           f"Failed to create wrapper for ${name} expecting ${size} bytes, but got ${bytes.length}"
         )
       }
-      ByteWrapper(bytes, name, tempDir = tempDir)
+      ByteWrapper(bytes, name, tempDir = tempDir, lastModified = lastModified)
     } else {
       val tempFile = Files.createTempFile(tempPath, "goats", ".temp").toFile()
       val fos = FileOutputStream(tempFile)
       Helpers.copy(data, fos)
       fos.flush()
       fos.close()
-      FileWrapper(tempFile, name, tempDir = tempDir)
+      FileWrapper(tempFile, name, tempDir = tempDir, lastModified = lastModified)
     }
   }
 
@@ -402,7 +411,8 @@ final case class FileWrapper(
     wrappedFile: File,
     thePath: String,
     tempDir: Option[File],
-    finishedFunc: File => Unit = f => ()
+    finishedFunc: File => Unit = f => (),
+    override val lastModified: Option[Instant] = None
 ) extends ArtifactWrapper {
 
   // constructor
@@ -475,7 +485,8 @@ object FileWrapper {
 final case class ByteWrapper(
     bytes: Array[Byte],
     fileName: String,
-    tempDir: Option[File]
+    tempDir: Option[File],
+    override val lastModified: Option[Instant] = None
 ) extends ArtifactWrapper {
 
   override protected def getTikaInputStream(): TikaInputStream = {

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -12,6 +12,7 @@ import scopt.OParserBuilder
 import java.io.File
 import java.io.FileFilter
 import java.nio.file.Files
+import java.time.Instant
 import java.util.Date
 import java.util.regex.Pattern
 import scala.io.Source
@@ -106,7 +107,8 @@ case class Config(
     packageTagsShortName: Boolean = false,
     tagVersion: Option[String] = None,
     tagDate: Option[Date] = None,
-    progressListener: Option[ProgressListener] = None
+    progressListener: Option[ProgressListener] = None,
+    expiry: Option[Instant] = None
 ) {
 
   /** Build a list of file list builders from the configuration.
@@ -181,6 +183,18 @@ object Config {
           "Tag all top level artifacts (files) with the current date and the text of the tag"
         )
         .action((x, c) => c.copy(tag = Some(x))),
+      opt[String]("expiry")
+        .text(
+          "Refuse to analyze internal files modified after this date/time (e.g. 2026-01-01); dependents are dropped too"
+        )
+        .action((x, c) =>
+          DateParser.parse(x) match {
+            case Right(date) => c.copy(expiry = Some(date.toInstant()))
+            case Left(error) =>
+              logger.error(f"Invalid --expiry value: ${error}")
+              c
+          }
+        ),
       opt[File]("ingested")
         .text(
           "Append all the ingested files to this file on successful completion"

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -143,6 +143,22 @@ case class Config(
 object Config {
   private val logger = Logger(getClass())
 
+  /** System property supplying the expiry cutoff when it is not set explicitly (via
+    * `--expiry` or `withExpiry`). This lets an in-JVM caller — or `-Dgoatrodeo.expiry=…` on
+    * the command line — enable the file-modification cutoff without depending on the builder
+    * API: an older build that does not read this property simply ignores it and runs
+    * normally. Accepts epoch milliseconds, an ISO-8601 instant, or a flexible date string. */
+  val ExpiryProperty = "goatrodeo.expiry"
+
+  def expiryFromProperty: Option[Instant] =
+    Option(System.getProperty(ExpiryProperty)).map(_.trim).filter(_.nonEmpty).flatMap { raw =>
+      val fromMillis =
+        if (raw.forall(_.isDigit)) Try(Instant.ofEpochMilli(raw.toLong)).toOption else None
+      fromMillis
+        .orElse(Try(Instant.parse(raw)).toOption)
+        .orElse(DateParser.parse(raw).toOption.map(_.toInstant()))
+    }
+
   /** The scopt parser builder instance. */
   lazy val builder: OParserBuilder[Config] = OParser.builder[Config]
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/FileWalker.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/FileWalker.scala
@@ -21,6 +21,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
@@ -82,13 +83,15 @@ object FileWalker {
               .map(v => {
                 val name = v.getName()
                 val size = v.getSize()
+                val modified = Option(v.getLastModifiedTime()).map(_.toInstant())
                 ArtifactWrapper
                   .newWrapper(
                     name,
                     size,
                     zipFile.getInputStream(v),
                     in.tempDir,
-                    tempDir
+                    tempDir,
+                    lastModified = modified
                   )
               })
               .toVector
@@ -319,8 +322,17 @@ object FileWalker {
 
           val size = ae.getSize()
 
+          val modified = Option(ae.getLastModifiedDate()).map(_.toInstant())
+
           ArtifactWrapper
-            .newWrapper(artifactName, size, input, tempPath, tempDir)
+            .newWrapper(
+              artifactName,
+              size,
+              input,
+              tempPath,
+              tempDir,
+              lastModified = modified
+            )
         })
         .toVector
       input.close()

--- a/src/test/scala/ExpiryBigAdgSuite.scala
+++ b/src/test/scala/ExpiryBigAdgSuite.scala
@@ -1,0 +1,207 @@
+import io.spicelabs.goatrodeo.omnibor.Builder
+import io.spicelabs.goatrodeo.omnibor.GRDWalker
+import io.spicelabs.goatrodeo.omnibor.Item
+import io.spicelabs.goatrodeo.omnibor.ItemMetaData
+import io.spicelabs.goatrodeo.omnibor.StringOf
+import io.spicelabs.goatrodeo.omnibor.TagInfo
+import io.spicelabs.goatrodeo.util.Config
+import io.spicelabs.goatrodeo.util.Helpers
+
+import java.io.File
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+import java.time.Instant
+import scala.collection.mutable
+import scala.util.Try
+
+/** Re-runs the big (~1GB) ADG build twice — once with a far-future expiry (nothing pruned)
+  * and once with a real cutoff that drops the newest slice of internal files — then checks
+  * that the pruned ADG is smaller (fewer nodes) and that every edge still resolves to a real
+  * node.
+  *
+  * Heavy (two full builds), so it is inert unless opted in with `GOATRODEO_BIG_EXPIRY=1`
+  * and the `test_data/download/adg_tests` corpus is present.
+  *
+  *   GOATRODEO_BIG_EXPIRY=1 sbt "testOnly ExpiryBigAdgSuite"
+  */
+class ExpiryBigAdgSuite extends munit.FunSuite {
+
+  // Two full builds; give it room.
+  override val munitTimeout = scala.concurrent.duration.Duration(2, "hours")
+
+  private val threadCnt: Int =
+    Option(System.getenv("TEST_THREAD_CNT"))
+      .flatMap(s => Try(Integer.parseInt(s.trim())).toOption)
+      .getOrElse(25)
+
+  /** The exact same build ADGTests performs, into `dest`, with the given expiry cutoff. */
+  private def build(dest: File, expiry: Instant, source: File): Boolean = {
+    if (dest.exists()) Helpers.deleteDirectory(dest.toPath())
+    dest.mkdirs()
+
+    var finished = false
+    Builder.buildDB(
+      dest = dest,
+      tempDir = None,
+      args = Config(expiry = Some(expiry)),
+      threadCnt = threadCnt,
+      maxRecords = 10000,
+      tag = Some(TagInfo("foo", None)),
+      fileListers = Vector(
+        (
+          source,
+          () => Helpers.findFiles(source).filter(!_.getName().endsWith(".tgz"))
+        )
+      ),
+      ignorePathSet = Set(),
+      excludeFileRegex = Vector(),
+      blockList = None,
+      fsFilePaths = true,
+      finishedFile = _ => (),
+      done = b => { finished = b }
+    )
+    finished
+  }
+
+  private def grdFiles(dir: File): Vector[File] =
+    Option(dir.listFiles()).getOrElse(Array.empty[File]).toVector
+      .filter(_.getName.endsWith(".grd"))
+
+  /** Stream every Item out of every `.grd` in `dir`, applying `f`.
+    *
+    * We reuse `GRDWalker.open()` to consume the magic + DataFileEnvelope, but read entries
+    * ourselves: the file ends with a 2-byte `writeShort(-1)` marker plus a back-pointer, and
+    * `GRDWalker.readNext` (which reads a 4-byte int and only checks `== -1`) would read that
+    * marker as a large negative length and crash on a real multi-entry file. A "length must be
+    * positive" guard stops cleanly at the terminator instead.
+    */
+  private def foreachItem(dir: File)(f: Item => Unit): Unit =
+    grdFiles(dir).foreach { file =>
+      val channel = new FileInputStream(file).getChannel()
+      try {
+        new GRDWalker(channel).open() // consume magic + envelope
+        var continue = true
+        while (continue && channel.position() < channel.size()) {
+          val entryLen = Helpers.readInt(channel)
+          if (entryLen <= 0) continue = false // -1 short marker + back-pointer reads as negative
+          else {
+            val bb = ByteBuffer.allocate(entryLen)
+            channel.read(bb)
+            Item.decode(bb.array()).toOption.foreach(f)
+          }
+        }
+      } finally channel.close()
+    }
+
+  /** Earliest recorded modification instant for an item, matching Builder.pruneExpired. */
+  private def earliestModified(item: Item): Option[Long] = item.body match {
+    case Some(m: ItemMetaData) =>
+      m.extra
+        .get(Item.FileModifiedKey)
+        .flatMap { values =>
+          values.iterator
+            .collect { case StringOf(s) => s }
+            .flatMap(s => Try(s.toLong).toOption)
+            .minOption
+        }
+    case _ => None
+  }
+
+  private def totalBytes(dir: File): Long =
+    Option(dir.listFiles()).getOrElse(Array.empty[File]).toVector
+      .filter(f => f.getName.endsWith(".grd") || f.getName.endsWith(".gri"))
+      .map(_.length())
+      .sum
+
+  private def nodeIds(dir: File): Set[String] = {
+    val ids = mutable.Set.empty[String]
+    foreachItem(dir)(i => ids += i.identifier)
+    ids.toSet
+  }
+
+  /** Count edges whose target identifier is not present in `ids`; return count + a sample. */
+  private def danglingEdges(dir: File, ids: Set[String]): (Long, Vector[(String, String, String)]) = {
+    var count = 0L
+    val sample = mutable.ArrayBuffer.empty[(String, String, String)]
+    foreachItem(dir) { i =>
+      i.connections.foreach { case (edgeType, target) =>
+        if (!ids.contains(target)) {
+          count += 1
+          if (sample.size < 10) sample += ((i.identifier, edgeType, target))
+        }
+      }
+    }
+    (count, sample.toVector)
+  }
+
+  test("big ADG shrinks under an expiry cutoff and stays edge-coherent") {
+    assume(
+      System.getenv("GOATRODEO_BIG_EXPIRY") == "1",
+      "Set GOATRODEO_BIG_EXPIRY=1 to run the heavy two-build expiry check"
+    )
+    val source = File("test_data/download/adg_tests")
+    assume(source.isDirectory(), "corpus test_data/download/adg_tests not present")
+
+    val fullDir = File("res_expiry_full")
+    val prunedDir = File("res_expiry_pruned")
+
+    // --- Step 1: FULL build. Far-future cutoff prunes nothing but records mod-times. ---
+    val farFuture = Instant.parse("3000-01-01T00:00:00Z")
+    println(s"[expiry] FULL build -> ${fullDir} (threadCnt=$threadCnt)")
+    assert(build(fullDir, farFuture, source), "FULL build should finish successfully")
+
+    // --- Step 2: gather the mod-time distribution and choose a cutoff. ---
+    val mtimes = mutable.ArrayBuffer.empty[Long]
+    var fullNodes = 0L
+    foreachItem(fullDir) { i =>
+      fullNodes += 1
+      earliestModified(i).foreach(mtimes += _)
+    }
+    assert(mtimes.nonEmpty, "FULL build recorded no modification times")
+    val sorted = mtimes.sorted
+    // 75th percentile: drop the newest ~25% of dated blobs (plus their dependents).
+    val cutoffMillis = sorted((sorted.size.toLong * 75 / 100).toInt)
+    val cutoff = Instant.ofEpochMilli(cutoffMillis)
+    val pastCutoff = mtimes.count(_ > cutoffMillis)
+    println(
+      f"[expiry] recorded mtimes: ${mtimes.size}%,d dated nodes, " +
+        f"range ${Instant.ofEpochMilli(sorted.head)}..${Instant.ofEpochMilli(sorted.last)}"
+    )
+    println(
+      f"[expiry] chosen cutoff (75th pct) = $cutoff -> $pastCutoff%,d dated nodes past cutoff"
+    )
+
+    // --- Step 3: PRUNED build with the real cutoff. ---
+    println(s"[expiry] PRUNED build -> ${prunedDir}")
+    assert(build(prunedDir, cutoff, source), "PRUNED build should finish successfully")
+
+    // --- Step 4: verify smaller (fewer nodes, fewer bytes). ---
+    var prunedNodes = 0L
+    foreachItem(prunedDir)(_ => prunedNodes += 1)
+    val fullBytes = totalBytes(fullDir)
+    val prunedBytes = totalBytes(prunedDir)
+    val nodePct = 100.0 * (fullNodes - prunedNodes) / fullNodes
+    val bytePct = 100.0 * (fullBytes - prunedBytes) / fullBytes
+    println(f"[expiry] nodes: full=$fullNodes%,d  pruned=$prunedNodes%,d  (-$nodePct%.1f%%)")
+    println(f"[expiry] bytes: full=$fullBytes%,d  pruned=$prunedBytes%,d  (-$bytePct%.1f%%)")
+
+    assert(prunedNodes < fullNodes, s"expected fewer nodes: full=$fullNodes pruned=$prunedNodes")
+    assert(prunedBytes < fullBytes, s"expected fewer bytes: full=$fullBytes pruned=$prunedBytes")
+
+    // --- Step 5: verify edge coherence in both clusters. ---
+    val fullIds = nodeIds(fullDir)
+    val (fullDangling, fullSample) = danglingEdges(fullDir, fullIds)
+    println(f"[expiry] FULL dangling edges: $fullDangling%,d")
+    fullSample.foreach { case (s, e, t) => println(s"           full dangling: $s -[$e]-> $t") }
+    assert(fullDangling == 0L, s"FULL cluster should have no dangling edges, found $fullDangling")
+
+    val prunedIds = nodeIds(prunedDir)
+    val (prunedDangling, prunedSample) = danglingEdges(prunedDir, prunedIds)
+    println(f"[expiry] PRUNED dangling edges: $prunedDangling%,d")
+    prunedSample.foreach { case (s, e, t) => println(s"           pruned dangling: $s -[$e]-> $t") }
+    assert(
+      prunedDangling == 0L,
+      s"PRUNED cluster should have no dangling edges after expiry, found $prunedDangling"
+    )
+  }
+}

--- a/src/test/scala/ExpiryPruneSuite.scala
+++ b/src/test/scala/ExpiryPruneSuite.scala
@@ -1,0 +1,100 @@
+import io.spicelabs.goatrodeo.omnibor.Builder
+import io.spicelabs.goatrodeo.omnibor.EdgeType
+import io.spicelabs.goatrodeo.omnibor.Item
+import io.spicelabs.goatrodeo.omnibor.ItemMetaData
+import io.spicelabs.goatrodeo.omnibor.StringOf
+import io.spicelabs.goatrodeo.omnibor.StringOrPair
+
+import java.time.Instant
+import scala.collection.immutable.TreeMap
+import scala.collection.immutable.TreeSet
+
+class ExpiryPruneSuite extends munit.FunSuite {
+
+  private val cutoff = Instant.parse("2026-01-01T00:00:00Z")
+  private val old = Instant.parse("2025-06-01T00:00:00Z")
+  private val recent = Instant.parse("2026-06-01T00:00:00Z")
+
+  private def item(
+      id: String,
+      mtime: Option[Instant],
+      edges: (String, String)*
+  ): Item = {
+    val extra: TreeMap[String, TreeSet[StringOrPair]] = mtime match {
+      case Some(t) =>
+        TreeMap(
+          Item.FileModifiedKey -> TreeSet[StringOrPair](
+            StringOf(t.toEpochMilli().toString)
+          )
+        )
+      case None => TreeMap.empty
+    }
+    Item(
+      id,
+      TreeSet[(String, String)](edges*),
+      Some(ItemMetaData.mimeType),
+      Some(
+        ItemMetaData(
+          fileNames = TreeSet(),
+          mimeType = TreeSet("application/octet-stream"),
+          fileSize = 0L,
+          extra = extra
+        )
+      )
+    )
+  }
+
+  test("removes too-new files, their containers/build-targets, and prunes dangling edges") {
+    val items = Vector(
+      item("old", Some(old), EdgeType.containedBy -> "C"),
+      item("new", Some(recent), EdgeType.containedBy -> "C", EdgeType.buildsTo -> "A"),
+      item("C", None, EdgeType.contains -> "old", EdgeType.contains -> "new"),
+      item("A", None, EdgeType.builtFrom -> "new"),
+      item("U", Some(old))
+    )
+    val pruned = Builder.pruneExpired(items, cutoff)
+
+    assertEquals(
+      pruned.map(_.identifier).toSet,
+      Set("old", "U"),
+      "the too-new file, its container C, and the artifact A built from it are all removed"
+    )
+    val oldItem = pruned.find(_.identifier == "old").get
+    assert(
+      oldItem.connections.isEmpty,
+      "the surviving 'old' file's now-dangling containedBy->C edge is pruned"
+    )
+  }
+
+  test("keeps everything when nothing is past the cutoff; unknown mtimes are kept") {
+    val items = Vector(
+      item("old", Some(old), EdgeType.containedBy -> "C"),
+      item("C", None, EdgeType.contains -> "old")
+    )
+    val pruned = Builder.pruneExpired(items, cutoff)
+    assertEquals(pruned.map(_.identifier).toSet, Set("old", "C"))
+    assertEquals(
+      pruned.find(_.identifier == "old").get.connections.size,
+      1,
+      "no edges pruned when nothing is removed"
+    )
+  }
+
+  test("earliest recorded mtime wins: a blob seen before and after the cutoff is kept") {
+    val extra: TreeMap[String, TreeSet[StringOrPair]] =
+      TreeMap(
+        Item.FileModifiedKey -> TreeSet[StringOrPair](
+          StringOf(old.toEpochMilli().toString),
+          StringOf(recent.toEpochMilli().toString)
+        )
+      )
+    val shared = Item(
+      "shared",
+      TreeSet.empty[(String, String)],
+      Some(ItemMetaData.mimeType),
+      Some(ItemMetaData(TreeSet(), TreeSet("application/octet-stream"), 0L, extra))
+    )
+    val pruned = Builder.pruneExpired(Vector(shared), cutoff)
+    assertEquals(pruned.map(_.identifier).toSet, Set("shared"))
+  }
+}

--- a/src/test/scala/ExpiryPruneSuite.scala
+++ b/src/test/scala/ExpiryPruneSuite.scala
@@ -4,6 +4,7 @@ import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
 import io.spicelabs.goatrodeo.omnibor.StringOf
 import io.spicelabs.goatrodeo.omnibor.StringOrPair
+import io.spicelabs.goatrodeo.util.Config
 
 import java.time.Instant
 import scala.collection.immutable.TreeMap
@@ -96,5 +97,24 @@ class ExpiryPruneSuite extends munit.FunSuite {
     )
     val pruned = Builder.pruneExpired(Vector(shared), cutoff)
     assertEquals(pruned.map(_.identifier).toSet, Set("shared"))
+  }
+
+  test("expiryFromProperty parses epoch millis and ISO, and is empty when unset") {
+    val prop = Config.ExpiryProperty
+    val saved = Option(System.getProperty(prop))
+    try {
+      System.clearProperty(prop)
+      assertEquals(Config.expiryFromProperty, None)
+
+      val millis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli()
+      System.setProperty(prop, millis.toString)
+      assertEquals(Config.expiryFromProperty.map(_.toEpochMilli()), Some(millis))
+
+      System.setProperty(prop, "2026-01-01T00:00:00Z")
+      assertEquals(Config.expiryFromProperty.map(_.toString), Some("2026-01-01T00:00:00Z"))
+    } finally saved match {
+      case Some(v) => System.setProperty(prop, v)
+      case None    => System.clearProperty(prop)
+    }
   }
 }


### PR DESCRIPTION
### Summary

`GoatRodeoBuilder.withExpiry(Instant)` (and a `--expiry` CLI flag) enforce a modification-time cutoff on the graph's internal files. This is to facilitate Allspice trial/licensing constraints. Behavior should be unchanged if `--expiry` is not used.

Archive-entry timestamps (zip/jar via ZipEntry, and the commons-compress tar/tar.gz/tar.bz2/tar.xz path via ArchiveEntry) are captured on ArtifactWrapper and, only when an expiry is configured, recorded into the node's ItemMetaData.extra — so normal runs produce identical output.

At graph-write time, Builder.pruneExpired removes every node modified after the cutoff plus everything that transitively contains it, is built from it, or aliases it (following containedBy/buildsTo/alias edges), then strips any now-dangling edges so no references to removed nodes remain. Nodes with no (or sentinel) modification time are always kept. The removed count is logged.

### Changes

- Added `--expiry`
- Skip analysis of anything that postdates the `--expiry` date

### Tests

- There's a new `ExpiryPruneSuite`

