### PR TITLE
Declare where spice-config is published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,17 @@
       <name>GitHub Package Registry</name>
       <url>https://maven.pkg.github.com/spice-labs-inc/goatrodeo</url>
     </repository>
+    <!-- spice-config carries the naming, layering and precedence rules every Spice
+         component shares. Each GitHub Packages URL serves only its own repo's
+         artifacts, so it cannot be resolved from the entry above. Consumed as a
+         SNAPSHOT, republished whenever its main moves. -->
+    <repository>
+      <id>github-spice-config</id>
+      <name>GitHub Packages (spice-labs-inc/spice-config)</name>
+      <url>https://maven.pkg.github.com/spice-labs-inc/spice-config</url>
+      <releases><enabled>true</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
   </repositories>
 
   <distributionManagement>


### PR DESCRIPTION
The Maven build cannot resolve `io.spicelabs:spice-config`, having looked in the only three places it knows about:

```
Could not find artifact io.spicelabs:spice-config:jar:0.1.0-SNAPSHOT
  in central, in ow2, in github (spice-labs-inc/goatrodeo)
```

Each GitHub Packages URL serves only its own repository, so spice-config cannot arrive through the goatrodeo entry however well authenticated it is.

**This alone will not turn #288/#289/#293 green.** GitHub Packages needs authentication even for public reads, and those branches carry the Maven CI workflow whose settings.xml needs a `<server>` matching the new id — that belongs with the workflow, so I will add it to the stack once this lands. Flagging it so this is not mistaken for the whole fix.

Worth knowing: `main`'s `build_test.yml` still runs `sbt test` against a `build.sbt` that the configuration branches no longer have; those branches switched the workflow to Maven. So this pom entry has no effect on `main`'s own CI — it is here so every branch inherits it.