### PR TITLE
Say in both build files that changes must be made in both

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,6 +222,19 @@ lazy val root = project
     scalaVersion := scala3Version,
     semanticdbEnabled := true, // enable SemanticDB,
     semanticdbVersion := scalafixSemanticdb.revision,
+    // TWO BUILDS: this project is built by both this file and the root pom.xml,
+    // from the same sources. A dependency, version, compiler flag or plugin
+    // changed in one must be changed in the other. This lasts until the
+    // duplication is resolved and one build is retired; which one that will be
+    // is not decided, so neither file is the authority over the other.
+    //
+    // Nothing enforces it. build_test.yml runs only `sbt test`, and
+    // publish.yml's Maven step targets maven/pom.xml -- the publish-only shim
+    // whose dependencies are injected from the sbt-produced pom at release --
+    // so the root pom is built by no CI job at all. Drift is found by whoever
+    // next runs Maven, which is how the -release 17/21 mismatch in #301 got in.
+    // Run `mvn -DskipTests package` alongside `sbt compile` before pushing a
+    // build change.
     libraryDependencies += "io.spicelabs" % "spice-bom" % "1.0.6" % Import intransitive (),
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.3.0",
     libraryDependencies += "org.ow2.asm" % "asm" % "9.8",
@@ -242,9 +255,11 @@ lazy val root = project
     libraryDependencies += "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     libraryDependencies += "org.apache.tika" % "tika-core" % "3.2.3",
-    // Config files. Kept in step with pom.xml, which declares the same two: the sbt and
-    // Maven builds compile the same sources, so a dependency added to one and not the
-    // other fails whichever build CI happens to run.
+    // Config files. Kept in step with pom.xml like everything else here -- see
+    // the TWO BUILDS note above. (This previously said that a dependency added
+    // to one build and not the other "fails whichever build CI happens to run".
+    // It does not: CI runs only sbt, which is exactly why the drift is not
+    // self-correcting.)
     libraryDependencies += "org.tomlj" % "tomlj" % "1.1.1",
     // The naming, layering and precedence rules every Spice component shares.
     libraryDependencies += "io.spicelabs" % "spice-config" % "1.0.0",

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,19 @@
     development; `maven/pom.xml` remains the publish-only shell used by the
     release workflow.
 
+    TWO BUILDS: this project is built by both this file and build.sbt, from the
+    same sources. A dependency, version, compiler flag or plugin changed in one
+    must be changed in the other. This lasts until the duplication is resolved
+    and one build is retired; which one that will be is not decided, so neither
+    file is the authority over the other.
+
+    Nothing enforces it. build_test.yml runs only `sbt test`, and publish.yml's
+    Maven step targets maven/pom.xml rather than this file, so this build runs
+    in no CI job at all, so drift is found by whoever next runs Maven. That is
+    how the `-release` 17/21 mismatch noted on maven.compiler.release below got
+    in. Run `mvn -DskipTests package` alongside `sbt compile` before pushing a
+    build change.
+
     Quick start:
       mvn -DskipTests compile     # fast: verify it compiles
       mvn test                    # runs the unit-test suite (see PreflightSuite
@@ -49,7 +62,7 @@
     <!-- The sbt version used by the sibling build.sbt build; surfaced in BuildInfo for parity -->
     <sbt.version>1.10.6</sbt.version>
 
-    <!-- Library versions, aligned with build.sbt -->
+    <!-- Library versions, aligned with build.sbt; see the TWO BUILDS note above -->
     <scala-xml.version>2.3.0</scala-xml.version>
     <asm.version>9.8</asm.version>
     <bcel.version>6.11.0</bcel.version>


### PR DESCRIPTION
## Why

Goat Rodeo is built by `build.sbt` **and** by the root `pom.xml`, from the same sources, and nothing checks that they agree:

- `build_test.yml` runs only `sbt test`
- `publish.yml`'s Maven step targets `maven/pom.xml` — the publish-only shim, whose dependencies are injected from the sbt-produced pom at release

So the root `pom.xml` is built by **no CI job at all**. Drift is found by whoever next runs Maven locally, which has already happened twice: the `-release` 17/21 mismatch fixed in #301, and a saffron version bump made only in `build.sbt` (which left the Maven build unable to compile until it was caught by hand).

## What this does

A note at the top of each file saying a change to one must be made in the other. Neither file claims to be the authority: two builds is a temporary state and which one survives is undecided, so saying otherwise in a comment would pre-empt that decision.

## Why a comment rather than a CI job

A comment is what someone reads at the moment they are editing the file, which is when it matters. Enforcement would be the durable answer if the duplication were permanent — but building the root pom on every PR spends real time defending an arrangement we intend to remove.

## Also

Corrects the narrower note above the config dependencies in `build.sbt`. It said a dependency added to one build and not the other "fails whichever build CI happens to run". That is exactly wrong, and load-bearing: it tells a reader the mistake is self-correcting when nothing catches it.

Comments only, no semantic change. Verified with both `sbt compile` and `mvn -DskipTests package`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)