### PR TITLE
Refuse a symlinked CBOM output directory, not a symlinked path to one

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/omnibor/CbomEmitter.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/omnibor/CbomEmitter.scala
@@ -1001,22 +1001,38 @@ object CbomEmitter {
     f"cbom_${safe}.json"
   }
 
-  /** Validate the output directory, reject symlinks, and create it safely. */
+  /** Validate the output directory, refuse a symlinked one, and create it
+    * safely.
+    *
+    * The refusal applies to the output directory itself, not to its ancestors.
+    * Walking every ancestor rejected ordinary installations: on macOS `/tmp`
+    * and `/var` are symlinks into `/private`, so `--emit-cbom-dir /tmp/cbom` --
+    * and anything under the system temporary directory -- could not run at all,
+    * and on Linux the same holds for bind-mounted, automounted or
+    * `/home`-redirected paths. Where the run's own output lands is the caller's
+    * business; how the machine arranges the path above it is not.
+    *
+    * The `Files.exists` guard is gone too. `exists` follows links, so it was
+    * false for a dangling symlink and `isSymbolicLink` was never reached --
+    * exempting a link aimed at a path that does not exist yet, which is the
+    * usual shape of the attack. `isSymbolicLink` alone is false for an absent
+    * path and true for a dangling link, which is what was wanted.
+    *
+    * A check on a path can only ever be a guard rail: whoever can plant a
+    * symlink can plant it after the check. What holds regardless is at the
+    * write -- [[atomicWrite]] moves the finished file into place with
+    * `Files.move`, which acts on the final path entry itself rather than
+    * following it, so a link planted at the target is replaced rather than
+    * written through.
+    */
   private def safeOutputDir(dir: File): Try[File] = Try {
     val path = pathOf(dir)
 
-    @tailrec
-    def checkSymlinks(p: Path | Null): Unit = {
-      if (p != null) {
-        if (Files.exists(p) && Files.isSymbolicLink(p)) {
-          throw new IllegalArgumentException(
-            f"CBOM output directory contains symlink: $p"
-          )
-        }
-        checkSymlinks(p.getParent())
-      }
+    if (Files.isSymbolicLink(path)) {
+      throw new IllegalArgumentException(
+        f"CBOM output directory is a symlink: $path"
+      )
     }
-    checkSymlinks(path)
 
     if (!dir.exists()) {
       try {

--- a/src/test/scala/io/spicelabs/goatrodeo/omnibor/CbomEmitterSuite.scala
+++ b/src/test/scala/io/spicelabs/goatrodeo/omnibor/CbomEmitterSuite.scala
@@ -801,6 +801,80 @@ class CbomEmitterSuite extends FunSuite {
     }
   }
 
+  // T3.18b — a symlink anywhere above the output directory is fine. On macOS
+  // `/tmp` and `/var` are symlinks into `/private`, so refusing them made
+  // --emit-cbom-dir unusable with the system temporary directory; on Linux the
+  // same is true of bind mounts and automounted homes.
+  test("T3.18b a symlinked ancestor of the output directory is accepted") {
+    val real = Files.createTempDirectory("cbom-real").toFile()
+    val linkParent = Files.createTempDirectory("cbom-link").toFile()
+    val link = new File(linkParent, "via-link")
+    try {
+      Files.createSymbolicLink(link.toPath(), real.toPath())
+      val dir = new File(link, "output")
+      val storage = MemStorage(None)
+      val root = makeItem(
+        id =
+          "gitoid:blob:sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        fileNames = TreeSet("root")
+      )
+      storeItem(storage, root)
+      val files = CbomEmitter.emitForStorage(storage, "1.6", dir).get
+      assertEquals(files.length, 1)
+      assert(files.head.isFile(), "the CBOM must actually be written")
+      // and it lands in the real directory the link names
+      assert(
+        new File(new File(real, "output"), files.head.getName()).isFile(),
+        "the CBOM should be written through the link into the real directory"
+      )
+    } finally {
+      cleanup(real)
+      cleanup(linkParent)
+    }
+  }
+
+  // T3.18c — the property the removed ancestor check was reaching for, pinned
+  // where it actually holds. A symlink planted at the target file must be
+  // replaced, not written through: Files.move acts on the final path entry
+  // rather than following it.
+  test("T3.18c a symlink planted at the target is replaced, not followed") {
+    val dir = Files.createTempDirectory("cbom-target").toFile()
+    val victimDir = Files.createTempDirectory("cbom-victim").toFile()
+    try {
+      val storage = MemStorage(None)
+      val root = makeItem(
+        id =
+          "gitoid:blob:sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        fileNames = TreeSet("root")
+      )
+      storeItem(storage, root)
+
+      // First emission tells us the filename the emitter chooses.
+      val first = CbomEmitter.emitForStorage(storage, "1.6", dir).get.head
+      assert(first.delete(), "could not clear the first emission")
+
+      // Plant a link at that exact path, aimed at a file we do not want touched.
+      val victim = new File(victimDir, "precious")
+      Files.writeString(victim.toPath(), "do not overwrite me")
+      Files.createSymbolicLink(first.toPath(), victim.toPath())
+
+      CbomEmitter.emitForStorage(storage, "1.6", dir).get
+
+      assertEquals(
+        Files.readString(victim.toPath()),
+        "do not overwrite me",
+        "the CBOM write must not follow the link to its target"
+      )
+      assert(
+        !Files.isSymbolicLink(first.toPath()),
+        "the planted symlink should have been replaced by a regular file"
+      )
+    } finally {
+      cleanup(dir)
+      cleanup(victimDir)
+    }
+  }
+
   // ----------------------------------------------------------------------
   // T3.19 private-key-marker Items are emitted faithfully (no redaction)
   // ----------------------------------------------------------------------
@@ -944,6 +1018,33 @@ class CbomEmitterSuite extends FunSuite {
       storeItem(storage, root)
       val result = CbomEmitter.emitForStorage(storage, "1.6", linkDir)
       assert(result.isFailure)
+    } finally {
+      cleanup(parent)
+    }
+  }
+
+  // T3.21b — a dangling symlink is still a symlink. The previous check guarded
+  // `isSymbolicLink` behind `Files.exists`, which follows links and is
+  // therefore false when the link's target does not exist -- so a link planted
+  // at a path before anything is created there, the usual shape of the attack,
+  // was exempt from the very check meant to catch it.
+  test("T3.21b a dangling symlink as the output directory is rejected") {
+    val parent = Files.createTempDirectory("cbom-dangling").toFile()
+    val linkDir = new File(parent, "link")
+    try {
+      Files.createSymbolicLink(
+        linkDir.toPath(),
+        new File(parent, "does-not-exist").toPath()
+      )
+      assert(!Files.exists(linkDir.toPath()), "fixture should be dangling")
+      val storage = MemStorage(None)
+      val root = makeItem(
+        id =
+          "gitoid:blob:sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        fileNames = TreeSet("root")
+      )
+      storeItem(storage, root)
+      assert(CbomEmitter.emitForStorage(storage, "1.6", linkDir).isFailure)
     } finally {
       cleanup(parent)
     }


### PR DESCRIPTION
## The problem

`CbomEmitter.safeOutputDir` walked **every ancestor** of `--emit-cbom-dir` and refused if any of them was a symlink.

On macOS `/tmp` and `/var` are symlinks into `/private`, so emitting anywhere under the system temporary directory failed outright. On Linux the same applies to bind mounts, automounted homes, and any `/home` → `/mnt` redirection.

The effect on `main` today, on macOS:

```
$ sbt "testOnly io.spicelabs.goatrodeo.omnibor.CbomEmitterSuite"
[error] Failed: Total 37, Failed 32, Errors 0, Passed 5
```

all with `IllegalArgumentException: CBOM output directory contains symlink: /var`. Across the whole suite it accounted for 54 failures. With this change the full suite is green: **2365 passed, 0 failed**.

## The change

**Check the output directory itself, not its ancestors.** That is what T3.21 has always been about, and it still asserts it unchanged. Where a run's own output lands is the caller's business; how the machine arranges the path above it is not.

**Drop the `Files.exists` guard in front of `isSymbolicLink`.** `exists` follows links, so it was false for a dangling symlink and the check never ran — exempting a link aimed at a path that does not exist yet, which is the usual shape of the attack it was written to stop. `isSymbolicLink` alone is false for an absent path and true for a dangling one. Covered by the new T3.21b.

## On what a path check can promise

A check on a path is a guard rail either way: whoever can plant a symlink can plant it in the window after the check. The property that holds regardless is at the write — `atomicWrite` moves the finished file into place with `Files.move`, which acts on the final path entry rather than following it, so a link planted at the target is replaced rather than written through. That was untested; new T3.18c pins it.

## Tests

| | |
|---|---|
| T3.21 | unchanged — a symlinked output directory is still rejected |
| T3.21b | new — a *dangling* symlinked output directory is rejected too |
| T3.18b | new — a symlinked *ancestor* is accepted, and the CBOM lands in the real directory |
| T3.18c | new — a symlink planted at the target file is replaced, not followed |

Full suite: 2365 passed, 0 failed (macOS). Independent of #305 and #306 — this code is already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)