### PR TITLE
Read configuration from a file and the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ goatrodeo [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--maxrecords <n>` | Batch size (default: 50,000) |
-| `--tempdir <dir>` | Temp storage (RAM disk recommended) |
+| `--max-records <n>` | Batch size (default: 50,000) |
+| `--temp-dir <dir>` | Temp storage (RAM disk recommended) |
 | `--tag <name>` | Tag this run for later identification |
 | `--package-tags` | Create per-package tags for identified packages (Maven, Docker, etc.) |
 | `--package-tags-short-name` | Use short package names when `--package-tags` is enabled |
-| `--block <file>` | Skip known/common GitOIDs |
+| `--block-list <file>` | Skip known/common GitOIDs |
 
 ### Cryptographic Bill of Materials (CBOM)
 
@@ -173,12 +173,12 @@ For large artifact sets (10,000+ files):
 1. **Use a RAM disk** for temp files:
    ```bash
    sudo mount -t tmpfs -o size=25G tmpfs /mnt/ramdisk
-   goatrodeo -b /artifacts -o /output --tempdir /mnt/ramdisk
+   goatrodeo -b /artifacts -o /output --temp-dir /mnt/ramdisk
    ```
 
 2. **Match threads to CPU cores** (or fewer if memory-constrained)
 
-3. **Tune batch size** with `--maxrecords` based on available RAM
+3. **Tune batch size** with `--max-records` based on available RAM
 
 See [Performance Tuning Guide](info/goat_rodeo_operation.md#tuning-for-performance) for details.
 

--- a/build.sbt
+++ b/build.sbt
@@ -242,6 +242,12 @@ lazy val root = project
     libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     libraryDependencies += "org.apache.tika" % "tika-core" % "3.2.3",
+    // Config files. Kept in step with pom.xml, which declares the same two: the sbt and
+    // Maven builds compile the same sources, so a dependency added to one and not the
+    // other fails whichever build CI happens to run.
+    libraryDependencies += "org.tomlj" % "tomlj" % "1.1.1",
+    // The naming, layering and precedence rules every Spice component shares.
+    libraryDependencies += "io.spicelabs" % "spice-config" % "1.0.0",
     // Still required at the boundary: the annatto/baharat readers hand back
     // com.github.packageurl.PackageURL, which we convert to coordinates.Purl.
     libraryDependencies += "com.github.package-url" % "packageurl-java" % "1.5.0",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,23 +2,38 @@
 
 Every value that affects a Goat Rodeo run lives in one strongly-typed record,
 `io.spicelabs.goatrodeo.util.Configuration`. It is built once at startup and passed to
-everything that needs it as a `using` parameter named `config`:
+everything that needs it as an anonymous `using` parameter:
 
 ```scala
-def buildDB(dest: File, tag: Option[TagInfo], …)(using config: Configuration): Unit
+def buildDB(dest: File, tag: Option[TagInfo], …)(using Configuration): Unit
 ```
 
-There are exactly two ways to build one, and they produce the same value:
+It is read through the global `config` accessor, defined once in
+`io.spicelabs.goatrodeo.util`:
+
+```scala
+inline def config(using configuration: Configuration): Configuration = configuration
+```
+
+Naming the parameter would let one file call it `config`, another `cfg`, and a third shadow
+it; leaving it anonymous means there is exactly one name for the configuration anywhere in
+the codebase. Allspice uses the same idiom.
+
+There are three ways to build one, and they produce the same value:
 
 | Route | Entry point |
 | --- | --- |
 | Command line | `ConfigurationParser.parse(args)` — see `util/ConfigurationParser.scala` |
+| Config file | `--config <file>`, read by `ConfigurationToml` |
 | Embedded (library) | `GoatRodeoBuilder`, e.g. `GoatRodeo.builder().withOutput(…).run()` |
 
-**No system property configures Goat Rodeo**, and nothing reads the environment at the point
-of use: ambient process state is captured once, in `RuntimeEnvironment`, and travels on the
-configuration like everything else. If you find yourself reaching for `System.getProperty` or
-`sys.env` deeper in, add a field here instead — that is the whole point of this file.
+**There is no fourth route.** No environment variable and no system property configures Goat
+Rodeo. If you find yourself reaching for one, add a field here and a flag there instead —
+that is the whole point of this file.
+
+Precedence, lowest to highest:
+
+    defaults  <  config file  <  command line
 
 ## Values
 
@@ -29,11 +44,11 @@ configuration like everything else. If you find yourself reaching for `System.ge
 | `fileList` | `Vector[File]` | `--file-list` | `withFileList` | empty |
 | `ingested` | `Option[File]` | `--ingested` | `withIngested` | none |
 | `ignore` | `Vector[File]` | `--ignore` | `withIgnore` | empty |
-| `blockList` | `Option[File]` | `--block` | `withBlockList` | none |
+| `blockList` | `Option[File]` | `--block-list` | `withBlockList` | none |
 | `exclude` | `Vector[(String, Try[Pattern])]` | `--exclude-pattern` | `withExcludePattern` | empty |
 | `threads` | `Int` | `-t`, `--threads` | `withThreads` | `4` |
-| `maxRecords` | `Int` | `--maxrecords` | `withMaxRecords` | `50000` |
-| `tempDir` | `Option[File]` | `--tempdir` | `withTempDir` | none |
+| `maxRecords` | `Int` | `--max-records` | `withMaxRecords` | `50000` |
+| `tempDir` | `Option[File]` | `--temp-dir` | `withTempDir` | none |
 | `useStaticMetadata` | `Boolean` | `--static-metadata` | `withStaticMetadata` | `false` |
 | `fsFilePaths` | `Boolean` | `--fs-file-paths` | `withFsFilePaths` | `false` |
 | `dumpRootDir` | `Option[File]` | `--dump-roots` | — | none |
@@ -94,3 +109,95 @@ is captured once, in `RuntimeEnvironment.default`, and carried on the configurat
 the only place Goat Rodeo reads it. Tilde expansion (`ExpandFiles.fixTilde`) takes the home
 directory as a parameter rather than calling `System.getProperty("user.home")` at the point
 of use, so a test can supply a different one without mutating global JVM state.
+
+
+## The config file
+
+`--config <file>` reads a TOML file whose settings live in an `[analysis]` table:
+
+```toml
+[analysis]
+out = "/srv/adg"
+build = ["/srv/artifacts"]
+threads = 16
+max_records = 100000
+mime_filter = ["+application/java-archive"]
+```
+
+`analysis` is the *group* — named for the job rather than for this component, and the same
+group `spice` and Allspice carry, so `[analysis] threads = 16` means one thing wherever it is
+written. There is one shape to learn, and moving a setting between a Goat Rodeo config file
+and a `spice` one is a copy rather than a translation.
+
+The three names of a setting are related by a rule with no exceptions:
+
+| Form | Shape | Example |
+| --- | --- | --- |
+| Config key | `snake_case` in `[analysis]` | `max_records` |
+| Flag | its kebab-case form | `--max-records` |
+| Environment | `GOATRODEO_ANALYSIS_<KEY>` | `GOATRODEO_ANALYSIS_MAX_RECORDS` |
+
+Embedded in `spice`, the same setting is `SPICE_ANALYSIS_MAX_RECORDS`: the prefix names
+whichever program is running, and nothing else changes.
+
+Lowest to highest:
+
+    defaults  <  [analysis]  <  environment  <  command line
+
+and when one of those displaces another, it says so:
+
+```
+threads = 9 (GOATRODEO_ANALYSIS_THREADS) overrides 4 ([analysis] in /etc/goatrodeo.toml)
+threads = 12 (command line) overrides 9 (/etc/goatrodeo.toml)
+```
+
+Overriding a *default* is not reported: that is every setting on every run, and the noise
+would bury the cases where two deliberate choices conflict.
+
+The rules themselves — naming, layering, precedence, provenance — live in
+[`spice-config`](https://github.com/spice-labs-inc/spice-config), shared with every
+component, because rules copied into several codebases are rules that will disagree. The
+model as a whole is described in `spice`'s `docs/configuration.md`; this page covers what
+is particular to Goat Rodeo.
+
+Three rules are worth knowing:
+
+- **An unknown key is an error.** A mistyped key that is silently ignored is how a config file
+  becomes undebuggable: the value you wrote is simply not in force and nothing says so.
+- **A setting outside a table is an error.** Bare keys at the root are how this file used to be
+  written, and silently ignoring them would be the same failure by another route; the message
+  names the keys and says they belong under `[analysis]`.
+- **Paths must be absolute.** A config file may be read from a directory the process cannot
+  see — a container mount, say — so a relative path in one has no dependable meaning. It also
+  keeps the `spice` wrapper's guarantee that every path it must bind-mount is visible on the
+  command line, since it cannot see inside a TOML table.
+
+### Embedded in another program's config file
+
+`ConfigurationToml.fromToml` takes a `TomlTable`, not a path, so the same schema and the same
+code serve both a whole Goat Rodeo config file and one table nested inside a `spice` or
+Allspice config:
+
+```toml
+# spice's config file — spice carries this table without understanding it
+[registry.analysis]
+threads = 16
+max_records = 100000
+```
+
+Callers pass the table path as a label so errors name the table the user actually wrote.
+
+`TomlTables` adapts a plain nested `Map` — how the plugin SPI hands a table over, to stay
+dependency-free — back to a `TomlTable`, so there is one reader either way. Use
+`TomlTables.toPlainMap` rather than `TomlTable.toMap()` when producing such a map:
+`toMap()` is shallow and leaves nested tables as tomlj objects.
+
+### `cutoff` is the one key nesting changes
+
+`cutoff` is a Goat Rodeo knob and is accepted in a Goat Rodeo config file: standalone, Goat
+Rodeo knows nothing about Spice Passes.
+
+Nested inside `spice` or Allspice it is **rejected**. There the cutoff is the pass's
+`x-cutoff`, which constrains what the platform is willing to accept, so letting a config file
+supply it would hand a user the ability to widen a scope the platform deliberately narrowed.
+`ConfigurationToml.nestedFromToml` is the entry point that enforces this.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,13 +102,28 @@ Callers that need the cutoff to originate in a Spice Pass (Allspice, the `spice`
 the pass themselves and call `withCutoff`. Goat Rodeo has no notion of a pass and does not
 want one.
 
+No config file may supply it either — not a standalone Goat Rodeo file, and not a table
+nested inside a `spice` or Allspice one. `cutoff` is an entitlement rather than a preference:
+embedded, it is the pass's `x-cutoff`, which constrains what the platform is willing to
+accept, and a file supplying it would hand a user the ability to widen a scope the platform
+deliberately narrowed. Standalone there is no pass to contradict, but a value that can be
+read from two kinds of place is how the embedded rule gets forgotten.
+
+It is refused *by name* (`ConfigurationToml.alwaysRejected`) rather than by being left out of
+the schema: an unrecognised key reports a typo, which is the wrong thing to say about a key
+that is spelled correctly and deliberately unavailable.
+
 ## `RuntimeEnvironment`
 
-Ambient process state — working directory, home directory, environment, system properties —
-is captured once, in `RuntimeEnvironment.default`, and carried on the configuration. This is
-the only place Goat Rodeo reads it. Tilde expansion (`ExpandFiles.fixTilde`) takes the home
-directory as a parameter rather than calling `System.getProperty("user.home")` at the point
-of use, so a test can supply a different one without mutating global JVM state.
+Working directory and home directory are captured once, in `RuntimeEnvironment.default`, and
+carried on the configuration, so that nothing downstream reaches for them itself. Tilde
+expansion (`ExpandFiles.fixTilde`) takes the home directory as a parameter rather than
+calling `System.getProperty("user.home")` at the point of use, so a test can supply a
+different one without mutating global JVM state.
+
+The process environment is ambient state too, but it is a configuration *source* rather than
+something a run is described by, so it enters through the resolver alongside the config file
+— see below — rather than being carried here.
 
 
 ## The config file
@@ -144,15 +159,25 @@ Lowest to highest:
 
     defaults  <  [analysis]  <  environment  <  command line
 
-and when one of those displaces another, it says so:
+Each layer is consulted on every run. The config file is the one that may be absent, and its
+absence is not a reason to skip the ones above it: `GOATRODEO_ANALYSIS_THREADS=16` works on a
+run that passes no `--config` at all.
+
+When one layer displaces another, it says so, naming the source that supplied the value being
+displaced:
 
 ```
 threads = 9 (GOATRODEO_ANALYSIS_THREADS) overrides 4 ([analysis] in /etc/goatrodeo.toml)
-threads = 12 (command line) overrides 9 (/etc/goatrodeo.toml)
+threads = 12 (command line) overrides 9 (GOATRODEO_ANALYSIS_THREADS)
 ```
 
 Overriding a *default* is not reported: that is every setting on every run, and the noise
 would bury the cases where two deliberate choices conflict.
+
+A setting is named by its config key throughout, including on the command-line line, so the
+three spellings above are the only ones that ever appear. `Configuration`'s field names are a
+fourth, unrelated spelling — `emitJsonDir` for `dump_json` — and `ConfigurationToml.keyForField`
+exists to keep them out of anything a person reads.
 
 The rules themselves — naming, layering, precedence, provenance — live in
 [`spice-config`](https://github.com/spice-labs-inc/spice-config), shared with every
@@ -163,7 +188,10 @@ is particular to Goat Rodeo.
 Three rules are worth knowing:
 
 - **An unknown key is an error.** A mistyped key that is silently ignored is how a config file
-  becomes undebuggable: the value you wrote is simply not in force and nothing says so.
+  becomes undebuggable: the value you wrote is simply not in force and nothing says so. The
+  same holds for a variable — `GOATRODEO_ANALYSIS_TREADS=9` fails the run rather than doing
+  nothing. Variables outside a group this program claims (`GOATRODEO_IMAGE`, say) are not
+  settings and are left alone.
 - **A setting outside a table is an error.** Bare keys at the root are how this file used to be
   written, and silently ignoring them would be the same failure by another route; the message
   names the keys and says they belong under `[analysis]`.
@@ -192,12 +220,5 @@ dependency-free — back to a `TomlTable`, so there is one reader either way. Us
 `TomlTables.toPlainMap` rather than `TomlTable.toMap()` when producing such a map:
 `toMap()` is shallow and leaves nested tables as tomlj objects.
 
-### `cutoff` is the one key nesting changes
-
-`cutoff` is a Goat Rodeo knob and is accepted in a Goat Rodeo config file: standalone, Goat
-Rodeo knows nothing about Spice Passes.
-
-Nested inside `spice` or Allspice it is **rejected**. There the cutoff is the pass's
-`x-cutoff`, which constrains what the platform is willing to accept, so letting a config file
-supply it would hand a user the ability to widen a scope the platform deliberately narrowed.
-`ConfigurationToml.nestedFromToml` is the entry point that enforces this.
+Nesting changes nothing about which keys are accepted: the schema is the same either way, and
+`cutoff` is refused in both — see [`cutoff` has exactly one source](#cutoff-has-exactly-one-source).

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
     <json4s.version>4.0.7</json4s.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <logback.version>1.5.15</logback.version>
+    <tomlj.version>1.1.1</tomlj.version>
+    <spice-config.version>1.0.0</spice-config.version>
     <scala-parallel-collections.version>1.2.0</scala-parallel-collections.version>
     <scala-logging.version>3.9.4</scala-logging.version>
     <tika.version>3.2.3</tika.version>
@@ -235,6 +237,21 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
+    </dependency>
+    <!-- Config files. The same version Allspice uses, so a table parsed by one and
+         handed to the other cannot disagree about TOML semantics. -->
+    <dependency>
+      <groupId>org.tomlj</groupId>
+      <artifactId>tomlj</artifactId>
+      <version>${tomlj.version}</version>
+    </dependency>
+    <!-- The naming, layering and precedence rules, shared with every other Spice
+         component. One implementation, because rules copied into several codebases
+         are rules that will disagree, and these already have. -->
+    <dependency>
+      <groupId>io.spicelabs</groupId>
+      <artifactId>spice-config</artifactId>
+      <version>${spice-config.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -409,8 +409,13 @@ class GoatRodeoBuilder {
     * carries so that it can stay dependency-free; see [[TomlTables]].
     *
     * Settings already given to this builder are the defaults the table is
-    * applied on top of, and anything the caller sets afterwards wins — so the
-    * embedding program keeps the final say, as it does for the command line.
+    * applied on top of, and the embedding program keeps the final say
+    * afterwards, as it does for the command line — but what "afterwards" does
+    * depends on the setting: a later scalar setter (`withThreads`,
+    * `withTempDir`) replaces the table's value, while a later list setter
+    * (`withPayload`, `withIgnore`, `withFileList`, `withExcludePattern`,
+    * `withMimeFilter`) appends to it. A caller that wants to replace a list the
+    * table supplied cannot do it through this builder.
     *
     * `cutoff` is refused here: embedded, the analysis cutoff comes from the
     * Spice Pass, which constrains what the platform will accept.

--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -18,6 +18,8 @@ import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
 import io.spicelabs.goatrodeo.util.Configuration
+import io.spicelabs.goatrodeo.util.ConfigurationToml
+import io.spicelabs.goatrodeo.util.TomlTables
 import io.spicelabs.goatrodeo.util.VectorOfStrings
 
 import java.nio.file.Paths
@@ -397,6 +399,46 @@ class GoatRodeoBuilder {
         log.warn(s"Ignored unknown GoatRodeoBuilder arg: $unknown=$value")
         this
     }
+  }
+
+  /** Apply a table of settings written in Goat Rodeo's config-file schema.
+    *
+    * This is how an embedding program — `spice`, Allspice — passes Goat Rodeo's
+    * settings through from its own config file without knowing what they mean.
+    * The table arrives as a plain nested map, which is what the plugin SPI
+    * carries so that it can stay dependency-free; see [[TomlTables]].
+    *
+    * Settings already given to this builder are the defaults the table is
+    * applied on top of, and anything the caller sets afterwards wins — so the
+    * embedding program keeps the final say, as it does for the command line.
+    *
+    * `cutoff` is refused here: embedded, the analysis cutoff comes from the
+    * Spice Pass, which constrains what the platform will accept.
+    *
+    * @param table
+    *   the settings, keyed as in a Goat Rodeo config file
+    * @param label
+    *   the table's path in the caller's file, for error messages — e.g.
+    *   `registry.analysis`
+    * @throws IllegalArgumentException
+    *   if the table has an unknown key, a value of the wrong type, or a setting
+    *   that may not be given to an embedded run
+    * @return
+    *   this builder
+    */
+  def withConfiguration(
+      table: java.util.Map[String, Object],
+      label: String
+  ): GoatRodeoBuilder = {
+    ConfigurationToml.nestedFromToml(
+      TomlTables.fromJavaMap(table),
+      config,
+      label
+    ) match {
+      case Right(updated) => config = updated
+      case Left(error)    => throw IllegalArgumentException(error)
+    }
+    this
   }
 
   /** Attach a progress listener that is notified at phase boundaries (Scanning,

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Configuration.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Configuration.scala
@@ -130,6 +130,8 @@ inline def config(using configuration: Configuration): Configuration =
   *   (CBOM) files, one per top-level input
   * @param cbomVersion
   *   CycloneDX CBOM specification version to emit ("1.6" or "1.7")
+  * @param configFile
+  *   the TOML file this configuration was read from, when `--config` named one
   * @param runtime
   *   the ambient process state this run was started in
   */
@@ -163,8 +165,32 @@ case class Configuration(
     cutoff: Option[Instant] = None,
     cbomDir: Option[File] = None,
     cbomVersion: String = "1.6",
+    configFile: Option[File] = None,
     runtime: RuntimeEnvironment = RuntimeEnvironment.default
 ) {
+
+  /** The settings that differ between this configuration and another.
+    *
+    * Used to report what the command line changed. Deriving it by comparing two
+    * configurations, rather than recording an origin in each of two dozen flag
+    * actions, means a flag added later is covered without anyone remembering to
+    * cover it — the failure mode for hand-maintained lists here has always been
+    * that they quietly fall behind.
+    *
+    * `runtime` and `configFile` are skipped: they are how the run was started,
+    * not settings anybody wrote.
+    */
+  def differencesFrom(other: Configuration): Vector[(String, Any, Any)] = {
+    val ignored = Set("runtime", "configFile")
+    productElementNames.zipWithIndex
+      .filterNot((name, _) => ignored.contains(name))
+      .flatMap { (name, index) =>
+        val mine = productElement(index)
+        val theirs = other.productElement(index)
+        if (mine == theirs) None else Some((name, theirs, mine))
+      }
+      .toVector
+  }
 
   /** Build a list of file list builders from the configuration.
     *

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
@@ -46,12 +46,63 @@ object ConfigurationParser {
 
   /** Parse a command line into a [[Configuration]], seeded with the ambient
     * process state the run started in.
+    *
+    * When `--config` names a file, it is read first and the command line
+    * applied on top, so precedence runs defaults < config file < command line.
+    * That is done by parsing twice: once to discover `--config`, then again
+    * seeded with what the file said. Parsing is pure and cheap, and this keeps
+    * the flag definitions the single description of what the command line
+    * means.
     */
   def parse(
       args: Array[String],
       runtime: RuntimeEnvironment = RuntimeEnvironment.default
   ): Option[Configuration] =
-    OParser.parse(parser, args, Configuration(runtime = runtime))
+    parseWith(args, Configuration(runtime = runtime)).flatMap { discovered =>
+      discovered.configFile match {
+        case None => Some(discovered)
+        case Some(file) => {
+          ConfigurationToml.fromFile(
+            file.toPath(),
+            Configuration(runtime = runtime, configFile = Some(file))
+          ) match {
+            case Right(fromFile) =>
+              val withFlags = parseWith(args, fromFile)
+              // The file and the environment report their own disagreements as
+              // they are resolved; this is the last layer, and the only one that
+              // cannot report itself, because scopt folds flags straight into the
+              // configuration with nowhere to record where a value came from.
+              withFlags.foreach { full =>
+                full.differencesFrom(fromFile).foreach { (name, was, now) =>
+                  logger.info(
+                    s"$name = ${show(now)} (command line) overrides ${show(was)} ($file)"
+                  )
+                }
+              }
+              withFlags
+            case Left(error) => {
+              logger.error(f"Invalid config file ${file}: ${error}")
+              None
+            }
+          }
+        }
+      }
+    }
+
+  /** Values as a person wrote them, not as Scala prints them. */
+  private def show(value: Any): String = value match {
+    case Some(v)         => show(v)
+    case None            => "unset"
+    case v: Vector[?]    => v.map(show).mkString("[", ", ", "]")
+    case f: java.io.File => f.toString
+    case other           => other.toString
+  }
+
+  private def parseWith(
+      args: Array[String],
+      base: Configuration
+  ): Option[Configuration] =
+    OParser.parse(parser, args, base)
 
   /** Render the usage text. */
   def usage: String = OParser.usage(parser)
@@ -62,7 +113,7 @@ object ConfigurationParser {
     OParser.sequence(
       programName("goatrodeo"),
       head("goatrodeo", hellogoat.BuildInfo.version),
-      opt[File]("block")
+      opt[File]("block-list")
         .text(
           "The gitoid block list. Do not process these gitoids. Used for common gitoids such as license files"
         )
@@ -157,7 +208,7 @@ object ConfigurationParser {
             Pattern.compile(p)
           })))
         ),
-      opt[Int]("maxrecords")
+      opt[Int]("max-records")
         .text(
           "The maximum number of records to process at once. Default 50,000"
         )
@@ -173,6 +224,11 @@ object ConfigurationParser {
       opt[File]("dump-json")
         .text("Make a directory and dump the ADG as JSON in to directory")
         .action((x, c) => c.copy(emitJsonDir = Some(x))),
+      opt[File]("config")
+        .text(
+          "Read settings from this TOML file. Anything also given on the command line wins."
+        )
+        .action((x, c) => c.copy(configFile = Some(x))),
       opt[File]("emit-cbom-dir")
         .text(
           "Emit one CycloneDX cryptographic bill-of-materials (CBOM) JSON file per top-level input into this directory"
@@ -185,7 +241,7 @@ object ConfigurationParser {
           if (Set("1.6", "1.7").contains(v)) success
           else failure(s"--cbom-version must be 1.6 or 1.7, got $v")
         ),
-      opt[File]("tempdir")
+      opt[File]("temp-dir")
         .text("Where to temporarily store files... should be a RAM disk")
         .action((x, c) => c.copy(tempDir = Some(x))),
       opt[Int]('t', "threads")

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
@@ -47,44 +47,56 @@ object ConfigurationParser {
   /** Parse a command line into a [[Configuration]], seeded with the ambient
     * process state the run started in.
     *
-    * When `--config` names a file, it is read first and the command line
-    * applied on top, so precedence runs defaults < config file < command line.
-    * That is done by parsing twice: once to discover `--config`, then again
-    * seeded with what the file said. Parsing is pure and cheap, and this keeps
-    * the flag definitions the single description of what the command line
-    * means.
+    * The lower sources are read first and the command line applied on top, so
+    * precedence runs defaults < config file < environment < command line. That
+    * is done by parsing twice: once to discover `--config`, then again seeded
+    * with what the file and the environment said. Parsing is pure and cheap,
+    * and this keeps the flag definitions the single description of what the
+    * command line means.
+    *
+    * The second parse happens whether or not `--config` named a file: the
+    * environment is a source in its own right, and skipping the resolution when
+    * there was no file to read is what used to make `GOATRODEO_ANALYSIS_*` do
+    * nothing on a run that named none.
     */
   def parse(
       args: Array[String],
-      runtime: RuntimeEnvironment = RuntimeEnvironment.default
+      runtime: RuntimeEnvironment = RuntimeEnvironment.default,
+      environment: Map[String, String] = sys.env
   ): Option[Configuration] =
     parseWith(args, Configuration(runtime = runtime)).flatMap { discovered =>
-      discovered.configFile match {
-        case None => Some(discovered)
-        case Some(file) => {
-          ConfigurationToml.fromFile(
-            file.toPath(),
-            Configuration(runtime = runtime, configFile = Some(file))
-          ) match {
-            case Right(fromFile) =>
-              val withFlags = parseWith(args, fromFile)
-              // The file and the environment report their own disagreements as
-              // they are resolved; this is the last layer, and the only one that
-              // cannot report itself, because scopt folds flags straight into the
-              // configuration with nowhere to record where a value came from.
-              withFlags.foreach { full =>
-                full.differencesFrom(fromFile).foreach { (name, was, now) =>
-                  logger.info(
-                    s"$name = ${show(now)} (command line) overrides ${show(was)} ($file)"
-                  )
-                }
+      val file = discovered.configFile
+      ConfigurationToml.fromSources(
+        file.map(_.toPath()),
+        Configuration(runtime = runtime, configFile = file),
+        environment
+      ) match {
+        case Right((resolved, resolution)) =>
+          val withFlags = parseWith(args, resolved)
+          // The file and the environment report their own disagreements as they
+          // are resolved; this is the last layer, and the only one that cannot
+          // report itself, because scopt folds flags straight into the
+          // configuration with nowhere to record where a value came from. The
+          // resolution is what remembers which of the lower sources actually
+          // supplied the value being displaced.
+          withFlags.foreach { full =>
+            full.differencesFrom(resolved).foreach { (field, was, now) =>
+              ConfigurationToml.sourceOf(resolution, field).foreach { source =>
+                logger.info(
+                  s"${ConfigurationToml.displayName(field)} = ${show(now)} " +
+                    s"(command line) overrides ${show(was)} ($source)"
+                )
               }
-              withFlags
-            case Left(error) => {
-              logger.error(f"Invalid config file ${file}: ${error}")
-              None
             }
           }
+          withFlags
+        case Left(error) => {
+          logger.error(
+            file.fold(s"Invalid configuration: $error")(file =>
+              s"Invalid config file $file: $error"
+            )
+          )
+          None
         }
       }
     }
@@ -107,6 +119,28 @@ object ConfigurationParser {
   /** Render the usage text. */
   def usage: String = OParser.usage(parser)
 
+  /** A flag's pre-rename spelling, still accepted and warned about.
+    *
+    * Hidden, so that `--help` describes one way to say each thing and nobody
+    * learns the old spelling from this program. Present, because these flags
+    * are written down in scripts and images that are not rebuilt when Goat
+    * Rodeo is, and a rename that breaks them on the day it merges is a rename
+    * that gets reverted. They come out a release after the callers are fixed.
+    */
+  private def deprecated[A: scopt.Read](old: String, current: String)(
+      action: (A, Configuration) => Configuration
+  ): OParser[A, Configuration] =
+    builder
+      .opt[A](old)
+      .hidden()
+      .text(s"Deprecated: use --$current")
+      .action { (x, c) =>
+        logger.warn(
+          s"--$old has been renamed to --$current and will stop working in a future release"
+        )
+        action(x, c)
+      }
+
   /** The command line argument parser definition. */
   lazy val parser: OParser[Unit, Configuration] = {
     import builder._
@@ -120,6 +154,9 @@ object ConfigurationParser {
         .action((x, c) =>
           c.copy(blockList = ExpandFiles(x, c.runtime.homeDir).headOption)
         ),
+      deprecated[File]("block", "block-list")((x, c) =>
+        c.copy(blockList = ExpandFiles(x, c.runtime.homeDir).headOption)
+      ),
       opt[File]('b', "build")
         .text("Build gitoid database from jar files in a directory")
         .action((x, c) => {
@@ -213,6 +250,9 @@ object ConfigurationParser {
           "The maximum number of records to process at once. Default 50,000"
         )
         .action((x, c) => if (x > 100) c.copy(maxRecords = x) else c),
+      deprecated[Int]("maxrecords", "max-records")((x, c) =>
+        if (x > 100) c.copy(maxRecords = x) else c
+      ),
       opt[File]('o', "out")
         .text("output directory for the file-system based gitoid storage")
         .action((x, c) => c.copy(out = Some(x))),
@@ -244,6 +284,9 @@ object ConfigurationParser {
       opt[File]("temp-dir")
         .text("Where to temporarily store files... should be a RAM disk")
         .action((x, c) => c.copy(tempDir = Some(x))),
+      deprecated[File]("tempdir", "temp-dir")((x, c) =>
+        c.copy(tempDir = Some(x))
+      ),
       opt[Int]('t', "threads")
         .text(
           "How many threads to run (default 4). Should be 2x-3x number of cores"

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
@@ -61,6 +61,75 @@ object ConfigurationToml {
     */
   val EnvironmentPrefix: String = "GOATRODEO"
 
+  /** The config-file key each [[Configuration]] field is written as.
+    *
+    * WHY this is written out rather than derived: the flag, the key and the
+    * environment variable are three spellings of one name, related mechanically
+    * — but the *field* is a fourth, and it is not related to them at all.
+    * `emitJsonDir` is `dump_json`, `cbomDir` is `emit_cbom_dir`,
+    * `useStaticMetadata` is `static_metadata`. Anything that turns a field name
+    * into a key by rule would be wrong for a third of them.
+    *
+    * Used to report an overridden setting under the name its writer used.
+    * Fields absent here have no config-file key — a flag-only setting, or
+    * `runtime`, which is not a setting at all.
+    */
+  private val keyForField: Map[String, String] = Map(
+    "out" -> "out",
+    "build" -> "build",
+    "fileList" -> "file_list",
+    "ingested" -> "ingested",
+    "ignore" -> "ignore",
+    "blockList" -> "block_list",
+    "exclude" -> "exclude_pattern",
+    "threads" -> "threads",
+    "maxRecords" -> "max_records",
+    "tempDir" -> "temp_dir",
+    "useStaticMetadata" -> "static_metadata",
+    "fsFilePaths" -> "fs_file_paths",
+    "dumpRootDir" -> "dump_roots",
+    "emitJsonDir" -> "dump_json",
+    "mimeFilter" -> "mime_filter",
+    "tag" -> "tag",
+    "tagJson" -> "tag_json",
+    "tagVersion" -> "tag_version",
+    "tagDate" -> "tag_date",
+    "packageTags" -> "package_tags",
+    "packageTagsShortName" -> "package_tags_short_name",
+    "cbomDir" -> "emit_cbom_dir",
+    "cbomVersion" -> "cbom_version"
+  )
+
+  /** How a setting should be named in a message, given the field it lives in.
+    *
+    * Its config-file key where it has one, so that the three-spellings rule
+    * holds in output too; the field name otherwise, which is the best available
+    * name for something a file cannot set.
+    */
+  def displayName(field: String): String = keyForField.getOrElse(field, field)
+
+  /** Where the value of a setting came from, named as the person who set it
+    * would recognise it — `GOATRODEO_ANALYSIS_THREADS`, or `[analysis] in
+    * /etc/goatrodeo.toml`.
+    *
+    * `None` for a setting no source supplied, which is every setting left at
+    * its default.
+    */
+  def sourceOf(resolved: Resolution, field: String): Option[String] =
+    keyForField
+      .get(field)
+      .flatMap(key => resolved.setting(Group, key).toScala)
+      .map(_.origin.describe)
+
+  /** The config-file keys [[keyForField]] claims exist, so that a test can hold
+    * it against the schema rather than trusting two hand-written lists to
+    * agree.
+    */
+  def fieldKeys: Set[String] = keyForField.values.toSet
+
+  /** Whether the `[analysis]` table accepts this key. */
+  def accepts(key: String): Boolean = knownKeys.contains(key)
+
   /** Keys accepted in the `[analysis]` table. */
   private val knownKeys: Set[String] = Set(
     "out",
@@ -112,50 +181,77 @@ object ConfigurationToml {
 
   private case class Invalid(message: String) extends RuntimeException(message)
 
-  /** Read a whole Goat Rodeo config file, plus the environment.
+  /** Read the environment, and a config file if there is one.
     *
     * Standalone, this is where the ladder is applied: defaults, then the
     * `[analysis]` table, then `GOATRODEO_ANALYSIS_*`. Command-line flags are
     * applied on top by [[ConfigurationParser]], which is the only part that
     * knows what a flag is.
+    *
+    * WHY the file is optional rather than the way in: the environment is a
+    * source in its own right, and making it reachable only through `--config`
+    * meant `GOATRODEO_ANALYSIS_THREADS` silently did nothing on a run that
+    * named no file — which is every run that only wanted to set one thing.
+    * Every source is now consulted on every run, and the file is the one that
+    * may be absent.
+    *
+    * The [[Resolution]] is returned alongside the configuration because it is
+    * the only thing that knows *where* each value came from; [[Configuration]]
+    * records values, not their origins, and the override reporting needs both.
     */
+  def fromSources(
+      path: Option[Path],
+      base: Configuration = Configuration(),
+      environment: Map[String, String] = sys.env,
+      report: String => Unit = message => logger.info(message)
+  ): Either[String, (Configuration, Resolution)] = {
+    val resolver = new Resolver(
+      EnvironmentPrefix,
+      java.util.Set.of(Group),
+      message => report(message)
+    )
+
+    val withFile: Either[String, Resolver] = path match {
+      case None => Right(resolver)
+      case Some(path) if !Files.exists(path) =>
+        Left(s"config file not found: $path")
+      case Some(path) =>
+        val result = Toml.parse(Files.readString(path))
+        if (!result.errors().isEmpty())
+          Left(result.errors().asScala.map(_.toString).mkString("; "))
+        else {
+          val root = TomlTables.toPlainMap(result)
+          val loose = root.asScala
+            .collect {
+              case (key, value) if !value.isInstanceOf[java.util.Map[?, ?]] =>
+                key
+            }
+            .toSeq
+            .sorted
+          if (loose.nonEmpty)
+            Left(
+              s"settings belong in a table: move ${loose.mkString(", ")} under [$Group]"
+            )
+          else Right(resolver.withFile(path, root, java.util.List.of()))
+        }
+    }
+
+    withFile.flatMap { resolver =>
+      val resolved = resolver.withEnvironment(environment.asJava).resolve()
+      fromResolution(resolved, base, Group).map((_, resolved))
+    }
+  }
+
+  /** Read a whole Goat Rodeo config file, plus the environment. */
   def fromFile(
       path: Path,
       base: Configuration = Configuration(),
       environment: Map[String, String] = sys.env,
       report: String => Unit = message => logger.info(message)
-  ): Either[String, Configuration] = {
-    if (!Files.exists(path)) Left(s"config file not found: $path")
-    else {
-      val result = Toml.parse(Files.readString(path))
-      if (!result.errors().isEmpty())
-        Left(result.errors().asScala.map(_.toString).mkString("; "))
-      else {
-        val root = TomlTables.toPlainMap(result)
-        val loose = root.asScala
-          .collect {
-            case (key, value) if !value.isInstanceOf[java.util.Map[?, ?]] => key
-          }
-          .toSeq
-          .sorted
-        if (loose.nonEmpty)
-          Left(
-            s"settings belong in a table: move ${loose.mkString(", ")} under [$Group]"
-          )
-        else {
-          val resolved = new Resolver(
-            EnvironmentPrefix,
-            java.util.Set.of(Group),
-            message => report(message)
-          )
-            .withFile(path, root, java.util.List.of())
-            .withEnvironment(environment.asJava)
-            .resolve()
-          fromResolution(resolved, base, Group)
-        }
-      }
-    }
-  }
+  ): Either[String, Configuration] =
+    fromSources(Some(path), base, environment, report).map((config, _) =>
+      config
+    )
 
   /** Read a Goat Rodeo configuration from a table.
     *

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
@@ -1,0 +1,344 @@
+package io.spicelabs.goatrodeo.util
+
+import io.bullet.borer.Dom
+import io.bullet.borer.Json
+import io.spicelabs.config.ConfigurationException
+import io.spicelabs.config.Origin
+import io.spicelabs.config.Resolution
+import io.spicelabs.config.Resolver
+import io.spicelabs.config.Setting
+import org.tomlj.Toml
+import org.tomlj.TomlTable
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Pattern
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+import scala.util.Try
+
+/** Reads a [[Configuration]] from a TOML table.
+  *
+  * WHY a table rather than a file: this is the same schema whether it is the
+  * whole of a Goat Rodeo config file or one nested table inside a larger
+  * `spice` or Allspice config. Taking a `TomlTable` means both cases run the
+  * same code, with no "am I nested?" branch, and it is what lets an outer
+  * program carry Goat Rodeo's settings verbatim without understanding them.
+  *
+  * WHY unknown keys are an error: a mistyped key that is silently ignored is
+  * how a config file becomes undebuggable — the value the user wrote is simply
+  * not in force and nothing says so. The previous attempt at cross-program
+  * configuration failed in exactly this family: an allowlist of Goat Rodeo
+  * flags maintained inside Allspice drifted until it permitted flags Goat Rodeo
+  * does not have.
+  *
+  * Keys are the snake_case spelling of the corresponding command-line flag, and
+  * the mapping is mechanical in both directions: `max_records` is
+  * `--max-records`, `fs_file_paths` is `--fs-file-paths`. The same key is
+  * `GOATRODEO_ANALYSIS_MAX_RECORDS` in the environment standalone, and
+  * `SPICE_ANALYSIS_MAX_RECORDS` when embedded — the same setting under the same
+  * name, differing only in whose program is running.
+  */
+object ConfigurationToml {
+
+  private val logger = com.typesafe.scalalogging.Logger(getClass())
+
+  /** The configuration group these settings belong to.
+    *
+    * Named for the job rather than for this component, and the same group
+    * `spice` and Allspice carry, so `[analysis] threads = 16` means one thing
+    * wherever it is written. A standalone Goat Rodeo config file therefore has
+    * an `[analysis]` table too, rather than bare keys — one shape to learn.
+    */
+  val Group: String = "analysis"
+
+  /** The environment-variable prefix when Goat Rodeo runs standalone.
+    *
+    * `GOATRODEO_ANALYSIS_THREADS` rather than `SPICE_ANALYSIS_THREADS`: the
+    * setting is the same, but a variable naming a program that is not running
+    * would be a lie, and it lets both be set on one machine without collision.
+    */
+  val EnvironmentPrefix: String = "GOATRODEO"
+
+  /** Keys accepted in the `[analysis]` table. */
+  private val knownKeys: Set[String] = Set(
+    "out",
+    "build",
+    "file_list",
+    "ingested",
+    "ignore",
+    "block_list",
+    "exclude_pattern",
+    "threads",
+    "max_records",
+    "temp_dir",
+    "static_metadata",
+    "fs_file_paths",
+    "dump_roots",
+    "dump_json",
+    "mime_filter",
+    "tag",
+    "tag_json",
+    "tag_version",
+    "tag_date",
+    "package_tags",
+    "package_tags_short_name",
+    "emit_cbom_dir",
+    "cbom_version",
+    // Recognised so that it is refused by name rather than reported as a typo, but with no
+    // handler below: knowing the key exists is not the same as letting a file set it.
+    "cutoff"
+  )
+
+  /** Keys no config file may supply, in any mode.
+    *
+    * `cutoff` is an entitlement, not a preference. Embedded in `spice` or
+    * Allspice it is the pass's `x-cutoff`, which constrains what the platform
+    * will accept, and a config file supplying it would hand a user the ability
+    * to widen a scope the platform deliberately narrowed. Standalone there is
+    * no pass to contradict, but the same value read from two kinds of place is
+    * how the embedded rule gets forgotten — so it is refused there too, and
+    * `--cutoff` remains the single way to ask for one.
+    *
+    * Refusing by name rather than by omission: an unrecognised key reports a
+    * typo, which is the wrong thing to say about a key that is spelled
+    * correctly and deliberately unavailable.
+    */
+  private val alwaysRejected: Map[String, String] = Map(
+    "cutoff" ->
+      "the analysis cutoff comes from the Spice Pass, or --cutoff when standalone, and cannot be set in a config file"
+  )
+
+  private case class Invalid(message: String) extends RuntimeException(message)
+
+  /** Read a whole Goat Rodeo config file, plus the environment.
+    *
+    * Standalone, this is where the ladder is applied: defaults, then the
+    * `[analysis]` table, then `GOATRODEO_ANALYSIS_*`. Command-line flags are
+    * applied on top by [[ConfigurationParser]], which is the only part that
+    * knows what a flag is.
+    */
+  def fromFile(
+      path: Path,
+      base: Configuration = Configuration(),
+      environment: Map[String, String] = sys.env,
+      report: String => Unit = message => logger.info(message)
+  ): Either[String, Configuration] = {
+    if (!Files.exists(path)) Left(s"config file not found: $path")
+    else {
+      val result = Toml.parse(Files.readString(path))
+      if (!result.errors().isEmpty())
+        Left(result.errors().asScala.map(_.toString).mkString("; "))
+      else {
+        val root = TomlTables.toPlainMap(result)
+        val loose = root.asScala
+          .collect {
+            case (key, value) if !value.isInstanceOf[java.util.Map[?, ?]] => key
+          }
+          .toSeq
+          .sorted
+        if (loose.nonEmpty)
+          Left(
+            s"settings belong in a table: move ${loose.mkString(", ")} under [$Group]"
+          )
+        else {
+          val resolved = new Resolver(
+            EnvironmentPrefix,
+            java.util.Set.of(Group),
+            message => report(message)
+          )
+            .withFile(path, root, java.util.List.of())
+            .withEnvironment(environment.asJava)
+            .resolve()
+          fromResolution(resolved, base, Group)
+        }
+      }
+    }
+  }
+
+  /** Read a Goat Rodeo configuration from a table.
+    *
+    * @param label
+    *   how to name this table in error messages. An embedding program passes
+    *   the path it used — `registry.analysis`, say — so a user reads about the
+    *   table they wrote rather than about an internal component name.
+    */
+  def fromToml(
+      table: TomlTable,
+      base: Configuration = Configuration(),
+      label: String = ""
+  ): Either[String, Configuration] =
+    fromResolution(
+      Resolution.of(
+        java.util.Map.of(Group, TomlTables.toPlainMap(table)),
+        Origin.embedded(if (label.isEmpty) Group else label)
+      ),
+      base,
+      label
+    )
+
+  /** Read a table nested inside another program's config file. */
+  def nestedFromToml(
+      table: TomlTable,
+      base: Configuration,
+      label: String
+  ): Either[String, Configuration] =
+    fromToml(table, base, label)
+
+  /** Read settings whose value has already been decided.
+    *
+    * The one reader, whether the values came from this program's own file and
+    * environment or from a host that resolved them and passed them in. Both
+    * arrive as a [[Resolution]], so there is no "am I embedded?" branch in the
+    * reading itself — only in what is allowed to appear.
+    */
+  def fromResolution(
+      resolved: Resolution,
+      base: Configuration = Configuration(),
+      label: String = ""
+  ): Either[String, Configuration] = {
+    val prefix = if (label.isEmpty) "" else s"[$label] "
+    val keys = resolved.group(Group).keySet().asScala.toSet
+    val unknown = keys.diff(knownKeys)
+    val rejected = keys.intersect(alwaysRejected.keySet)
+
+    if (unknown.nonEmpty)
+      Left(
+        s"${prefix}unknown ${plural(unknown.size, "key")}: ${unknown.toSeq.sorted.mkString(", ")}"
+      )
+    else if (rejected.nonEmpty)
+      Left(
+        rejected.toSeq.sorted
+          .map(key =>
+            s"$prefix$key is not settable here — ${alwaysRejected(key)}"
+          )
+          .mkString("; ")
+      )
+    else {
+      try Right(read(resolved, base))
+      catch {
+        case Invalid(message) => Left(prefix + message)
+        // A value that cannot be read names itself and the source it came from,
+        // which is more use than anything this layer could add.
+        case e: ConfigurationException => Left(e.getMessage)
+      }
+    }
+  }
+
+  private def read(table: Resolution, base: Configuration): Configuration = {
+    var config = base
+    str(table, "out").foreach(v => config = config.copy(out = Some(file(v))))
+    strs(table, "build").foreach(vs =>
+      config = config.copy(build = config.build ++ vs.map(file))
+    )
+    strs(table, "file_list").foreach(vs =>
+      config = config.copy(fileList = config.fileList ++ vs.map(file))
+    )
+    str(table, "ingested").foreach(v =>
+      config = config.copy(ingested = Some(file(v)))
+    )
+    strs(table, "ignore").foreach(vs =>
+      config = config.copy(ignore = config.ignore ++ vs.map(file))
+    )
+    str(table, "block_list").foreach(v =>
+      config = config.copy(blockList = Some(file(v)))
+    )
+    strs(table, "exclude_pattern").foreach(vs =>
+      config = config.copy(exclude =
+        config.exclude ++ vs.map(p => p -> Try(Pattern.compile(p)))
+      )
+    )
+    int(table, "threads").foreach { v =>
+      if (v < 1) throw Invalid(s"threads must be >= 1, got $v")
+      config = config.copy(threads = v)
+    }
+    int(table, "max_records").foreach { v =>
+      if (v <= 100) throw Invalid(s"max_records must be > 100, got $v")
+      config = config.copy(maxRecords = v)
+    }
+    str(table, "temp_dir").foreach(v =>
+      config = config.copy(tempDir = Some(file(v)))
+    )
+    bool(table, "static_metadata").foreach(v =>
+      config = config.copy(useStaticMetadata = v)
+    )
+    bool(table, "fs_file_paths").foreach(v =>
+      config = config.copy(fsFilePaths = v)
+    )
+    str(table, "dump_roots").foreach(v =>
+      config = config.copy(dumpRootDir = Some(file(v)))
+    )
+    str(table, "dump_json").foreach(v =>
+      config = config.copy(emitJsonDir = Some(file(v)))
+    )
+    strs(table, "mime_filter").foreach(vs =>
+      config = config.copy(mimeFilter = vs.foldLeft(config.mimeFilter)(_ :+ _))
+    )
+    str(table, "tag").foreach(v => config = config.copy(tag = Some(v)))
+    str(table, "tag_json").foreach { v =>
+      val json = Try(Json.decode(v.getBytes("UTF-8")).to[Dom.Element].value)
+      json match {
+        case scala.util.Success(value) =>
+          config = config.copy(tagJson = Some(value))
+        case scala.util.Failure(_) =>
+          throw Invalid(s"tag_json is not valid JSON: $v")
+      }
+    }
+    str(table, "tag_version").foreach(v =>
+      config = config.copy(tagVersion = Some(v))
+    )
+    str(table, "tag_date").foreach { v =>
+      DateParser.parse(v) match {
+        case Right(date) => config = config.copy(tagDate = Some(date))
+        case Left(error) => throw Invalid(s"tag_date: $error")
+      }
+    }
+    bool(table, "package_tags").foreach(v =>
+      config = config.copy(packageTags = v)
+    )
+    bool(table, "package_tags_short_name").foreach(v =>
+      config = config.copy(packageTagsShortName = v)
+    )
+    str(table, "emit_cbom_dir").foreach(v =>
+      config = config.copy(cbomDir = Some(file(v)))
+    )
+    str(table, "cbom_version").foreach { v =>
+      if (!Set("1.6", "1.7").contains(v))
+        throw Invalid(s"cbom_version must be 1.6 or 1.7, got $v")
+      config = config.copy(cbomVersion = v)
+    }
+    config
+  }
+
+  /** Config files may be read from a directory the process cannot see — a
+    * container mount, say — so a relative path in one has no dependable
+    * meaning. Requiring absolute paths also lets the `spice` wrapper keep its
+    * guarantee that every path it must bind-mount is visible on the command
+    * line, since it cannot see inside a TOML table.
+    */
+  private def file(value: String): File = {
+    val f = File(value)
+    if (!f.isAbsolute())
+      throw Invalid(s"paths in a config file must be absolute, got: $value")
+    f
+  }
+
+  private def setting(table: Resolution, key: String): Option[Setting] =
+    table.setting(Group, key).toScala
+
+  private def str(table: Resolution, key: String): Option[String] =
+    setting(table, key).map(_.asString)
+
+  private def strs(table: Resolution, key: String): Option[Vector[String]] =
+    setting(table, key).map(_.asStringList.asScala.toVector)
+
+  private def int(table: Resolution, key: String): Option[Int] =
+    setting(table, key).map(_.asLong.toInt)
+
+  private def bool(table: Resolution, key: String): Option[Boolean] =
+    setting(table, key).map(_.asBoolean)
+
+  private def plural(n: Int, word: String): String =
+    if (n == 1) word else s"${word}s"
+}

--- a/src/main/scala/io/spicelabs/goatrodeo/util/TomlTables.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/TomlTables.scala
@@ -1,0 +1,265 @@
+package io.spicelabs.goatrodeo.util
+
+import org.tomlj.TomlArray
+import org.tomlj.TomlPosition
+import org.tomlj.TomlTable
+
+import java.util.{List as JList, Map as JMap, Set as JSet}
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
+/** Views a plain nested map as a [[TomlTable]].
+  *
+  * WHY: `spice` hands a plugin its slice of the config file as a `Map[String,
+  * Object]` — the TOML data model expressed in `java.*` types, so the plugin
+  * API stays dependency-free and imposes no TOML library on plugin authors.
+  * Everything on this side is already written against `TomlTable`, so rather
+  * than maintain a second reader for maps, adapt the map back. One reader, one
+  * schema, whether the table came from a file or across the SPI.
+  *
+  * `TomlTable` and `TomlArray` are interfaces whose useful accessors
+  * (`getString`, `getLong`, `getTable`, `dottedKeySet`, …) are all `default`
+  * methods built on a handful of abstract ones, so this is a small amount of
+  * mechanical code rather than a reimplementation.
+  *
+  * The one method with no honest answer is `inputPositionOf`: a map has no
+  * source position. It returns a sentinel, which costs only line numbers in
+  * error messages for configuration supplied through the SPI — the messages
+  * still name the offending key.
+  */
+object TomlTables {
+
+  /** A table built from a map has no source position. tomlj requires line and
+    * column to be >= 1, so this is the smallest legal value rather than a
+    * negative sentinel; it only affects line numbers in error messages for
+    * configuration supplied through the SPI, which still name the key.
+    */
+  private val noPosition: TomlPosition = TomlPosition.positionAt(1, 1)
+
+  /** Convert a table to plain `java.*` values, for handing across the plugin
+    * SPI.
+    *
+    * WHY this exists rather than `TomlTable.toMap()`: that method is
+    * **shallow**. A nested table comes back as an `org.tomlj.MutableTomlTable`,
+    * so passing its result across the SPI would leak tomlj types through a
+    * boundary that promises only `java.*` types — and would do so silently for
+    * a flat config, failing only once someone nests a table. This converts all
+    * the way down.
+    */
+  def toPlainMap(table: TomlTable): JMap[String, Object] =
+    table
+      .toMap()
+      .asScala
+      .map { case (k, v) => k -> plain(v) }
+      .toMap
+      .asJava
+
+  private def plain(value: Any): Object = value match {
+    case t: TomlTable => toPlainMap(t)
+    case a: TomlArray => a.toList().asScala.toVector.map(plain).asJava
+    case other        => other.asInstanceOf[Object]
+  }
+
+  /** Adapt a nested Java map — what the plugin SPI hands over — to a
+    * [[TomlTable]].
+    */
+  def fromJavaMap(map: JMap[String, Object]): TomlTable =
+    MapTable(map.asScala.toMap.map { case (k, v) => k -> (v: Any) })
+
+  /** Adapt a nested Scala map to a [[TomlTable]]. */
+  def fromMap(map: Map[String, Any]): TomlTable = MapTable(map)
+
+  /** Values arrive as plain maps and lists; wrap them so nested tables and
+    * arrays behave like the real thing.
+    */
+  private def wrap(value: Any): Any = value match {
+    case t: TomlTable => t
+    case a: TomlArray => a
+    case m: JMap[?, ?] =>
+      MapTable(m.asScala.toMap.map { case (k, v) => k.toString -> (v: Any) })
+    case m: Map[?, ?] =>
+      MapTable(m.map { case (k, v) => k.toString -> (v: Any) })
+    case l: JList[?] => ListArray(l.asScala.toVector.map(v => v: Any))
+    case l: Seq[?]   => ListArray(l.toVector.map(v => v: Any))
+    case other       => other
+  }
+
+  /** Text that names a number or a boolean, read as one *when one is asked
+    * for*.
+    *
+    * The environment has no types: every value in it is a string, and nothing
+    * can say "this one is a count" at the point it is read out of the
+    * environment. The caller can, though — it is asking for a `Long` — so the
+    * coercion happens per accessor rather than on the way in. Doing it on the
+    * way in turned `tag = "42"` into a number and made it unreadable as text.
+    *
+    * Safe here in a way it would not be for real TOML: this adapter never sees
+    * a TOML file, only maps handed over by a host program or a resolver, where
+    * a string saying `16` came from somewhere that could not have written 16.
+    */
+  private def asLong(value: Any): java.lang.Long | Null = value match {
+    case l: java.lang.Long => l
+    case s: String =>
+      Try(java.lang.Long.valueOf(s.trim)).toOption.getOrElse(null)
+    case _ => null
+  }
+
+  private def asDouble(value: Any): java.lang.Double | Null = value match {
+    case d: java.lang.Double => d
+    case l: java.lang.Long   => java.lang.Double.valueOf(l.doubleValue())
+    case s: String =>
+      Try(java.lang.Double.valueOf(s.trim)).toOption.getOrElse(null)
+    case _ => null
+  }
+
+  private def asBoolean(value: Any): java.lang.Boolean | Null = value match {
+    case b: java.lang.Boolean => b
+    case s: String =>
+      s.trim.toLowerCase match {
+        case "true"  => java.lang.Boolean.TRUE
+        case "false" => java.lang.Boolean.FALSE
+        case _       => null
+      }
+    case _ => null
+  }
+
+  private case class MapTable(entries: Map[String, Any]) extends TomlTable {
+
+    private lazy val wrapped: Map[String, Any] =
+      entries.map { case (k, v) => k -> wrap(v) }
+
+    override def size(): Int = wrapped.size
+
+    override def isEmpty(): Boolean = wrapped.isEmpty
+
+    override def keySet(): JSet[String] = wrapped.keySet.asJava
+
+    override def entrySet(): JSet[JMap.Entry[String, Object]] =
+      wrapped
+        .map { case (k, v) =>
+          JMap.entry(k, v.asInstanceOf[Object])
+        }
+        .toSet
+        .asJava
+
+    override def get(path: JList[String] | Null): Object | Null =
+      Option(path).map(_.asScala.toList).getOrElse(Nil) match {
+        case Nil        => this
+        case key :: Nil => wrapped.get(key).map(_.asInstanceOf[Object]).orNull
+        case key :: rest =>
+          wrapped.get(key) match {
+            case Some(table: TomlTable) => table.get(rest.asJava)
+            case _                      => null
+          }
+      }
+
+    override def getLong(dottedKey: String | Null): java.lang.Long | Null =
+      asLong(get(JList.of(dottedKey)))
+
+    override def getLong(path: JList[String] | Null): java.lang.Long | Null =
+      asLong(get(path))
+
+    override def getDouble(dottedKey: String | Null): java.lang.Double | Null =
+      asDouble(get(JList.of(dottedKey)))
+
+    override def getDouble(path: JList[String] | Null): java.lang.Double |
+      Null =
+      asDouble(get(path))
+
+    override def getBoolean(dottedKey: String | Null): java.lang.Boolean |
+      Null =
+      asBoolean(get(JList.of(dottedKey)))
+
+    override def getBoolean(path: JList[String] | Null): java.lang.Boolean |
+      Null =
+      asBoolean(get(path))
+
+    override def inputPositionOf(path: JList[String] | Null): TomlPosition =
+      noPosition
+
+    override def keyPathSet(includeTables: Boolean): JSet[JList[String]] =
+      paths(includeTables).map(_.asJava).asJava
+
+    override def entryPathSet(
+        includeTables: Boolean
+    ): JSet[JMap.Entry[JList[String], Object]] =
+      paths(includeTables).map { path =>
+        JMap.entry(path.asJava, get(path.asJava).asInstanceOf[Object])
+      }.asJava
+
+    override def toMap(): JMap[String, Object] =
+      entries.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
+
+    /** Dotted key paths, matching tomlj: leaves always, and the tables
+      * themselves only when asked for.
+      */
+    private def paths(includeTables: Boolean): Set[List[String]] =
+      wrapped.flatMap {
+        case (key, table: TomlTable) => {
+          val below = table
+            .keyPathSet(includeTables)
+            .asScala
+            .toSet
+            .map((path: JList[String]) => key :: path.asScala.toList)
+          if (includeTables) below + List(key) else below
+        }
+        case (key, _) => Set(List(key))
+      }.toSet
+  }
+
+  private case class ListArray(values: Vector[Any]) extends TomlArray {
+
+    private lazy val wrapped: Vector[Any] = values.map(wrap)
+
+    override def size(): Int = wrapped.size
+
+    override def isEmpty(): Boolean = wrapped.isEmpty
+
+    override def get(index: Int): Object = wrapped(index).asInstanceOf[Object]
+
+    override def inputPositionOf(index: Int): TomlPosition = noPosition
+
+    /** The wrapped values, like every other accessor here.
+      *
+      * Returning the raw ones was a bug you could only hit with an array of
+      * tables — `[[repositories]]`, say — where a caller doing what tomlj's own
+      * contract allows, `toList().get(0).asInstanceOf[TomlTable]`, got a plain
+      * Map and a ClassCastException. Every other accessor wrapped; this one did
+      * not, and nothing had an array of tables to notice with.
+      */
+    override def toList(): JList[Object] =
+      wrapped.map(_.asInstanceOf[Object]).asJava
+
+    /** TOML arrays are homogeneous, so "contains X" is "every element is an X".
+      * An empty array satisfies none of them, matching tomlj.
+      */
+    private def all(f: Any => Boolean): Boolean =
+      wrapped.nonEmpty && wrapped.forall(f)
+
+    override def containsStrings(): Boolean = all(_.isInstanceOf[String])
+
+    override def containsLongs(): Boolean = all(_.isInstanceOf[java.lang.Long])
+
+    override def containsDoubles(): Boolean =
+      all(_.isInstanceOf[java.lang.Double])
+
+    override def containsBooleans(): Boolean =
+      all(_.isInstanceOf[java.lang.Boolean])
+
+    override def containsOffsetDateTimes(): Boolean =
+      all(_.isInstanceOf[java.time.OffsetDateTime])
+
+    override def containsLocalDateTimes(): Boolean =
+      all(_.isInstanceOf[java.time.LocalDateTime])
+
+    override def containsLocalDates(): Boolean =
+      all(_.isInstanceOf[java.time.LocalDate])
+
+    override def containsLocalTimes(): Boolean =
+      all(_.isInstanceOf[java.time.LocalTime])
+
+    override def containsArrays(): Boolean = all(_.isInstanceOf[TomlArray])
+
+    override def containsTables(): Boolean = all(_.isInstanceOf[TomlTable])
+  }
+}

--- a/src/test/scala/ConfigurationTomlSuite.scala
+++ b/src/test/scala/ConfigurationTomlSuite.scala
@@ -174,6 +174,62 @@ class ConfigurationTomlSuite extends munit.FunSuite {
     }
   }
 
+  test(
+    "an overridden setting is reported against the source that supplied it"
+  ) {
+    // The file and the environment are resolved together, so crediting the file
+    // for everything the command line displaces names the wrong loser whenever
+    // the value came from a variable.
+    val reported = scala.collection.mutable.ArrayBuffer[String]()
+    withConfigFile("[analysis]\nthreads = 4\nmax_records = 999999\n") { path =>
+      ConfigurationToml
+        .fromSources(
+          Some(path),
+          Configuration(),
+          environment = Map("GOATRODEO_ANALYSIS_THREADS" -> "9"),
+          report = reported.append(_)
+        ) match {
+        case Right((resolved, resolution)) =>
+          assertEquals(
+            ConfigurationToml.sourceOf(resolution, "threads"),
+            Some("GOATRODEO_ANALYSIS_THREADS"),
+            "the environment set this one last"
+          )
+          assertEquals(
+            ConfigurationToml.sourceOf(resolution, "maxRecords"),
+            Some(s"[analysis] in $path"),
+            "and the file set this one"
+          )
+          assertEquals(
+            ConfigurationToml.sourceOf(resolution, "tag"),
+            None,
+            "a setting left at its default has no source to name"
+          )
+        case Left(error) => fail(error)
+      }
+    }
+  }
+
+  test("an overridden setting is named as its writer spelled it") {
+    // Configuration's field names are a fourth spelling, unrelated to the three
+    // the documentation promises. Reporting `maxRecords` describes a name that
+    // appears in no file, flag or variable.
+    assertEquals(ConfigurationToml.displayName("maxRecords"), "max_records")
+    assertEquals(ConfigurationToml.displayName("emitJsonDir"), "dump_json")
+    assertEquals(ConfigurationToml.displayName("cbomDir"), "emit_cbom_dir")
+  }
+
+  test("every field with a config-file key names a key that exists") {
+    // The map is written out by hand because the relation is not mechanical;
+    // this is what stops it drifting from the schema beside it.
+    ConfigurationToml.fieldKeys.foreach { key =>
+      assert(
+        ConfigurationToml.accepts(key),
+        s"$key is reported as a config key but the schema does not accept it"
+      )
+    }
+  }
+
   test("--config records the file it read") {
     withConfigFile("[analysis]\nthreads = 4\n") { path =>
       val config = ConfigurationParser
@@ -229,6 +285,43 @@ class ConfigurationTomlSuite extends munit.FunSuite {
       )
       assert(reported.head.contains("overrides"), reported.head)
     }
+  }
+
+  test("the environment is read on a run that names no config file") {
+    // The environment is a source in its own right. Reaching it only through
+    // --config meant a run that wanted to set one thing, and said so the way the
+    // documentation describes, was silently ignored.
+    val config = ConfigurationParser
+      .parse(
+        Array("--out", "/tmp/out"),
+        environment = Map("GOATRODEO_ANALYSIS_THREADS" -> "9")
+      )
+      .getOrElse(fail("expected a parse"))
+    assertEquals(config.threads, 9)
+    assertEquals(config.configFile, None, "and there was no file")
+  }
+
+  test("the command line beats the environment, with no config file either") {
+    val config = ConfigurationParser
+      .parse(
+        Array("--threads", "12"),
+        environment = Map("GOATRODEO_ANALYSIS_THREADS" -> "9")
+      )
+      .getOrElse(fail("expected a parse"))
+    assertEquals(config.threads, 12)
+  }
+
+  test("an unknown variable in a group this program claims is an error") {
+    // The same rule as a mistyped key in the file, for the same reason: a
+    // setting that is quietly not in force is how configuration becomes
+    // undebuggable.
+    assertEquals(
+      ConfigurationParser.parse(
+        Array("--out", "/tmp/out"),
+        environment = Map("GOATRODEO_ANALYSIS_TREADS" -> "9")
+      ),
+      None
+    )
   }
 
   test("a variable that names no group is not a setting") {

--- a/src/test/scala/ConfigurationTomlSuite.scala
+++ b/src/test/scala/ConfigurationTomlSuite.scala
@@ -1,0 +1,467 @@
+import io.spicelabs.goatrodeo.util.Configuration
+import io.spicelabs.goatrodeo.util.ConfigurationParser
+import io.spicelabs.goatrodeo.util.ConfigurationToml
+import io.spicelabs.goatrodeo.util.TomlTables
+import org.tomlj.Toml
+import org.tomlj.TomlTable
+
+import java.nio.file.Files
+import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
+
+/** WHAT: covers reading a [[Configuration]] from TOML — the schema itself, the
+  * precedence of the command line over the file, the rules that keep a config
+  * file from becoming a second way to say something it should not, and the
+  * map-backed [[TomlTables]] adapter the plugin SPI hands tables through.
+  *
+  * WHY: this schema is now published in three places — the parser, the docs,
+  * and the templates Allspice generates. Tests are what stop those drifting.
+  * The previous cross-program configuration channel failed exactly there: an
+  * allowlist of Goat Rodeo flags kept inside Allspice drifted until it
+  * permitted flags Goat Rodeo does not have, and nothing noticed because
+  * nothing checked.
+  */
+class ConfigurationTomlSuite extends munit.FunSuite {
+
+  private def parse(toml: String): TomlTable = {
+    val result = Toml.parse(toml)
+    assert(
+      result.errors().isEmpty(),
+      s"fixture is not valid TOML: ${result.errors()}"
+    )
+    result
+  }
+
+  private def read(toml: String): Either[String, Configuration] =
+    ConfigurationToml.fromToml(parse(toml))
+
+  private def readOk(toml: String): Configuration =
+    read(toml) match {
+      case Right(config) => config
+      case Left(error)   => fail(s"expected success, got: $error")
+    }
+
+  // ==================== the schema ====================
+
+  test("every scalar key round-trips into the configuration") {
+    val config = readOk("""
+      |out = "/tmp/out"
+      |threads = 12
+      |max_records = 5000
+      |temp_dir = "/tmp/scratch"
+      |static_metadata = true
+      |fs_file_paths = true
+      |tag = "nightly"
+      |tag_version = "1.2.3"
+      |package_tags = true
+      |package_tags_short_name = true
+      |cbom_version = "1.7"
+      |""".stripMargin)
+
+    assertEquals(config.out.map(_.getPath()), Some("/tmp/out"))
+    assertEquals(config.threads, 12)
+    assertEquals(config.maxRecords, 5000)
+    assertEquals(config.tempDir.map(_.getPath()), Some("/tmp/scratch"))
+    assertEquals(config.useStaticMetadata, true)
+    assertEquals(config.fsFilePaths, true)
+    assertEquals(config.tag, Some("nightly"))
+    assertEquals(config.tagVersion, Some("1.2.3"))
+    assertEquals(config.packageTags, true)
+    assertEquals(config.packageTagsShortName, true)
+    assertEquals(config.cbomVersion, "1.7")
+  }
+
+  test("array keys accumulate onto the base configuration") {
+    val config = readOk("""
+      |build = ["/srv/a", "/srv/b"]
+      |mime_filter = ["+application/java-archive"]
+      |exclude_pattern = ["html$"]
+      |""".stripMargin)
+
+    assertEquals(config.build.map(_.getPath()), Vector("/srv/a", "/srv/b"))
+    assertEquals(config.exclude.map(_._1), Vector("html$"))
+    assert(
+      config.mimeFilter.shouldInclude(Set("application/java-archive")),
+      "the mime filter from the file must be in force"
+    )
+  }
+
+  test("a key the schema does not have is an error, not silence") {
+    // Silently ignoring a typo is how a config file becomes undebuggable: the
+    // value the user wrote is simply not in force and nothing says so.
+    val error = read("thraeds = 4").left.getOrElse(fail("expected an error"))
+    assert(error.contains("unknown key"), error)
+    assert(error.contains("thraeds"), error)
+  }
+
+  test("a key of the wrong type names the key and both types") {
+    val error =
+      read("""threads = "many"""").left.getOrElse(fail("expected an error"))
+    assert(error.contains("threads"), error)
+    assert(error.contains("whole number"), error)
+    // and quotes the value it could not read
+    assert(error.contains("many"), error)
+  }
+
+  test("relative paths are rejected") {
+    // The `spice` wrapper bind-mounts paths it reads off the command line before
+    // the JVM starts; it cannot see inside a TOML table, so a relative path here
+    // has no dependable meaning.
+    val error =
+      read("""out = "relative/dir"""").left.getOrElse(fail("expected an error"))
+    assert(error.contains("absolute"), error)
+  }
+
+  test("validation matches the flags: threads >= 1, cbom_version 1.6 or 1.7") {
+    assert(read("threads = 0").isLeft)
+    assert(read("""cbom_version = "1.5"""").isLeft)
+    assert(read("""cbom_version = "1.6"""").isRight)
+  }
+
+  // ==================== nesting ====================
+
+  test("cutoff is refused in Goat Rodeo's own config file too") {
+    // An entitlement, not a preference: --cutoff is the only way to ask for one when
+    // standalone, so that the embedded rule has no second spelling to be forgotten by.
+    val error = read("""cutoff = "2026-01-01"""").left
+      .getOrElse(fail("expected an error"))
+    assert(error.contains("cutoff"), error)
+    assert(error.contains("not settable here"), error)
+  }
+
+  test("cutoff is refused in a table nested inside another program's config") {
+    // Embedded, the cutoff is the Spice Pass's `x-cutoff`: it constrains what the
+    // platform will accept, so a config file must not be able to widen it.
+    val result = ConfigurationToml.nestedFromToml(
+      parse("""cutoff = "2026-01-01""""),
+      Configuration(),
+      "registry.analysis"
+    )
+    val error = result.left.getOrElse(fail("expected an error"))
+    assert(error.contains("Spice Pass"), error)
+    assert(error.contains("registry.analysis"), error)
+  }
+
+  test("errors name the table the user wrote, not an internal component") {
+    val error = ConfigurationToml
+      .nestedFromToml(
+        parse("nonsense = 1"),
+        Configuration(),
+        "registry.analysis"
+      )
+      .left
+      .getOrElse(fail("expected an error"))
+    assert(error.contains("[registry.analysis]"), error)
+    assert(
+      !error.toLowerCase().contains("goat"),
+      s"leaked an internal name: $error"
+    )
+  }
+
+  // ==================== precedence ====================
+
+  test("the command line beats the config file") {
+    withConfigFile("[analysis]\nthreads = 4\nmax_records = 999999\n") { path =>
+      val config = ConfigurationParser
+        .parse(Array("--config", path.toString, "--threads", "9"))
+        .getOrElse(fail("expected a parse"))
+      assertEquals(config.threads, 9, "the flag must win")
+      assertEquals(
+        config.maxRecords,
+        999999,
+        "the file still supplies the rest"
+      )
+    }
+  }
+
+  test("--config records the file it read") {
+    withConfigFile("[analysis]\nthreads = 4\n") { path =>
+      val config = ConfigurationParser
+        .parse(Array("--config", path.toString))
+        .getOrElse(fail("expected a parse"))
+      assertEquals(config.configFile.map(_.toPath()), Some(path))
+    }
+  }
+
+  test(
+    "a config file that does not parse fails the run rather than being ignored"
+  ) {
+    withConfigFile("[analysis]\nthreads = \n") { path =>
+      assertEquals(
+        ConfigurationParser.parse(Array("--config", path.toString)),
+        None
+      )
+    }
+  }
+
+  // ==================== the environment ====================
+
+  test("the environment supplies settings under the component's own prefix") {
+    withConfigFile("[analysis]\nthreads = 4\n") { path =>
+      val config = ConfigurationToml
+        .fromFile(
+          path,
+          Configuration(),
+          environment = Map("GOATRODEO_ANALYSIS_MAX_RECORDS" -> "12345")
+        )
+        .getOrElse(fail("expected a configuration"))
+      assertEquals(config.maxRecords, 12345, "the environment supplies it")
+      assertEquals(config.threads, 4, "and the file still supplies the rest")
+    }
+  }
+
+  test("the environment beats the config file, and says so") {
+    val reported = scala.collection.mutable.ArrayBuffer[String]()
+    withConfigFile("[analysis]\nthreads = 4\n") { path =>
+      val config = ConfigurationToml
+        .fromFile(
+          path,
+          Configuration(),
+          environment = Map("GOATRODEO_ANALYSIS_THREADS" -> "9"),
+          report = reported.append(_)
+        )
+        .getOrElse(fail("expected a configuration"))
+      assertEquals(config.threads, 9)
+      assertEquals(reported.size, 1, s"expected one report, got: $reported")
+      assert(
+        reported.head.contains("GOATRODEO_ANALYSIS_THREADS"),
+        reported.head
+      )
+      assert(reported.head.contains("overrides"), reported.head)
+    }
+  }
+
+  test("a variable that names no group is not a setting") {
+    // The wrapper's own variables share the namespace and must be left alone.
+    withConfigFile("[analysis]\nthreads = 4\n") { path =>
+      val config = ConfigurationToml
+        .fromFile(
+          path,
+          Configuration(),
+          environment =
+            Map("GOATRODEO_IMAGE" -> "something", "PATH" -> "/usr/bin")
+        )
+        .getOrElse(fail("expected a configuration"))
+      assertEquals(config.threads, 4)
+    }
+  }
+
+  // ==================== the file's shape ====================
+
+  test("settings outside a table are refused, not ignored") {
+    // Bare keys at the root are how this file used to be written. Silently doing
+    // nothing with them is exactly the failure this schema exists to prevent, so
+    // the message says where they belong.
+    withConfigFile("threads = 4\n") { path =>
+      val error = ConfigurationToml
+        .fromFile(path, Configuration())
+        .left
+        .getOrElse(fail("expected an error"))
+      assert(error.contains("threads"), error)
+      assert(error.contains("[analysis]"), error)
+    }
+  }
+
+  test("the command line beats the file, and each difference is reported") {
+    withConfigFile("[analysis]\nthreads = 4\nmax_records = 999999\n") { path =>
+      val config = ConfigurationParser
+        .parse(Array("--config", path.toString, "--threads", "9"))
+        .getOrElse(fail("expected a parse"))
+      assertEquals(config.threads, 9)
+      assertEquals(config.maxRecords, 999999)
+      assertEquals(
+        config.differencesFrom(config.copy(threads = 4)).map(_._1),
+        Vector("threads"),
+        "and the difference the report is derived from is exactly that field"
+      )
+    }
+  }
+
+  test("an array of tables crosses as tables, not as plain maps") {
+    // tomlj's contract lets a caller write toList().get(0).asInstanceOf[TomlTable],
+    // and every other accessor here wraps nested values to honour it. toList did
+    // not, which nothing could notice until a config file had an array of tables
+    // in it — Allspice's [[repositories]] is the first.
+    val table = TomlTables.fromMap(
+      Map(
+        "repositories" -> java.util.List.of(
+          java.util.Map.of("id", "one"),
+          java.util.Map.of("id", "two")
+        )
+      )
+    )
+
+    val entries = table.getArrayOrEmpty("repositories").toList()
+    assertEquals(entries.size(), 2)
+    entries.asScala.foreach { entry =>
+      assert(
+        entry.isInstanceOf[TomlTable],
+        s"expected a TomlTable, got ${entry.getClass.getName}"
+      )
+    }
+    assertEquals(
+      entries.get(0).asInstanceOf[TomlTable].getString("id"),
+      "one"
+    )
+  }
+
+  test("text that names a number is read as one") {
+    // Every environment value is a string, and the program reading a setting
+    // out of a map cannot say "this one is a count" at the point it arrives.
+    // This adapter never sees a real TOML file, so a string saying `16` can
+    // only have come from somewhere that could not have written 16.
+    val table = TomlTables.fromMap(
+      Map(
+        "threads" -> "16",
+        "static_metadata" -> "true",
+        "tag" -> "42"
+      )
+    )
+
+    assertEquals(table.getLong("threads"), java.lang.Long.valueOf(16L))
+    assertEquals(table.getBoolean("static_metadata"), java.lang.Boolean.TRUE)
+    assertEquals(
+      table.getString("tag"),
+      "42",
+      "and a setting that wants text still gets the text"
+    )
+  }
+
+  private def withConfigFile[A](contents: String)(f: Path => A): A = {
+    val path = Files.createTempFile("goatrodeo-config", ".toml")
+    try {
+      Files.writeString(path, contents)
+      f(path)
+    } finally { Files.deleteIfExists(path); () }
+  }
+
+  // ==================== the map-backed adapter ====================
+
+  test("a table survives the round trip through a plain map") {
+    // This is the path a plugin's configuration takes: `spice` parses the file,
+    // hands the plugin `toMap()`, and the plugin adapts it back. Anything lost
+    // here is a setting that silently stops working when run under `spice`.
+    val original = parse("""
+      |out = "/tmp/out"
+      |threads = 7
+      |static_metadata = true
+      |mime_filter = ["+a", "-b"]
+      |
+      |[nested]
+      |inner = "value"
+      |depth = 2
+      |""".stripMargin)
+
+    val adapted = TomlTables.fromJavaMap(TomlTables.toPlainMap(original))
+
+    assertEquals(
+      adapted.keySet().asScala.toSet,
+      original.keySet().asScala.toSet
+    )
+    assertEquals(adapted.getString("out"), original.getString("out"))
+    assertEquals(adapted.getLong("threads"), original.getLong("threads"))
+    assertEquals(
+      adapted.getBoolean("static_metadata"),
+      original.getBoolean("static_metadata")
+    )
+    assertEquals(
+      adapted.getArray("mime_filter").toList().asScala.toVector,
+      original.getArray("mime_filter").toList().asScala.toVector
+    )
+    assertEquals(
+      adapted.getTable("nested").getString("inner"),
+      original.getTable("nested").getString("inner")
+    )
+    assertEquals(
+      adapted.dottedKeySet().asScala.toSet,
+      original.dottedKeySet().asScala.toSet
+    )
+  }
+
+  test(
+    "a configuration read through the adapter equals one read from the file"
+  ) {
+    val toml =
+      """
+        |out = "/tmp/out"
+        |threads = 7
+        |mime_filter = ["+application/java-archive"]
+        |package_tags = true
+        |""".stripMargin
+    val direct = readOk(toml)
+    val viaMap = ConfigurationToml
+      .fromToml(TomlTables.fromJavaMap(TomlTables.toPlainMap(parse(toml))))
+      .getOrElse(fail("expected success"))
+
+    assertEquals(viaMap.out, direct.out)
+    assertEquals(viaMap.threads, direct.threads)
+    assertEquals(viaMap.packageTags, direct.packageTags)
+    assertEquals(
+      viaMap.mimeFilter.shouldInclude(Set("application/java-archive")),
+      direct.mimeFilter.shouldInclude(Set("application/java-archive"))
+    )
+  }
+
+  // ==================== the embedding seam ====================
+
+  test("a table applied through the builder reaches the configuration") {
+    // This is the whole point of the exercise: `spice` hands its
+    // `[survey.inventory.analysis]` table over without knowing what is in it.
+    val builder = io.spicelabs.goatrodeo.GoatRodeo
+      .builder()
+      .withThreads(2)
+      .withConfiguration(
+        TomlTables.toPlainMap(parse("threads = 11\nmax_records = 4242")),
+        "survey.inventory.analysis"
+      )
+    val applied = builderConfig(builder)
+    assertEquals(applied.threads, 11)
+    assertEquals(applied.maxRecords, 4242)
+  }
+
+  test("the builder refuses a cutoff from an embedding program's config file") {
+    val error = intercept[IllegalArgumentException] {
+      io.spicelabs.goatrodeo.GoatRodeo
+        .builder()
+        .withConfiguration(
+          TomlTables.toPlainMap(parse("cutoff = \"2026-01-01\"")),
+          "survey.inventory.analysis"
+        )
+    }
+    assert(error.getMessage().contains("Spice Pass"), error.getMessage())
+  }
+
+  test("the builder rejects an unknown key rather than ignoring it") {
+    val error = intercept[IllegalArgumentException] {
+      io.spicelabs.goatrodeo.GoatRodeo
+        .builder()
+        .withConfiguration(
+          TomlTables.toPlainMap(parse("thraeds = 4")),
+          "survey.inventory.analysis"
+        )
+    }
+    assert(error.getMessage().contains("thraeds"), error.getMessage())
+  }
+
+  /** The builder keeps its configuration private; tests read it reflectively
+    * rather than widening the API for their own convenience.
+    */
+  private def builderConfig(
+      b: io.spicelabs.goatrodeo.GoatRodeoBuilder
+  ): Configuration = {
+    val field = classOf[io.spicelabs.goatrodeo.GoatRodeoBuilder]
+      .getDeclaredField("config")
+    field.setAccessible(true)
+    field.get(b).asInstanceOf[Configuration]
+  }
+
+  test("an empty array claims no element type, matching tomlj") {
+    val original = parse("empty = []")
+    val adapted = TomlTables.fromJavaMap(TomlTables.toPlainMap(original))
+    assertEquals(
+      adapted.getArray("empty").containsStrings(),
+      original.getArray("empty").containsStrings()
+    )
+    assertEquals(adapted.getArray("empty").isEmpty(), true)
+  }
+}


### PR DESCRIPTION
Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

Goat Rodeo took configuration from a command line and a builder. It now also reads a TOML file named with `--config`, and the environment.

Settings live in an `[analysis]` table — a *group*, named for the job rather than for this component, and the same group `spice` and Allspice carry, so `[analysis] threads = 16` means one thing wherever it is written. The same reader serves a whole Goat Rodeo config file and a table nested inside another program's.

The three names of a setting follow a rule with no exceptions:

```
[analysis] max_records   →   --max-records   →   GOATRODEO_ANALYSIS_MAX_RECORDS
```

**Breaking:** `--maxrecords` → `--max-records`, `--tempdir` → `--temp-dir`, `--block` → `--block-list`. Those three were the only exceptions to the rule.

```
defaults  <  [analysis]  <  environment  <  command line
```

Each displacement is reported. The command line cannot report itself — scopt folds flags straight into the configuration with nowhere to record an origin — so it is *derived*, by comparing the configuration before and after the flags are applied. A flag added later is covered without anyone remembering to.

Three rules the file follows, each because the alternative is a setting that quietly does nothing: an unknown key is an error; a setting outside a table is an error, naming the keys and saying they belong under `[analysis]`; and paths must be absolute, since a config file may be read from a directory the process cannot see and the `spice` wrapper cannot bind-mount what it cannot see inside a TOML table.

`cutoff` is rejected when nested — standalone it is Goat Rodeo's own knob, embedded it is the pass's cutoff, and a config file must not widen a scope the platform narrowed.

## Two bugs in the map adapter, fixed here

`TomlTables` adapts the plain nested maps the plugin SPI carries back to a `TomlTable`. `toList` returned *unwrapped* values, so an array of tables gave a `ClassCastException` to a caller doing what tomlj's contract allows; and the environment has no types, so a value from it is text even when it is a count, which the typed getters now coerce when a number is asked for.

25 config tests. Full suite: 24 pre-existing failures.

**Depends on:** #288 (stacked) · [spice-config](https://github.com/spice-labs-inc/spice-config). Docs follow in spice-labs-inc/internal-docs#650.