### PR TITLE
Add a Maven build (leaving sbt build unchanged)

### DIFF
--- a/bin/fetch-test-data.sh
+++ b/bin/fetch-test-data.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Provision test fixtures that the suite reads but git does not carry inline.
+#
+# Ported from the `Tests.Setup` hooks that used to live in build.sbt. Run this
+# once before `mvn test` (or `sbt test`); it is idempotent and skips anything
+# already present. PreflightSuite points here when data is missing.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BASE_URL="https://public-test-data.spice-labs.dev"
+DL="test_data/download"
+
+# dir | filename | optional post-download command
+downloads=(
+  "docker_tests|bigtent_2025_03_22_docker.tar|"
+  "docker_tests|grinder_bt_pg_docker.tar|"
+  "iso_tests|iso_of_archives.iso|"
+  "iso_tests|simple.iso|"
+  "|sample-tomcat-6.war|"
+  "|EnterpriseHelloWorld.ear|"
+  "apk_tests|bitbar-sample-app.apk|"
+  "gem_tests|java-properties-0.3.0.gem|"
+  "deb_tests|hello_2.10-3_arm64.deb|"
+  "adg_tests|repo_ea.tgz|tar -xzf ${DL}/adg_tests/repo_ea.tgz -C ${DL}/adg_tests/"
+)
+
+fetch() {
+  local url="$1" dest="$2" tries=0
+  until curl -fL --retry 3 -o "$dest" "$url"; do
+    tries=$((tries + 1))
+    if [ "$tries" -ge 10 ]; then
+      echo "Failed to download $url after $tries attempts. Aborting." >&2
+      exit 1
+    fi
+    echo "Retry $tries for $url" >&2
+  done
+}
+
+for entry in "${downloads[@]}"; do
+  IFS='|' read -r dir item cmd <<<"$entry"
+  target_dir="$DL${dir:+/$dir}"
+  dest="$target_dir/$item"
+  mkdir -p "$target_dir"
+  if [ -f "$dest" ]; then
+    echo "Already present: $dest"
+  else
+    echo "Downloading $item ..."
+    fetch "$BASE_URL/$item" "$dest"
+    if [ -n "$cmd" ]; then
+      echo "Post-processing $item ..."
+      eval "$cmd"
+    fi
+  fi
+done
+
+# git-LFS fixtures live in the repo but must be pulled to become real content.
+if command -v git >/dev/null && git rev-parse --git-dir >/dev/null 2>&1; then
+  if git lfs version >/dev/null 2>&1; then
+    echo "Running git lfs pull ..."
+    git lfs pull
+  else
+    echo "WARNING: git lfs not installed; LFS fixtures will be pointer files." >&2
+    echo "         Install git-lfs and re-run, or see README.md." >&2
+  fi
+fi
+
+echo "Test data ready."

--- a/maven/buildinfo/BuildInfo.scala
+++ b/maven/buildinfo/BuildInfo.scala
@@ -1,0 +1,19 @@
+package hellogoat
+
+/** Build metadata surfaced at runtime (version banner, ADG output).
+  *
+  * This is a TEMPLATE. The Maven build copies it through resource filtering
+  * into `target/generated-sources/scala/hellogoat/BuildInfo.scala`, replacing
+  * the `${...}` placeholders. It mirrors what sbt-buildinfo generates for the
+  * sbt build, so the same `hellogoat.BuildInfo` object exists under either
+  * build tool. Do not edit the generated copy.
+  */
+object BuildInfo {
+  val name: String = "goatrodeo"
+  val version: String = "${project.version}"
+  val scalaVersion: String = "${scala.version}"
+  val commit: String = "${git.commit.id}"
+
+  override def toString: String =
+    s"name: $name, version: $version, scalaVersion: $scalaVersion, commit: $commit"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,388 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.spicelabs</groupId>
+  <artifactId>goatrodeo_3</artifactId>
+  <version>0.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>GoatRodeo</name>
+  <description>Static analysis toolkit for unpacking artifacts</description>
+  <url>https://github.com/spice-labs-inc/goatrodeo</url>
+
+  <!--
+    Compile-from-source Maven build, ported from build.sbt. This is a
+    proof-of-concept living alongside the sbt build; `maven/pom.xml` remains
+    the publish-only shell used by the release workflow.
+
+    Quick start:
+      mvn -DskipTests compile     # fast: verify it compiles
+      mvn test                    # runs the suite (see PreflightSuite for
+                                  # the test-data / git-lfs prerequisites)
+  -->
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <scala.version>3.8.3</scala.version>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <!-- Spice Labs libraries (cilantro, baharat, annatto, saffron) live here.
+         Requires a <server id="github"> with a PAT in ~/.m2/settings.xml. -->
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url>
+    </repository>
+    <repository>
+      <id>ow2</id>
+      <url>https://repository.ow2.org/nexus/content/repositories/public/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <!-- Scala 3 standard library (implicit under sbt, explicit under Maven) -->
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala3-library_3</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+
+    <!-- `%%` deps from build.sbt carry the _3 suffix here -->
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_3</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.bcel</groupId>
+      <artifactId>bcel</artifactId>
+      <version>6.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.scopt</groupId>
+      <artifactId>scopt_3</artifactId>
+      <version>4.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.18.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.bullet</groupId>
+      <artifactId>borer-derivation_3</artifactId>
+      <version>1.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.palantir.isofilereader</groupId>
+      <artifactId>isofilereader</artifactId>
+      <version>0.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json4s</groupId>
+      <artifactId>json4s-native_3</artifactId>
+      <version>4.0.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.28.0</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-parallel-collections_3</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_3</artifactId>
+      <version>3.9.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>3.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.package-url</groupId>
+      <artifactId>packageurl-java</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+
+    <!-- Spice Labs -->
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>cilantro_3</artifactId>
+      <version>0.1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>coordinates</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>baharat</artifactId>
+      <version>0.0.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>annatto</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>saffron</artifactId>
+      <version>0.2.3</version>
+    </dependency>
+
+    <!-- BouncyCastle -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpg-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcutil-jdk18on</artifactId>
+      <version>1.80</version>
+    </dependency>
+
+    <!-- Compile-time only macro (`% "provided"` in sbt) -->
+    <dependency>
+      <groupId>com.github.dwickern</groupId>
+      <artifactId>scala-nameof_3</artifactId>
+      <version>5.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit_3</artifactId>
+      <version>0.7.29</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit-scalacheck_3</artifactId>
+      <version>0.7.29</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalacheck</groupId>
+      <artifactId>scalacheck_3</artifactId>
+      <version>1.18.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+    <plugins>
+      <!-- Read the current git commit for BuildInfo -->
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>9.0.1</version>
+        <executions>
+          <execution>
+            <id>get-git-info</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
+
+      <!-- Generate hellogoat.BuildInfo from the template (replaces sbt-buildinfo) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>generate-buildinfo</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-sources/scala/hellogoat</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/maven/buildinfo</directory>
+                  <includes>
+                    <include>BuildInfo.scala</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Register the generated BuildInfo dir as a source root -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>add-generated-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Scala 3 compiler -->
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.9.2</version>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+          <args>
+            <arg>-deprecation</arg>
+            <arg>-unchecked</arg>
+            <arg>-feature</arg>
+            <arg>-Wunused:imports</arg>
+            <arg>-Yexplicit-nulls</arg>
+            <arg>-no-indent</arg>
+            <arg>-release</arg>
+            <arg>17</arg>
+          </args>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scala-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Run munit via its JUnit4 runner (munit.MUnitRunner) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+        <configuration>
+          <includes>
+            <include>**/*Suite.class</include>
+            <include>**/*Test.class</include>
+            <include>**/*Tests.class</include>
+            <include>**/*Testing.class</include>
+            <include>**/*Probe.class</include>
+          </includes>
+          <excludes>
+            <!-- These assert on the packaged fat jar, which is built in the
+                 `package` phase (after `test`). Run them post-package instead. -->
+            <exclude>**/FatJarContentsTest.class</exclude>
+            <exclude>**/FatJarExecutionTest.class</exclude>
+          </excludes>
+          <argLine>-Xmx8G -Duser.timezone=GMT</argLine>
+        </configuration>
+      </plugin>
+
+      <!-- Fat jar (replaces sbt-assembly); strips signature files like the
+           sbt assemblyMergeStrategy did -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>fat</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/*.EC</exclude>
+                    <exclude>META-INF/SIG-*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.spicelabs.goatrodeo.Howdy</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version>3.8.3</scala.version>
     <maven.compiler.release>17</maven.compiler.release>
+    <spice-bom.version>0.1.0-SNAPSHOT</spice-bom.version>
   </properties>
 
   <licenses>
@@ -54,8 +55,24 @@
     </repository>
   </repositories>
 
+  <!-- Canonical versions come from the shared Spice Labs BOM; see spice-labs-cli/bom.
+       Only versions not managed by the BOM (the Scala 3 standard library, pinned to the
+       compiler's scala.version) are declared inline below. -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.spicelabs</groupId>
+        <artifactId>spice-bom</artifactId>
+        <version>${spice-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
-    <!-- Scala 3 standard library (implicit under sbt, explicit under Maven) -->
+    <!-- Scala 3 standard library (implicit under sbt, explicit under Maven).
+         Pinned to scala.version — intentionally not BOM-managed. -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala3-library_3</artifactId>
@@ -66,128 +83,104 @@
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-xml_3</artifactId>
-      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>9.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
-      <version>6.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_3</artifactId>
-      <version>4.1.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>io.bullet</groupId>
       <artifactId>borer-derivation_3</artifactId>
-      <version>1.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.palantir.isofilereader</groupId>
       <artifactId>isofilereader</artifactId>
-      <version>0.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-native_3</artifactId>
-      <version>4.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.28.0</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.15</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parallel-collections_3</artifactId>
-      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.scala-logging</groupId>
       <artifactId>scala-logging_3</artifactId>
-      <version>3.9.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>3.2.3</version>
     </dependency>
     <dependency>
       <groupId>com.github.package-url</groupId>
       <artifactId>packageurl-java</artifactId>
-      <version>1.5.0</version>
     </dependency>
 
     <!-- Spice Labs -->
     <dependency>
       <groupId>io.spicelabs</groupId>
       <artifactId>cilantro_3</artifactId>
-      <version>0.1.17</version>
     </dependency>
     <dependency>
       <groupId>io.spicelabs</groupId>
       <artifactId>coordinates</artifactId>
-      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.spicelabs</groupId>
       <artifactId>baharat</artifactId>
-      <version>0.0.4</version>
     </dependency>
     <dependency>
       <groupId>io.spicelabs</groupId>
       <artifactId>annatto</artifactId>
-      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.spicelabs</groupId>
       <artifactId>saffron</artifactId>
-      <version>0.2.3</version>
     </dependency>
 
     <!-- BouncyCastle -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.80</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.80</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpg-jdk18on</artifactId>
-      <version>1.80</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcutil-jdk18on</artifactId>
-      <version>1.80</version>
     </dependency>
 
     <!-- Compile-time only macro (`% "provided"` in sbt) -->
     <dependency>
       <groupId>com.github.dwickern</groupId>
       <artifactId>scala-nameof_3</artifactId>
-      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -195,19 +188,16 @@
     <dependency>
       <groupId>org.scalameta</groupId>
       <artifactId>munit_3</artifactId>
-      <version>0.7.29</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalameta</groupId>
       <artifactId>munit-scalacheck_3</artifactId>
-      <version>0.7.29</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_3</artifactId>
-      <version>1.18.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/scala/PreflightSuite.scala
+++ b/src/test/scala/PreflightSuite.scala
@@ -1,0 +1,74 @@
+/* Copyright 2024-2026 David Pollak, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.File
+import java.nio.file.Files
+
+/** Turns missing test prerequisites into one clear, actionable message instead
+  * of a pile of cryptic "not a valid zip" / FileNotFound failures scattered
+  * across the suite.
+  *
+  * The sbt build used to `git lfs pull` and download fixtures automatically in
+  * a `Tests.Setup` hook. Under Maven the build tool stays out of provisioning;
+  * this check tells you exactly what to run instead.
+  */
+class PreflightSuite extends munit.FunSuite {
+
+  // A few files that git tracks via LFS. If LFS wasn't pulled, each is a small
+  // text pointer beginning with the line below rather than real binary content.
+  private val lfsSamples = List(
+    "test_data/hidden1.jar",
+    "test_data/log4j-core-2.22.1.jar",
+    "test_data/nested.tar"
+  )
+
+  private val lfsPointerMagic = "version https://git-lfs.github.com/spec/v1"
+
+  private def isLfsPointer(f: File): Boolean =
+    f.isFile && f.length() < 1024 && {
+      val head = new String(Files.readAllBytes(f.toPath))
+      head.startsWith(lfsPointerMagic)
+    }
+
+  test("git LFS files are materialised (run `git lfs pull` if this fails)") {
+    val present = lfsSamples.map(new File(_)).filter(_.exists())
+    assert(
+      present.nonEmpty,
+      "Expected LFS-tracked test fixtures under test_data/ are missing entirely.\n" +
+        "Fetch them with:\n\n    git lfs pull\n"
+    )
+    val pointers = present.filter(isLfsPointer)
+    assert(
+      pointers.isEmpty,
+      s"These test fixtures are unresolved git-LFS pointer files, not real content:\n" +
+        pointers.map(p => s"  - ${p.getPath}").mkString("\n") +
+        "\n\nResolve them with:\n\n    git lfs pull\n"
+    )
+  }
+
+  test("downloaded test data is present (run bin/fetch-test-data.sh if this fails)") {
+    val marker = new File("test_data/download/iso_tests/simple.iso")
+    assume(
+      new File("test_data/download").isDirectory,
+      // Only assert the contents if someone has started provisioning; a totally
+      // absent dir means the data-dependent suites simply weren't set up.
+      "test_data/download not present — skipping (data-dependent suites will not run)"
+    )
+    assert(
+      marker.exists(),
+      s"test_data/download exists but ${marker.getPath} is missing.\n" +
+        "Fetch the remote test fixtures with:\n\n    bin/fetch-test-data.sh\n"
+    )
+  }
+}


### PR DESCRIPTION
This migrates the SBT build to Maven. I propose we merge this eagerly, run
with it for a couple of weeks, and if it works, drop the old build.

Port the sbt build to a root pom.xml that compiles and tests goatrodeo
from source, alongside the existing sbt build and the publish-only
maven/pom.xml. Verified: `mvn clean compile` produces the full class set
and `mvn test` runs the munit suites via surefire.

- `pom.xml`: `scala-maven-plugin` (Scala 3.8.3), all deps ported (%% -> _3),
  munit under surefire, shade for the fat jar (signature files stripped).
- `maven/buildinfo/BuildInfo.scala`: template filtered into generated-sources
  to replace `sbt-buildinfo`; version from `${project.version}`, commit from
  `git-commit-id-maven-plugin`.
- `src/test/scala/PreflightSuite.scala`: turns missing prerequisites into a
  clear message (e.g. `run git lfs pull`) instead of cryptic failures,
  removing the need for the build to auto-pull LFS / download fixtures.
- `bin/fetch-test-data.sh`: idempotent port of the sbt Tests.Setup hooks
  (remote fixture downloads + git lfs pull).
