### PR TITLE
Make the config schema catch a field nobody gave a key

### DIFF
--- a/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
+++ b/src/main/scala/io/spicelabs/goatrodeo/util/ConfigurationToml.scala
@@ -128,6 +128,22 @@ object ConfigurationToml {
     */
   def fieldKeys: Set[String] = keyForField.values.toSet
 
+  /** The [[Configuration]] fields [[keyForField]] gives a config-file key.
+    *
+    * The companion to [[fieldKeys]], and it faces the other way. `fieldKeys`
+    * catches a key claimed here that the schema does not accept; this catches a
+    * field added to [[Configuration]] that nothing here mentions -- which is
+    * how a setting comes to have a flag and no file or environment spelling
+    * without anybody deciding that it should.
+    */
+  def mappedFields: Set[String] = keyForField.keySet
+
+  /** Keys a config file may name but not set, so that they are refused by name
+    * rather than reported as a typo. Exposed so a test can hold the two lists
+    * against each other.
+    */
+  def rejectedKeys: Set[String] = alwaysRejected.keySet
+
   /** Whether the `[analysis]` table accepts this key. */
   def accepts(key: String): Boolean = knownKeys.contains(key)
 

--- a/src/test/scala/ConfigurationTomlSuite.scala
+++ b/src/test/scala/ConfigurationTomlSuite.scala
@@ -219,6 +219,76 @@ class ConfigurationTomlSuite extends munit.FunSuite {
     assertEquals(ConfigurationToml.displayName("cbomDir"), "emit_cbom_dir")
   }
 
+  test("every setting a config file may name is one the schema accepts") {
+    // The mirror of the test below. That one catches a key claimed by
+    // keyForField that knownKeys does not accept; this one catches a field
+    // added to Configuration that keyForField never mentions -- which is how a
+    // setting ends up with a command-line flag and no config-file or
+    // environment spelling without anyone deciding it should be flag-only.
+    //
+    // The exemptions are written out, with the reason, so that adding a field
+    // means making the choice rather than inheriting it by silence.
+    val exempt: Map[String, String] = Map(
+      "cutoff" ->
+        "an entitlement, not a preference: --cutoff only, and alwaysRejected refuses it by name",
+      "configFile" -> "how the run was started, not a setting anybody wrote",
+      "runtime" -> "the ambient process state, not a setting",
+      "logging" ->
+        "carried for another program to apply; validated against the shared [logging] schema",
+      "progressListener" -> "a callback; reachable only through the builder",
+      "componentArgs" -> "flag-only diagnostic",
+      "printComponentInfo" -> "flag-only diagnostic",
+      "printComponentArgumentInfo" -> "flag-only diagnostic",
+      "nonexistentDirectories" -> "derived while parsing, never supplied"
+    )
+
+    val unaccounted = Configuration().productElementNames.toVector
+      .filterNot(ConfigurationToml.mappedFields.contains)
+      .filterNot(exempt.contains)
+
+    assert(
+      unaccounted.isEmpty,
+      s"${unaccounted.mkString(", ")} can be set on the command line but named " +
+        "by no config-file key. Either give it one in keyForField and knownKeys, " +
+        "or add it to this test's `exempt` map with the reason it is flag-only."
+    )
+
+    // and the exemptions must stay real: a field removed or renamed should not
+    // leave a stale excuse behind.
+    val stale = exempt.keySet.diff(Configuration().productElementNames.toSet)
+    assert(
+      stale.isEmpty,
+      s"exempt names no such field: ${stale.mkString(", ")}"
+    )
+  }
+
+  test("a key refused by name is a key the schema knows about") {
+    // The point of alwaysRejected is to say "you spelled this correctly and it
+    // is deliberately unavailable" rather than "unknown key". That only works
+    // while the key is also in knownKeys -- otherwise the unknown-key check
+    // fires first and reports it as a typo. Today only `cutoff` is involved,
+    // and it was put in both sets by hand.
+    val notKnown = ConfigurationToml.rejectedKeys.filterNot(
+      ConfigurationToml.accepts
+    )
+    assert(
+      notKnown.isEmpty,
+      s"${notKnown.mkString(", ")} would be reported as a typo rather than refused by name"
+    )
+  }
+
+  test("no two fields claim the same config-file key") {
+    // Two fields sharing a key would make sourceOf report one field's origin
+    // for the other, silently, and a file setting the key would write to
+    // whichever handler `read` happens to run.
+    val keys = ConfigurationToml.fieldKeys
+    assertEquals(
+      keys.size,
+      ConfigurationToml.mappedFields.size,
+      "keyForField maps two fields onto one key"
+    )
+  }
+
   test("every field with a config-file key names a key that exists") {
     // The map is written out by hand because the relation is not mechanical;
     // this is what stops it drifting from the schema beside it.


### PR DESCRIPTION
## Why

`ConfigurationTomlSuite` already checks that every key `keyForField` claims is one the schema accepts. Nothing checks the other direction, so a field added to `Configuration` with a command-line flag and no `[analysis]` key is invisible: no config-file spelling, no `GOATRODEO_ANALYSIS_*`, and — because `sourceOf` looks the field up in `keyForField` — no line in the override reporting either.

That is not hypothetical. It happened in #305, where `--print-files` and `--tamper-evident-log` arrived as flags only. No test failed. `ConfigurationToml`'s own scaladoc says the failure mode for hand-maintained lists here "has always been that they quietly fall behind" — this is the missing half of the check that stops it.

## What this adds

Three tests, and two accessors (`mappedFields`, `rejectedKeys`) to support them. **No behaviour change** — all three pass on `main` today.

**Every setting a config file may name is one the schema accepts.** Walks `Configuration`'s `productElementNames` and requires each to be in `keyForField` or in a written-out exempt map *with its reason*, so adding a field means making the choice rather than inheriting it by silence:

| field | why exempt |
|---|---|
| `cutoff` | an entitlement, not a preference; `alwaysRejected` refuses it by name |
| `configFile`, `runtime` | how the run was started, not settings |
| `logging` | carried for another program; validated against the shared `[logging]` schema |
| `progressListener` | a callback, builder-only |
| `componentArgs`, `printComponentInfo`, `printComponentArgumentInfo` | flag-only diagnostics |
| `nonexistentDirectories` | derived while parsing, never supplied |

It also fails if an exemption names a field that no longer exists, so a rename cannot leave a stale excuse behind.

**A key refused by name is a key the schema knows about.** `alwaysRejected` only produces "you spelled this correctly and it is deliberately unavailable" while the key is *also* in `knownKeys`; otherwise the unknown-key check fires first and calls it a typo. Today only `cutoff` is involved, and it was put in both sets by hand.

**No two fields claim the same config-file key.** A collision would make `sourceOf` report one field's origin for another, silently.

## Verified

The guard bites, with an actionable message. Adding a throwaway field to `Configuration` gives:

```
dummyProbeField can be set on the command line but named by no config-file key.
Either give it one in keyForField and knownKeys, or add it to this test's
`exempt` map with the reason it is flag-only.
```

`ConfigurationTomlSuite` 40/40. Full suite unchanged from `main`: 44 failures before and after, all the pre-existing macOS symlink issue that #307 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)