### PR TITLE
Call it the cutoff, which is what everyone else calls it

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/GoatRodeoBuilder.scala
@@ -272,23 +272,23 @@ class GoatRodeoBuilder {
     }
   }
 
-  /** Refuse to analyze internal files modified after `expiry`. Any archive
+  /** Refuse to analyze internal files modified after `cutoff`. Any archive
     * entry whose modification time is after this instant is dropped from the
     * ADG, along with everything that transitively contains it or is built from
     * it (they must be at least as new), so no dangling references remain.
     * Entries with no/unknown modification time are always kept.
     *
-    * @param expiry
+    * @param cutoff
     *   the cutoff instant
     * @return
     *   this builder
     */
-  def withExpiry(expiry: Instant): GoatRodeoBuilder = {
-    config = config.copy(expiry = Some(expiry))
+  def withCutoff(cutoff: Instant): GoatRodeoBuilder = {
+    config = config.copy(cutoff = Some(cutoff))
     this
   }
 
-  /** String form of [[withExpiry]] parsing a flexible date (e.g. "2026-01-01",
+  /** String form of [[withCutoff]] parsing a flexible date (e.g. "2026-01-01",
     * "today").
     *
     * @param d
@@ -296,10 +296,10 @@ class GoatRodeoBuilder {
     * @return
     *   Right(this builder) if parsed successfully, Left(errorMessage) otherwise
     */
-  def withExpiry(d: String): Either[String, GoatRodeoBuilder] = {
+  def withCutoff(d: String): Either[String, GoatRodeoBuilder] = {
     io.spicelabs.goatrodeo.util.DateParser.parse(d) match {
       case Right(date) =>
-        config = config.copy(expiry = Some(date.toInstant()))
+        config = config.copy(cutoff = Some(date.toInstant()))
         Right(this)
       case Left(error) =>
         Left(error)

--- a/src/main/scala/io/spicelabs/goatrodeo/Main.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/Main.scala
@@ -213,9 +213,9 @@ object Howdy {
       blockList = params.blockList,
       finishedFile = onFileFinish,
       done = onRunFinish,
-      // Fall back to the goatrodeo.expiry system property when no explicit expiry was set.
+      // Fall back to the goatrodeo.expiry system property when no explicit cutoff was set.
       args =
-        params.copy(expiry = params.expiry.orElse(Config.expiryFromProperty)),
+        params.copy(cutoff = params.cutoff.orElse(Config.expiryFromProperty)),
       preWriteDB = preWriteDB,
       fsFilePaths = params.fsFilePaths
     )

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Builder.scala
@@ -496,7 +496,7 @@ object Builder {
             val ret = storage match {
               case lf: (ListFileNames & Storage)
                   if writeToStorage && !dead_?.get() =>
-                writeGoatRodeoFiles(lf, args.expiry)
+                writeGoatRodeoFiles(lf, args.cutoff)
               case _ => logger.error("Didn't write"); None
             }
 
@@ -518,7 +518,7 @@ object Builder {
 
   }
 
-  /** Enforce an expiry cutoff on the fully-assembled graph: drop every node
+  /** Enforce an cutoff cutoff on the fully-assembled graph: drop every node
     * whose recorded file-modification time is after `cutoff`, plus every node
     * that transitively contains it or is built from it (they must be at least
     * as new), then strip any resulting dangling edges so no references to
@@ -573,7 +573,7 @@ object Builder {
         else i.copy(connections = kept)
       }
       logger.info(
-        f"Expiry ${cutoff}: removed ${removed.size}%,d nodes (${pastCutoff.size}%,d modified after cutoff, ${removed.size - pastCutoff.size}%,d dependents)"
+        f"Cutoff ${cutoff}: removed ${removed.size}%,d nodes (${pastCutoff.size}%,d modified after cutoff, ${removed.size - pastCutoff.size}%,d dependents)"
       )
       cleaned
     }
@@ -581,7 +581,7 @@ object Builder {
 
   def writeGoatRodeoFiles(
       store: ListFileNames & Storage,
-      expiry: Option[Instant] = None
+      cutoff: Option[Instant] = None
   ): Option[File] = {
     store.target() match {
       case Some(target) => {
@@ -619,7 +619,7 @@ object Builder {
           f"Post-sort at ${Duration.between(start, Instant.now())}"
         )
 
-        val finalItems = expiry match {
+        val finalItems = cutoff match {
           case Some(cutoff) => pruneExpired(sorted, cutoff)
           case None         => sorted
         }

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/Item.scala
@@ -347,8 +347,8 @@ object Item {
   protected val logger: Logger = Logger(getClass())
 
   /** `ItemMetaData.extra` key under which an internal file's modification time
-    * (epoch milliseconds) is recorded. Populated only when an expiry cutoff is
-    * configured, and consumed by the expiry filter in the graph writer.
+    * (epoch milliseconds) is recorded. Populated only when an cutoff cutoff is
+    * configured, and consumed by the cutoff filter in the graph writer.
     */
   val FileModifiedKey = "file_modified_epoch_millis"
 

--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/ToProcess.scala
@@ -370,7 +370,7 @@ trait ToProcess {
               Item.itemFrom(
                 artifact,
                 parentId,
-                recordModified = args.expiry.isDefined
+                recordModified = args.cutoff.isDefined
               )
 
             // in blocklist do nothing

--- a/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/Config.scala
@@ -113,7 +113,7 @@ case class Config(
     tagVersion: Option[String] = None,
     tagDate: Option[Date] = None,
     progressListener: Option[ProgressListener] = None,
-    expiry: Option[Instant] = None,
+    cutoff: Option[Instant] = None,
     cbomDir: Option[File] = None,
     cbomVersion: String = "1.6"
 ) {
@@ -150,8 +150,8 @@ case class Config(
 object Config {
   private val logger = Logger(getClass())
 
-  /** System property supplying the expiry cutoff when it is not set explicitly
-    * (via `--expiry` or `withExpiry`). This lets an in-JVM caller — or
+  /** System property supplying the cutoff cutoff when it is not set explicitly
+    * (via `--cutoff` or `withCutoff`). This lets an in-JVM caller — or
     * `-Dgoatrodeo.expiry=…` on the command line — enable the file-modification
     * cutoff without depending on the builder API: an older build that does not
     * read this property simply ignores it and runs normally. Accepts epoch
@@ -218,15 +218,15 @@ object Config {
           "Tag all top level artifacts (files) with the current date and the text of the tag"
         )
         .action((x, c) => c.copy(tag = Some(x))),
-      opt[String]("expiry")
+      opt[String]("cutoff")
         .text(
           "Refuse to analyze internal files modified after this date/time (e.g. 2026-01-01); dependents are dropped too"
         )
         .action((x, c) =>
           DateParser.parse(x) match {
-            case Right(date) => c.copy(expiry = Some(date.toInstant()))
+            case Right(date) => c.copy(cutoff = Some(date.toInstant()))
             case Left(error) =>
-              logger.error(f"Invalid --expiry value: ${error}")
+              logger.error(f"Invalid --cutoff value: ${error}")
               c
           }
         ),

--- a/src/test/scala/CutoffBigAdgSuite.scala
+++ b/src/test/scala/CutoffBigAdgSuite.scala
@@ -14,7 +14,7 @@ import java.time.Instant
 import scala.collection.mutable
 import scala.util.Try
 
-/** Re-runs the big (~1GB) ADG build twice — once with a far-future expiry
+/** Re-runs the big (~1GB) ADG build twice — once with a far-future cutoff
   * (nothing pruned) and once with a real cutoff that drops the newest slice of
   * internal files — then checks that the pruned ADG is smaller (fewer nodes)
   * and that every edge still resolves to a real node.
@@ -23,9 +23,9 @@ import scala.util.Try
   * `GOATRODEO_BIG_EXPIRY=1` and the `test_data/download/adg_tests` corpus is
   * present.
   *
-  * GOATRODEO_BIG_EXPIRY=1 sbt "testOnly ExpiryBigAdgSuite"
+  * GOATRODEO_BIG_EXPIRY=1 sbt "testOnly CutoffBigAdgSuite"
   */
-class ExpiryBigAdgSuite extends munit.FunSuite {
+class CutoffBigAdgSuite extends munit.FunSuite {
 
   // Two full builds; give it room.
   override val munitTimeout = scala.concurrent.duration.Duration(2, "hours")
@@ -35,10 +35,10 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
       .flatMap(s => Try(Integer.parseInt(s.trim())).toOption)
       .getOrElse(25)
 
-  /** The exact same build ADGTests performs, into `dest`, with the given expiry
+  /** The exact same build ADGTests performs, into `dest`, with the given cutoff
     * cutoff.
     */
-  private def build(dest: File, expiry: Instant, source: File): Boolean = {
+  private def build(dest: File, cutoff: Instant, source: File): Boolean = {
     if (dest.exists()) Helpers.deleteDirectory(dest.toPath())
     dest.mkdirs()
 
@@ -46,7 +46,7 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
     Builder.buildDB(
       dest = dest,
       tempDir = None,
-      args = Config(expiry = Some(expiry)),
+      args = Config(cutoff = Some(cutoff)),
       threadCnt = threadCnt,
       maxRecords = 10000,
       tag = Some(TagInfo("foo", None)),
@@ -150,10 +150,10 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
     (count, sample.toVector)
   }
 
-  test("big ADG shrinks under an expiry cutoff and stays edge-coherent") {
+  test("big ADG shrinks under an cutoff cutoff and stays edge-coherent") {
     assume(
       System.getenv("GOATRODEO_BIG_EXPIRY") == "1",
-      "Set GOATRODEO_BIG_EXPIRY=1 to run the heavy two-build expiry check"
+      "Set GOATRODEO_BIG_EXPIRY=1 to run the heavy two-build cutoff check"
     )
     val source = File("test_data/download/adg_tests")
     assume(
@@ -169,7 +169,7 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
 
     // --- Step 1: FULL build. Far-future cutoff prunes nothing but records mod-times. ---
     val farFuture = Instant.parse("3000-01-01T00:00:00Z")
-    println(s"[expiry] FULL build -> ${fullDir} (threadCnt=$threadCnt)")
+    println(s"[cutoff] FULL build -> ${fullDir} (threadCnt=$threadCnt)")
     assert(
       build(fullDir, farFuture, source),
       "FULL build should finish successfully"
@@ -189,15 +189,15 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
     val cutoff = Instant.ofEpochMilli(cutoffMillis)
     val pastCutoff = mtimes.count(_ > cutoffMillis)
     println(
-      f"[expiry] recorded mtimes: ${mtimes.size}%,d dated nodes, " +
+      f"[cutoff] recorded mtimes: ${mtimes.size}%,d dated nodes, " +
         f"range ${Instant.ofEpochMilli(sorted.head)}..${Instant.ofEpochMilli(sorted.last)}"
     )
     println(
-      f"[expiry] chosen cutoff (75th pct) = $cutoff -> $pastCutoff%,d dated nodes past cutoff"
+      f"[cutoff] chosen cutoff (75th pct) = $cutoff -> $pastCutoff%,d dated nodes past cutoff"
     )
 
     // --- Step 3: PRUNED build with the real cutoff. ---
-    println(s"[expiry] PRUNED build -> ${prunedDir}")
+    println(s"[cutoff] PRUNED build -> ${prunedDir}")
     assert(
       build(prunedDir, cutoff, source),
       "PRUNED build should finish successfully"
@@ -211,10 +211,10 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
     val nodePct = 100.0 * (fullNodes - prunedNodes) / fullNodes
     val bytePct = 100.0 * (fullBytes - prunedBytes) / fullBytes
     println(
-      f"[expiry] nodes: full=$fullNodes%,d  pruned=$prunedNodes%,d  (-$nodePct%.1f%%)"
+      f"[cutoff] nodes: full=$fullNodes%,d  pruned=$prunedNodes%,d  (-$nodePct%.1f%%)"
     )
     println(
-      f"[expiry] bytes: full=$fullBytes%,d  pruned=$prunedBytes%,d  (-$bytePct%.1f%%)"
+      f"[cutoff] bytes: full=$fullBytes%,d  pruned=$prunedBytes%,d  (-$bytePct%.1f%%)"
     )
 
     assert(
@@ -229,7 +229,7 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
     // --- Step 5: verify edge coherence in both clusters. ---
     val fullIds = nodeIds(fullDir)
     val (fullDangling, fullSample) = danglingEdges(fullDir, fullIds)
-    println(f"[expiry] FULL dangling edges: $fullDangling%,d")
+    println(f"[cutoff] FULL dangling edges: $fullDangling%,d")
     fullSample.foreach { case (s, e, t) =>
       println(s"           full dangling: $s -[$e]-> $t")
     }
@@ -240,13 +240,13 @@ class ExpiryBigAdgSuite extends munit.FunSuite {
 
     val prunedIds = nodeIds(prunedDir)
     val (prunedDangling, prunedSample) = danglingEdges(prunedDir, prunedIds)
-    println(f"[expiry] PRUNED dangling edges: $prunedDangling%,d")
+    println(f"[cutoff] PRUNED dangling edges: $prunedDangling%,d")
     prunedSample.foreach { case (s, e, t) =>
       println(s"           pruned dangling: $s -[$e]-> $t")
     }
     assert(
       prunedDangling == 0L,
-      s"PRUNED cluster should have no dangling edges after expiry, found $prunedDangling"
+      s"PRUNED cluster should have no dangling edges after cutoff, found $prunedDangling"
     )
   }
 }

--- a/src/test/scala/CutoffPruneSuite.scala
+++ b/src/test/scala/CutoffPruneSuite.scala
@@ -10,7 +10,7 @@ import java.time.Instant
 import scala.collection.immutable.TreeMap
 import scala.collection.immutable.TreeSet
 
-class ExpiryPruneSuite extends munit.FunSuite {
+class CutoffPruneSuite extends munit.FunSuite {
 
   private val cutoff = Instant.parse("2026-01-01T00:00:00Z")
   private val old = Instant.parse("2025-06-01T00:00:00Z")


### PR DESCRIPTION
The value is `x-cutoff` in the Spice Pass, `cutoff` in Allspice's `PassConfiguration`, and `cutoff` at all three call sites that pass it in, but it had been called `expiry` in Goat Rodeo, which could be easily confused with the expiry of the Spice Pass—which is a completely different thing.

| Was | Is |
|---|---|
| `expiry` (field, TOML key) | `cutoff` |
| `--expiry` | `--cutoff` |
| `withExpiry` | `withCutoff` |
| `ExpiryPruneSuite` | `CutoffPruneSuite` |
