### PR TITLE
Run Maven tests in parallel forked JVMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # macOS
 .DS_Store
 
+# Surefire's `runOrder=balanced` timing cache, written to the project root
+.surefire-*
+
 # sbt specific
 dist/*
 target/

--- a/README.md
+++ b/README.md
@@ -236,10 +236,22 @@ git clone https://github.com/spice-labs-inc/goatrodeo.git
 
 # Run tests
 cd goatrodeo
-mvn clean verify
+mvn clean verify  # independent test classes run in parallel forked JVMs
+sbt test          # the sbt build is still supported
 
 # Submit a PR against the `next` branch
 ```
+
+`mvn test` spreads test classes over forked JVMs — one per two cores, 4 GB heap
+each. Tune that for your machine, or disable it when investigating a
+test-isolation problem:
+
+```bash
+mvn test -Dtest.forkCount=1C  # one fork per core, needs more RAM
+mvn test -Dtest.forkCount=1   # one JVM, strictly serial
+```
+
+Setting `TEST_THREAD_CNT` (as CI does) selects a single-JVM serial run.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,14 @@
       mvn test                    # runs the unit-test suite (see PreflightSuite
                                   # for the test-data / git-lfs prerequisites)
       mvn verify                  # runs unit tests + fat-jar integration tests
+      mvn test -Dtest.forkCount=1 # serial run, for debugging test isolation
 
     Environment-based test tuning (mirrors build.sbt):
-      - TEST_THREAD_CNT unset -> dev mode: up to 4 forked JVMs in parallel
-      - TEST_THREAD_CNT set   -> CI mode: single non-forked JVM
-      - TEST_FORK set         -> force 4 forked JVMs even when TEST_THREAD_CNT is set
+      - TEST_THREAD_CNT unset -> dev mode: test classes spread over forked JVMs,
+                                 one fork per two cores
+      - TEST_THREAD_CNT set   -> CI mode: a single forked JVM
+      - TEST_FORK set         -> restore the parallel forks even when
+                                 TEST_THREAD_CNT is set
 
     Publishing:
       - distributionManagement points at GitHub Packages, matching build.sbt's
@@ -71,27 +74,29 @@
     <json-schema-validator.version>1.5.4</json-schema-validator.version>
     <zstd-jni.version>1.5.6-9</zstd-jni.version>
 
-    <!-- Test tuning (mirrors build.sbt) -->
-    <!-- Test forking/parallelism tuning.
-         TEST_THREAD_CNT=anything switches to a single non-forked JVM for CI.
-         TEST_FORK=anything forces forking.
-         Independent test classes run in parallel across up to 4 forked JVMs,
-         matching build.sbt's `Test / testForkedParallel := true`.
-         GC warnings are redirected to a file (-Xlog:disable followed by a
-         file selector) because the G1GC GCLocker warning is written to the
-         native console stream and corrupts Surefire's IPC channel when tests
-         fork. -Xmx16G is required for memory-intensive suites such as ADGTests. -->
-    <test.forkCount>4</test.forkCount>
+    <!-- Test parallelism: independent test classes are distributed over several
+         forked JVMs, restoring what sbt's default `Test / parallelExecution`
+         gave us. Lower it (-Dtest.forkCount=1) on a memory-constrained machine.
+
+         Surefire's in-JVM `<parallel>classes</parallel>` does NOT work here and
+         is deliberately not used: it is implemented by JUnit's ParallelComputer,
+         which can only schedule `ParentRunner`s, and munit's MUnitRunner is a
+         plain `Runner`. Setting it is silently a no-op — measured at 156s
+         against 153s serial for the same three suites, where forkCount=3 took
+         80s.
+
+         `0.5C` is half the available cores. Fewer, fatter forks measured
+         *slower* on a 12-core box (3 forks: 130s and 195s; 6 forks: 149s and
+         143s) — with only a handful of heavy suites, coarse forks sometimes put
+         two of them behind each other, and the heaviest suite is internally
+         multi-threaded anyway. -->
+    <test.forkCount>0.5C</test.forkCount>
     <test.reuseForks>true</test.reuseForks>
-    <!-- Dev mode mirrors build.sbt's `fork := true` and
-         `Test / testForkedParallel := true`: independent test classes run in
-         parallel across up to 4 forked JVMs. -->
-    <test.parallel>none</test.parallel>
-    <test.threadCount>4</test.threadCount>
-    <!-- -Xmx16G is required for memory-intensive suites such as ADGTests.
-         GC warnings are redirected to a file so they do not corrupt
-         Surefire's IPC channel in forked JVMs. -->
-    <test.argLine>-Xmx16G -Duser.timezone=GMT -Xlog:disable -Xlog:gc+alloc=warning:file=${project.build.directory}/gc-%p.log</test.argLine>
+    <!-- Per fork, so keep forkCount * Xmx within the machine's RAM. GC warnings
+         go to a file because the G1 GCLocker warning is written to the native
+         console stream, which corrupts surefire's IPC channel with a forked
+         JVM. -->
+    <test.argLine>-Xmx4G -Duser.timezone=GMT -Xlog:disable -Xlog:gc+alloc=warning:file=${project.build.directory}/gc-%p.log</test.argLine>
   </properties>
 
   <licenses>
@@ -507,8 +512,12 @@
           </excludes>
           <forkCount>${test.forkCount}</forkCount>
           <reuseForks>${test.reuseForks}</reuseForks>
-          <parallel>${test.parallel}</parallel>
-          <threadCount>${test.threadCount}</threadCount>
+          <!-- Spread classes over the forks by their previous run's duration,
+               so the one dominant suite (ADGTests) starts first rather than
+               landing last on an otherwise idle fork. -->
+          <runOrder>balanced</runOrder>
+          <!-- munit writes progress to stdout; with several forks the
+               interleaved output is unreadable on the console. -->
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <argLine>${test.argLine}</argLine>
         </configuration>
@@ -626,11 +635,14 @@
     </plugins>
   </build>
 
-  <!-- Environment-based test tuning, matching build.sbt:
-       - TEST_THREAD_CNT unset -> dev mode: forked JVMs, up to 4 concurrent forks
-       - TEST_THREAD_CNT set   -> CI mode: no forking, no parallelism
-       - TEST_FORK set         -> force forking even when TEST_THREAD_CNT is set,
-                                  but keep parallelism disabled (CI mode) -->
+  <!-- Environment-based test tuning, matching build.sbt's conventions:
+       - TEST_THREAD_CNT unset -> dev mode: classes spread over forked JVMs,
+                                  one fork per two cores
+       - TEST_THREAD_CNT set   -> CI mode: a single forked JVM, which is all a
+                                  GitHub runner's memory can afford
+       - TEST_FORK set         -> restore the parallel forks even when
+                                  TEST_THREAD_CNT is set (declared last, so it
+                                  wins when both profiles are active) -->
   <profiles>
     <profile>
       <id>ci</id>
@@ -640,8 +652,8 @@
         </property>
       </activation>
       <properties>
-        <test.forkCount>0</test.forkCount>
-        <test.parallel>none</test.parallel>
+        <test.forkCount>1</test.forkCount>
+        <test.argLine>-Xmx8G -Duser.timezone=GMT</test.argLine>
       </properties>
     </profile>
     <profile>
@@ -652,7 +664,8 @@
         </property>
       </activation>
       <properties>
-        <test.forkCount>4</test.forkCount>
+        <test.forkCount>0.5C</test.forkCount>
+        <test.argLine>-Xmx4G -Duser.timezone=GMT -Xlog:disable -Xlog:gc+alloc=warning:file=${project.build.directory}/gc-%p.log</test.argLine>
       </properties>
     </profile>
   </profiles>

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -159,19 +159,20 @@ object Config {
     */
   val ExpiryProperty = "goatrodeo.expiry"
 
+  /** Parse an expiry cutoff from its textual form: epoch milliseconds, an ISO-8601 instant, or
+    * a flexible date string. Kept separate from [[expiryFromProperty]] so the parsing rules
+    * can be tested without mutating the process-global system property. */
+  def parseExpiry(raw: String): Option[Instant] =
+    Option(raw).map(_.trim).filter(_.nonEmpty).flatMap { raw =>
+      val fromMillis =
+        if (raw.forall(_.isDigit)) Try(Instant.ofEpochMilli(raw.toLong)).toOption else None
+      fromMillis
+        .orElse(Try(Instant.parse(raw)).toOption)
+        .orElse(DateParser.parse(raw).toOption.map(_.toInstant()))
+    }
+
   def expiryFromProperty: Option[Instant] =
-    Option(System.getProperty(ExpiryProperty))
-      .map(_.trim)
-      .filter(_.nonEmpty)
-      .flatMap { raw =>
-        val fromMillis =
-          if (raw.forall(_.isDigit))
-            Try(Instant.ofEpochMilli(raw.toLong)).toOption
-          else None
-        fromMillis
-          .orElse(Try(Instant.parse(raw)).toOption)
-          .orElse(DateParser.parse(raw).toOption.map(_.toInstant()))
-      }
+    Option(System.getProperty(ExpiryProperty)).flatMap(parseExpiry)
 
   /** The scopt parser builder instance. */
   lazy val builder: OParserBuilder[Config] = OParser.builder[Config]

--- a/src/test/scala/ADGTests.scala
+++ b/src/test/scala/ADGTests.scala
@@ -14,6 +14,12 @@ import scala.util.Success
 import scala.util.Try
 
 class ADGTests extends munit.FunSuite {
+
+  // Builds an ADG over the whole ~10 GB adg_tests corpus; munit's 30-second
+  // default is nowhere near enough, and it is looser still when this runs
+  // alongside other test classes.
+  override val munitTimeout = scala.concurrent.duration.Duration(1, "hour")
+
   test("Questionable archives do not cause exceptions") {
     val source = File("test_data/download/adg_tests/repo_ea")
 
@@ -39,7 +45,12 @@ class ADGTests extends munit.FunSuite {
 
     if (source.isDirectory()) {
 
-      val resForBigTent = File("res_for_big_tent")
+      // Under `target/` rather than the repo root: suites now run in parallel
+      // forks that share one filesystem, and this build writes a multi-GB tree
+      // that should not land next to the sources or collide with another
+      // suite's output.
+      val resForBigTent = File("target/test-out/res_for_big_tent")
+      resForBigTent.getParentFile().mkdirs()
 
       // delete files if they exist
       if (resForBigTent.exists()) {

--- a/src/test/scala/DockerSuite.scala
+++ b/src/test/scala/DockerSuite.scala
@@ -16,6 +16,12 @@ import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
 
 class DockerSuite extends munit.FunSuite {
+
+  // Whichever suite touches DockerTestFixtures first pays for parsing the
+  // multi-hundred-MB docker tarballs, which exceeds munit's 30-second default
+  // on its own — and more so when other test classes are running concurrently.
+  override val munitTimeout = scala.concurrent.duration.Duration(30, "minutes")
+
   val logger = Logger(getClass())
 
   def createTestItem(id: String): Item = {

--- a/src/test/scala/ExpiryBigAdgSuite.scala
+++ b/src/test/scala/ExpiryBigAdgSuite.scala
@@ -161,8 +161,11 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
       "corpus test_data/download/adg_tests not present"
     )
 
-    val fullDir = File("res_expiry_full")
-    val prunedDir = File("res_expiry_pruned")
+    // Under `target/` for the same reason as ADGTests: parallel suites should
+    // not scatter multi-GB build output across the repo root.
+    val fullDir = File("target/test-out/res_expiry_full")
+    val prunedDir = File("target/test-out/res_expiry_pruned")
+    fullDir.getParentFile().mkdirs()
 
     // --- Step 1: FULL build. Far-future cutoff prunes nothing but records mod-times. ---
     val farFuture = Instant.parse("3000-01-01T00:00:00Z")

--- a/src/test/scala/ExpiryPruneSuite.scala
+++ b/src/test/scala/ExpiryPruneSuite.scala
@@ -112,31 +112,27 @@ class ExpiryPruneSuite extends munit.FunSuite {
     assertEquals(pruned.map(_.identifier).toSet, Set("shared"))
   }
 
-  test(
-    "expiryFromProperty parses epoch millis and ISO, and is empty when unset"
-  ) {
-    val prop = Config.ExpiryProperty
-    val saved = Option(System.getProperty(prop))
-    try {
-      System.clearProperty(prop)
+  // Asserts against `Config.parseExpiry` rather than setting the
+  // `goatrodeo.expiry` system property. The property is process-global, so a
+  // test that mutates it constrains how the suite may ever be scheduled; the
+  // parsing rules are what this test is actually about.
+  test("parseExpiry parses epoch millis and ISO, and is empty when blank") {
+    assertEquals(Config.parseExpiry(""), None)
+    assertEquals(Config.parseExpiry("   "), None)
+
+    val millis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli()
+    assertEquals(Config.parseExpiry(millis.toString).map(_.toEpochMilli()), Some(millis))
+
+    assertEquals(
+      Config.parseExpiry("2026-01-01T00:00:00Z").map(_.toString),
+      Some("2026-01-01T00:00:00Z")
+    )
+  }
+
+  test("expiryFromProperty is empty when the property is unset") {
+    // Read-only, so it cannot disturb anything else. The parsing behaviour
+    // itself is covered by the `parseExpiry` test above.
+    if (System.getProperty(Config.ExpiryProperty) == null)
       assertEquals(Config.expiryFromProperty, None)
-
-      val millis = Instant.parse("2026-01-01T00:00:00Z").toEpochMilli()
-      System.setProperty(prop, millis.toString)
-      assertEquals(
-        Config.expiryFromProperty.map(_.toEpochMilli()),
-        Some(millis)
-      )
-
-      System.setProperty(prop, "2026-01-01T00:00:00Z")
-      assertEquals(
-        Config.expiryFromProperty.map(_.toString),
-        Some("2026-01-01T00:00:00Z")
-      )
-    } finally
-      saved match {
-        case Some(v) => System.setProperty(prop, v)
-        case None    => System.clearProperty(prop)
-      }
   }
 }

--- a/src/test/scala/GraphManagerReadNextSuite.scala
+++ b/src/test/scala/GraphManagerReadNextSuite.scala
@@ -13,23 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 import ch.qos.logback.classic.Level
-import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.read.ListAppender
 import io.spicelabs.goatrodeo.omnibor.GRDWalker
 import io.spicelabs.goatrodeo.omnibor.GraphManager
 import io.spicelabs.goatrodeo.omnibor.Item
 import io.spicelabs.goatrodeo.omnibor.ItemMetaData
+import io.spicelabs.goatrodeo.testsupport.LogCapture
 import io.spicelabs.goatrodeo.util.Helpers
 import munit.FunSuite
-import org.slf4j.LoggerFactory
 
 import java.io.FileInputStream
 import java.nio.ByteBuffer
 import java.nio.file.Files
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
-import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 /** Phase 0 (0.8) — GRDWalker.readNext returns None for corrupt CBOR entry.
@@ -173,27 +170,11 @@ class GraphManagerReadNextSuite extends FunSuite {
     }
   }
 
+  // Root-logger capture, shared with PrivateKeyLogCaptureTests, which ran an
+  // identical copy of this dance. See LogCapture.
   private def runWithCapture[T](
       body: () => T
-  ): (T, Vector[ILoggingEvent]) = {
-    val ctx =
-      LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    val root = ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
-    val appender = new ListAppender[ILoggingEvent]()
-    appender.setContext(ctx)
-    appender.start()
-    root.addAppender(appender)
-    val priorLevel = root.getLevel
-    root.setLevel(Level.ALL)
-    try {
-      val result = body()
-      (result, appender.list.asScala.toVector)
-    } finally {
-      root.setLevel(priorLevel)
-      root.detachAppender(appender)
-      appender.stop()
-    }
-  }
+  ): (T, Vector[ILoggingEvent]) = LogCapture(body)
 
   test("GRDWalker - readNext logs WARN on corrupt CBOR entry") {
 

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/PackageTagIntegrationSuite.scala
@@ -43,6 +43,10 @@ import java.io.File
   */
 class PackageTagIntegrationSuite extends munit.FunSuite {
 
+  // Walks multi-hundred-MB docker tarballs, which takes well over munit's
+  // 30-second default — more so when other test classes run concurrently.
+  override val munitTimeout = scala.concurrent.duration.Duration(30, "minutes")
+
   // Helper to check if test files exist
   def checkTestFile(path: String): Boolean = new File(path).exists()
 

--- a/src/test/scala/io/spicelabs/goatrodeo/testsupport/LogCapture.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/testsupport/LogCapture.scala
@@ -1,0 +1,70 @@
+package io.spicelabs.goatrodeo.testsupport
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters.*
+
+/** Shared helper for suites that assert on what was (or was not) logged.
+  *
+  * Attaching an appender to the *root* logger and raising the root level are
+  * process-global mutations. Two suites do it, so rather than duplicating the
+  * dance, capture through here — it adds two safeguards that make the pattern
+  * safe even if test classes are ever run concurrently within one JVM:
+  *
+  *   1. captures are serialised on a single lock, so two suites cannot save and
+  *      restore the root level in an interleaved order; and
+  *   2. only events emitted by the capturing thread are returned, so log records
+  *      from suites running in parallel cannot leak into a "nothing was logged"
+  *      assertion.
+  *
+  * Consequence for callers: assertions must be about logging done on the calling
+  * thread. A body that logs from worker threads it spawns will appear silent.
+  */
+object LogCapture {
+
+  private val lock = new Object()
+
+  /** Force SLF4J to bind to logback, retrying while it briefly reports a
+    * `SubstituteLoggerFactory` during initialisation.
+    */
+  private def loggerContext(maxRetries: Int = 20): LoggerContext = {
+    var attempts = 0
+    while (attempts < maxRetries) {
+      LoggerFactory.getILoggerFactory match {
+        case c: LoggerContext => return c
+        case _                =>
+      }
+      Thread.sleep(50)
+      attempts += 1
+    }
+    throw new IllegalStateException(
+      "Logback LoggerContext not available after initialization"
+    )
+  }
+
+  def apply[T](body: () => T): (T, Vector[ILoggingEvent]) = lock.synchronized {
+    LoggerFactory.getLogger(getClass)
+    val ctx = loggerContext()
+    val root = ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
+    val appender = new ListAppender[ILoggingEvent]()
+    appender.setContext(ctx)
+    appender.start()
+    root.addAppender(appender)
+    val priorLevel = root.getLevel
+    root.setLevel(Level.ALL)
+    val thread = Thread.currentThread().getName
+    try {
+      val result = body()
+      val mine = appender.list.asScala.toVector.filter(_.getThreadName == thread)
+      (result, mine)
+    } finally {
+      root.setLevel(priorLevel)
+      root.detachAppender(appender)
+      appender.stop()
+    }
+  }
+}

--- a/src/test/scala/strategies/CertificatesPropertySuite.scala
+++ b/src/test/scala/strategies/CertificatesPropertySuite.scala
@@ -46,6 +46,10 @@ import scala.collection.immutable.TreeSet
   */
 class CertificatesPropertySuite extends ScalaCheckSuite {
 
+  // The heavier properties take ~15s each on an idle machine; leave headroom
+  // for the contention introduced by running test classes in parallel.
+  override val munitTimeout = scala.concurrent.duration.Duration(5, "minutes")
+
   // Register BC if not already (idempotent — also done by Certificates).
   if (Security.getProvider("BC") == null) {
     Security.addProvider(

--- a/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
+++ b/src/test/scala/strategies/PrivateKeyLogCaptureTests.scala
@@ -36,49 +36,15 @@ import scala.collection.immutable.TreeSet
   */
 class PrivateKeyLogCaptureTests extends FunSuite {
 
-  import ch.qos.logback.classic.{Level, LoggerContext}
   import ch.qos.logback.classic.spi.ILoggingEvent
-  import ch.qos.logback.core.read.ListAppender
-  import org.slf4j.LoggerFactory
+  import io.spicelabs.goatrodeo.testsupport.LogCapture
   import scala.jdk.CollectionConverters.*
 
-  private def waitForLoggerContext(maxRetries: Int = 20): LoggerContext = {
-    var attempts = 0
-    while (attempts < maxRetries) {
-      LoggerFactory.getILoggerFactory match {
-        case c: LoggerContext => return c
-        case _                =>
-      }
-      Thread.sleep(50)
-      attempts += 1
-    }
-    throw new IllegalStateException(
-      "Logback LoggerContext not available after initialization"
-    )
-  }
-
-  private def runWithCapture[T](body: () => T): (T, Vector[ILoggingEvent]) = {
-    // Force SLF4J to bind to logback. With forked/parallel test runs,
-    // getILoggerFactory may briefly return SubstituteLoggerFactory while
-    // logback initializes, so retry until the real LoggerContext appears.
-    LoggerFactory.getLogger(getClass)
-    val ctx = waitForLoggerContext(maxRetries = 200)
-    val root = ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)
-    val appender = new ListAppender[ILoggingEvent]()
-    appender.setContext(ctx)
-    appender.start()
-    root.addAppender(appender)
-    val priorLevel = root.getLevel
-    root.setLevel(Level.ALL)
-    try {
-      val result = body()
-      (result, appender.list.asScala.toVector)
-    } finally {
-      root.setLevel(priorLevel)
-      root.detachAppender(appender)
-      appender.stop()
-    }
-  }
+  // Root-logger capture, shared with GraphManagerReadNextSuite: serialised and
+  // thread-filtered so nothing can leak into the "nothing was logged"
+  // assertions below. See LogCapture.
+  private def runWithCapture[T](body: () => T): (T, Vector[ILoggingEvent]) =
+    LogCapture(body)
 
   private def stubItem(): Item = Item(
     identifier = "gitoid:blob:sha256:phase7-log-capture-stub",


### PR DESCRIPTION
## Why

The Maven build ran the test suite strictly serially. Surefire's defaults are
`forkCount=1` with no parallelism, and nothing in `pom.xml` overrode them —
whereas `build.sbt` never sets `Test / parallelExecution`, so it gets sbt's
default of `true` and runs independent test classes concurrently. The migration
silently traded N-way class parallelism for 1-way.

Measured on a 12-core / 24 GB machine, same 12 GB fixture corpus:

| | wall |
|---|---|
| `sbt test` (at `main`, in a worktree) | 143 s |
| `mvn test` before this change | 250 s |
| `mvn test` after this change | 133 s, 149 s, 157 s |

All runs: 2013 tests, 0 failures, 3 skipped.

## What

`forkCount=0.5C` (one fork per two cores), `reuseForks=true`,
`runOrder=balanced`, 4 GB heap per fork. Every knob is a property:

```bash
mvn test -Dtest.forkCount=1C   # one fork per core, needs more RAM
mvn test -Dtest.forkCount=1    # one JVM, strictly serial
```

A `ci` profile activated by `TEST_THREAD_CNT` — the convention `build.sbt`
already uses — pins CI to a single JVM with the 8 GB heap a GitHub runner can
afford. CI still runs sbt, so nothing about it changes today; the profile is
what the Maven CI switch will need.

### Why not in-JVM `<parallel>classes</parallel>`

It does not work with munit and is deliberately not used. Surefire implements it
via JUnit's `ParallelComputer`, which can only schedule `ParentRunner`s, and
`munit.MUnitRunner extends Runner`. Setting it is silently a no-op: 156 s with
`parallel=classes threadCount=4` against 153 s serial for the same three suites,
where `forkCount=3` took 80 s.

Fork count was picked by measurement, not taste. Fewer, fatter forks hit the same
floor but scatter when the balancer lands two heavy suites on one fork — 3 forks:
130 s and 195 s; 4 forks: 131 s and 237 s; `0.5C` (6 here): 149, 143, 133, 149 s.
The floor is `ADGTests`, ~120 s on its own and internally multi-threaded.

## Fallout the parallelism forced

- **Forks share a filesystem.** `ADGTests` and `ExpiryBigAdgSuite` wrote multi-GB
  trees to fixed paths in the repo root; they now write under `target/test-out/`.
- **Four heavy suites get a `munitTimeout`** above munit's 30-second default.
  Note two of them — `ADGTests` and `PackageTagIntegrationSuite` — were already
  failing the *serial* Maven run on that timeout before this branch; `mvn test`
  on `main` is red today.
- **Root-logger capture** was duplicated verbatim in `PrivateKeyLogCaptureTests`
  and `GraphManagerReadNextSuite`; both now call a shared `LogCapture` that
  serialises captures and filters to the capturing thread.
- **`Config.parseExpiry`** extracted so `ExpiryPruneSuite` can assert on the
  parsing rules without mutating the process-global `goatrodeo.expiry` property.

The last two are hardening rather than strict necessity — with forks, classes
never run concurrently *inside* a JVM.

## Blocked on

Draft: this needs spice-labs-inc/spice-bom#2 (baharat 0.0.4 → 0.1.1) to land
first. Without it `mvn test-compile` fails on `main` at `Baharat.scala:135`
(`PackageURL` vs `coordinates.Purl`), so the numbers above are from a local
`mvn install` of the bumped BOM.

## Not addressed

`sbt test` does not compile in a working checkout (`ItemTestSuite.scala:299`, a
`StringOrPair` `Ordering` error). It compiles and passes in a clean worktree at
`main`, so it looks like local build state rather than a repo problem — but I did
not chase it, and nothing here touches that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
