### PR TITLE
Bump spice-bom to 1.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version>3.8.3</scala.version>
     <maven.compiler.release>17</maven.compiler.release>
-    <spice-bom.version>0.1.0-SNAPSHOT</spice-bom.version>
+    <spice-bom.version>1.0.0-SNAPSHOT</spice-bom.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
The shared BOM `io.spicelabs:spice-bom` was re-baselined from `0.1.0-SNAPSHOT` to `1.0.0-SNAPSHOT` in spice-labs-cli (stable 1.x release line). This updates goatrodeo's imported `spice-bom.version` so it resolves the current BOM.

One-line change to `pom.xml`; no dependency versions change (they all still come from the BOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)