### PR TITLE
Tell spotless which scalafmt to use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
     <munit.version>0.7.29</munit.version>
     <scalacheck.version>1.18.1</scalacheck.version>
     <zstd-jni.version>1.5.6-9</zstd-jni.version>
+    <!-- Must equal the `version` in .scalafmt.conf. Spotless bundles one scalafmt build and
+         refuses any other exactly, so omitting this does not mean "whatever the config asks
+         for": it means the plugin's own default silently becomes the requirement, and the
+         check dies before it formats anything. -->
+    <scalafmt.version>3.7.15</scalafmt.version>
 
     <!-- Test parallelism: independent test classes are distributed over several
          forked JVMs, restoring what sbt's default `Test / parallelExecution`
@@ -732,6 +737,7 @@
         <configuration>
           <scala>
             <scalafmt>
+              <version>${scalafmt.version}</version>
               <file>${project.basedir}/.scalafmt.conf</file>
             </scalafmt>
           </scala>


### PR DESCRIPTION
`spotless:check` has not run since `.scalafmt.conf` moved to 3.7.15:

```
version [expected 3.7.3 or 3.7.3]: 3.7.15
```

Spotless bundles **one** scalafmt build and refuses any other exactly. The scalafmt block here set only `<file>`, so the plugin's own default became the requirement and the config's declared version was read only to be rejected — the check died before formatting anything. Nothing noticed, because CI runs sbt.

Declaring the version fixes it where it broke:

```xml
<scalafmt>
  <version>${scalafmt.version}</version>
  <file>${project.basedir}/.scalafmt.conf</file>
</scalafmt>
```

**Nothing is reformatted and no version moves.** With 3.7.15 named explicitly, the existing plugin formats the existing sources and reports zero violations — the code was already correct under the version the config asked for all along. This is what allspice already does, which is why it runs 3.8.6 on a plugin that would otherwise demand 3.8.1.

## The two alternatives, both tested

**Upgrading the plugin does not help.** 2.44.5 bundles 3.8.1, so it rejects 3.7.15 exactly as 2.43.0 does:

```
2.43.0 → wants 3.7.3      2.44.5 → wants 3.8.1
```

**Reverting to 3.7.3 costs something.** The two versions disagree about scaladoc `@param` continuation indentation, and 3.7.3 reformats `ArtifactWrapper.scala` and `FileWalker.scala`:

```
-    *   -- the input stream     (3.7.15)
+    * -- the input stream       (3.7.3)
```

It would also leave this repo on 3.7.3 while allspice is on 3.8.6.

Moving to 3.8.6 to match allspice is worth doing eventually, but that is a reformatting commit and belongs on its own.

**Independent** of #303 (Java 21) and of the configuration stack. Together with #303 it makes `mvn verify` work on `main` again; either alone is not enough.