### PR TITLE
Take a log level like every other Spice tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ Precedence, lowest to highest:
 | `progressListener` | `Option[ProgressListener]` | — (not on the CLI) | `withProgressListener` | none |
 | `runtime` | `RuntimeEnvironment` | — (captured at startup) | — | the real process |
 | `configFile` | `Option[File]` | `--config` | — | none |
+| `logging` | `Map[String, Any]` | `--log-level`, `--log-file` | — | empty |
 
 ## Not settings
 
@@ -199,6 +200,27 @@ Three rules are worth knowing:
   see — a container mount, say — so a relative path in one has no dependable meaning. It also
   keeps the `spice` wrapper's guarantee that every path it must bind-mount is visible on the
   command line, since it cannot see inside a TOML table.
+
+### The `[logging]` group
+
+How much a run says, and where:
+
+```toml
+[logging]
+level = "debug"      # error, warn, info, debug, trace
+file = "/tmp/gr.log" # in addition to the console, not instead of it
+```
+
+The same group, keys and precedence as every other Spice tool, so a level means one thing
+wherever it is set. Only this program's own loggers move: lifting Tika or the bytecode
+readers to `debug` alongside them would bury the output you asked for.
+
+Applied by `main`. Embedded through `GoatRodeoBuilder` the host owns logging and chose its
+levels deliberately, so nothing on that path touches them.
+
+Goat Rodeo carries this group rather than interpreting it, but carried does not mean
+unchecked: the three rules above apply here too, so `[logging] levl` fails the run instead of
+travelling as far as the code that applies it and being dropped there in silence.
 
 ### Embedded in another program's config file
 

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -16,6 +16,10 @@ package io.spicelabs.goatrodeo
 
 import com.typesafe.scalalogging.Logger
 import io.bullet.borer.Dom
+import io.spicelabs.config.LogbackLogging
+import io.spicelabs.config.Logging
+import io.spicelabs.config.Origin
+import io.spicelabs.config.Resolution
 import io.spicelabs.goatrodeo.omnibor.Builder
 import io.spicelabs.goatrodeo.omnibor.Storage
 import io.spicelabs.goatrodeo.omnibor.TagInfo
@@ -68,9 +72,37 @@ object Howdy {
 
     // Based on the CLI parse, make the right choices and do the right thing
     parsed match {
-      case Some(config) => run(using config)
-      case _            => Helpers.bailFail()
+      case Some(config) =>
+        // Applied here, where this program owns the process. Embedded in another program
+        // through GoatRodeoBuilder, the host owns logging and chose its levels
+        // deliberately, so nothing on that path touches them.
+        applyLogging(config)
+        run(using config)
+      case _ => Helpers.bailFail()
     }
+  }
+
+  /** Apply the resolved `[logging]` group — the same group, keys and precedence
+    * as every other Spice tool.
+    *
+    * Only the loggers this program owns are moved: a level says how much *this*
+    * program should say, and lifting Tika or the bytecode readers along with it
+    * would bury the output the person asked for.
+    */
+  private def applyLogging(config: Configuration): Unit = {
+    val defaults = Logging.defaults().get(Logging.GROUP).asScala
+    val settings = (defaults ++ config.logging).map { case (key, value) =>
+      key -> (value.asInstanceOf[Object])
+    }
+    LogbackLogging.apply(
+      Resolution.of(
+        java.util.Map.of(Logging.GROUP, settings.asJava),
+        Origin.embedded(Logging.GROUP)
+      ),
+      // Fully qualified because it names a logger, not a type: this is the
+      // package whose loggers move, and it stays right when the imports change.
+      "io.spicelabs.goatrodeo"
+    )
   }
 
   /** Run the Goat Rodeo builder with the given configuration.

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Configuration.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Configuration.scala
@@ -166,6 +166,7 @@ case class Configuration(
     cbomDir: Option[File] = None,
     cbomVersion: String = "1.6",
     configFile: Option[File] = None,
+    logging: Map[String, Any] = Map(),
     runtime: RuntimeEnvironment = RuntimeEnvironment.default
 ) {
 

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationParser.scala
@@ -245,6 +245,12 @@ object ConfigurationParser {
             Pattern.compile(p)
           })))
         ),
+      opt[String]("log-level")
+        .text("error, warn, info, debug or trace (default: info)")
+        .action((x, c) => c.copy(logging = c.logging + ("level" -> x))),
+      opt[String]("log-file")
+        .text("Also write log output to this file")
+        .action((x, c) => c.copy(logging = c.logging + ("file" -> x))),
       opt[Int]("max-records")
         .text(
           "The maximum number of records to process at once. Default 50,000"

--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
@@ -3,6 +3,7 @@ package io.spicelabs.goatrodeo.util
 import io.bullet.borer.Dom
 import io.bullet.borer.Json
 import io.spicelabs.config.ConfigurationException
+import io.spicelabs.config.Logging
 import io.spicelabs.config.Origin
 import io.spicelabs.config.Resolution
 import io.spicelabs.config.Resolver
@@ -207,7 +208,7 @@ object ConfigurationToml {
   ): Either[String, (Configuration, Resolution)] = {
     val resolver = new Resolver(
       EnvironmentPrefix,
-      java.util.Set.of(Group),
+      java.util.Set.of(Group, Logging.GROUP),
       message => report(message)
     )
 
@@ -238,7 +239,20 @@ object ConfigurationToml {
 
     withFile.flatMap { resolver =>
       val resolved = resolver.withEnvironment(environment.asJava).resolve()
-      fromResolution(resolved, base, Group).map((_, resolved))
+      // `[logging]` is carried, not interpreted — but "carried" must not mean
+      // "unchecked". The resolver filters by group and accepts any key inside
+      // one, so without this a mistyped `levl` would travel all the way to the
+      // program that applies it and be dropped there in silence: the same
+      // failure the `[analysis]` schema exists to prevent, one table over.
+      val unknownLogging = Logging.unknownKeys(resolved).asScala.toSeq
+      if (unknownLogging.nonEmpty)
+        Left(
+          s"[${Logging.GROUP}] unknown ${plural(unknownLogging.size, "key")}: ${unknownLogging.mkString(", ")}"
+        )
+      else
+        fromResolution(resolved, base, Group)
+          .map(_.copy(logging = plainGroup(resolved, Logging.GROUP)))
+          .map((_, resolved))
     }
   }
 
@@ -321,6 +335,15 @@ object ConfigurationToml {
       }
     }
   }
+
+  /** A resolved group as a plain Scala map, for a group this program carries
+    * but does not interpret.
+    */
+  private def plainGroup(
+      resolved: Resolution,
+      group: String
+  ): Map[String, Any] =
+    resolved.group(group).asScala.toMap.map { case (k, v) => k -> (v: Any) }
 
   private def read(table: Resolution, base: Configuration): Configuration = {
     var config = base

--- a/src/test/scala/ConfigurationTomlSuite.scala
+++ b/src/test/scala/ConfigurationTomlSuite.scala
@@ -420,6 +420,82 @@ class ConfigurationTomlSuite extends munit.FunSuite {
     )
   }
 
+  // ==================== logging ====================
+
+  test(
+    "the logging group is read like any other, and is the same one everywhere"
+  ) {
+    withConfigFile(
+      "[analysis]\nthreads = 4\n\n[logging]\nlevel = \"debug\"\n"
+    ) { path =>
+      val config = ConfigurationToml
+        .fromFile(path, Configuration(), environment = Map.empty)
+        .getOrElse(fail("expected a configuration"))
+      assertEquals(config.logging.get("level"), Some("debug"))
+      assertEquals(config.threads, 4, "and the analysis group is unaffected")
+    }
+  }
+
+  test("the environment supplies a log level, under this program's prefix") {
+    withConfigFile("[analysis]\nthreads = 4\n") { path =>
+      val config = ConfigurationToml
+        .fromFile(
+          path,
+          Configuration(),
+          environment = Map("GOATRODEO_LOGGING_LEVEL" -> "trace")
+        )
+        .getOrElse(fail("expected a configuration"))
+      assertEquals(config.logging.get("level"), Some("trace"))
+    }
+  }
+
+  test("a log level from the environment needs no config file") {
+    // The variable is the whole point of the group for anyone running a
+    // container: asking for one noisy run should not mean writing a file.
+    val config = ConfigurationParser
+      .parse(
+        Array("--out", "/tmp/out"),
+        environment = Map("GOATRODEO_LOGGING_LEVEL" -> "debug")
+      )
+      .getOrElse(fail("expected a parse"))
+    assertEquals(config.logging.get("level"), Some("debug"))
+  }
+
+  test("a mistyped logging key is an error, not silence") {
+    // This group is carried rather than interpreted, so nothing downstream is
+    // in a position to complain about it: unchecked, `levl` would be dropped
+    // wherever the level is finally applied, and nothing would say so.
+    withConfigFile("[analysis]\nthreads = 4\n\n[logging]\nlevl = \"debug\"\n") {
+      path =>
+        val error = ConfigurationToml
+          .fromFile(path, Configuration(), environment = Map.empty)
+          .left
+          .getOrElse(fail("expected an error"))
+        assert(error.contains("levl"), error)
+        assert(error.contains("unknown key"), error)
+    }
+  }
+
+  test("a mistyped logging variable is an error too") {
+    assertEquals(
+      ConfigurationParser.parse(
+        Array("--out", "/tmp/out"),
+        environment = Map("GOATRODEO_LOGGING_LEVL" -> "debug")
+      ),
+      None
+    )
+  }
+
+  test("the command line beats the file for logging too") {
+    withConfigFile("[analysis]\nthreads = 4\n\n[logging]\nlevel = \"warn\"\n") {
+      path =>
+        val config = ConfigurationParser
+          .parse(Array("--config", path.toString, "--log-level", "debug"))
+          .getOrElse(fail("expected a parse"))
+        assertEquals(config.logging.get("level"), Some("debug"))
+    }
+  }
+
   private def withConfigFile[A](contents: String)(f: Path => A): A = {
     val path = Files.createTempFile("goatrodeo-config", ".toml")
     try {


### PR DESCRIPTION
This has already had a couple of approvals—it's just changed target branch.

Part of [one configuration model](https://github.com/spice-labs-inc/spice-config).

This program had no way to turn its logging up or down: no flag, no config key, only a `logback.xml` fixed at build time. Debugging a run through several components meant a different lever for each, and here there was none.

`--log-level` and `--log-file` are the `[logging]` group, carried on the `Configuration` like everything else and resolved by the same ladder — so `GOATRODEO_LOGGING_LEVEL` and `[logging] level` work too, and the command line still wins.

Only this program's own loggers move. Lifting Tika or the bytecode readers to `debug` alongside them would bury the output the person asked for, so the `logback.xml` levels for those stay put.

Applied by `main`, where this program owns the process. Embedded through `GoatRodeoBuilder` the host owns logging and chose its levels deliberately, so nothing on that path touches them.

28 config tests. Full suite: the same 24 pre-existing failures (macOS `/var`-symlink CBOM family, and two needing a prior `package`).

**Depends on:** #289 (stacked) · [spice-config](https://github.com/spice-labs-inc/spice-config).